### PR TITLE
Removing -r from datasets create example

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ optional arguments:
 
 Example:
 
-`kaggle datasets create -r -p /path/to/dataset`
+`kaggle datasets create -p /path/to/dataset`
 
 
 ##### Create a new dataset version


### PR DESCRIPTION
```kaggle datasets create``` does not have an ```-r``` flag, so it should be removed from the example