### PR TITLE
Limit urlib3's version to avoid requests 2.18.4's dependency

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,9 @@ setup(
     keywords=['Kaggle', 'API'],
     entry_points={'console_scripts': ['kaggle = kaggle.cli:main']},
     install_requires=[
+        # Restriction that urllib3's version is less than 1.23.0 needed to avoid requests dependency problem.
+        # This restriction will be removed after request release later than 2.18.4.
+        # ref: https://github.com/Kaggle/kaggle-api/pull/49
         'urllib3 >= 1.15, < 1.23.0',
         'six >= 1.10',
         'certifi',

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,12 @@ setup(
     keywords=['Kaggle', 'API'],
     entry_points={'console_scripts': ['kaggle = kaggle.cli:main']},
     install_requires=[
-        'urllib3 >= 1.15', 'six >= 1.10', 'certifi', 'python-dateutil',
-        'requests', 'tqdm'
+        'urllib3 >= 1.15, < 1.23.0',
+        'six >= 1.10',
+        'certifi',
+        'python-dateutil',
+        'requests',
+        'tqdm'
     ],
     packages=find_packages(),
     license='Apache 2.0')


### PR DESCRIPTION
Currently, Installing this package has success, but kaggle command is failed by VersionConflict. (log below)
urllib3 1.23.0 has released in 2018-06-04.
But requests 2.18.4(latest) is limited urllib3's version to less than 1.23.0. ([source](https://github.com/requests/requests/blob/v2.18.4/setup.py#L47))

This limitation has already changed in requests. ([source]( https://github.com/requests/requests/commit/ac944b7439009ffbf7a10dfee35202f1ac090e76))
But this change have not released in pypi yet. 

For this reason, in this PR, I propose to limit urllib3's version as interim measures.

```
$ pip --no-cache-dir install kaggle
Collecting kaggle
  Downloading https://files.pythonhosted.org/packages/46/79/3630c8a7c96c382a2c2e65445c1291ac12e36e868e5c390f348b1d4d6171/kaggle-1.3.9.1.tar.gz
Collecting urllib3>=1.15 (from kaggle)
  Downloading https://files.pythonhosted.org/packages/bd/c9/6fdd990019071a4a32a5e7cb78a1d92c53851ef4f56f62a3486e6a7d8ffb/urllib3-1.23-py2.py3-none-any.whl (133kB)
    100% |████████████████████████████████| 143kB 956kB/s
Collecting six>=1.10 (from kaggle)
  Downloading https://files.pythonhosted.org/packages/67/4b/141a581104b1f6397bfa78ac9d43d8ad29a7ca43ea90a2d863fe3056e86a/six-1.11.0-py2.py3-none-any.whl
Collecting certifi (from kaggle)
  Downloading https://files.pythonhosted.org/packages/7c/e6/92ad559b7192d846975fc916b65f667c7b8c3a32bea7372340bfe9a15fa5/certifi-2018.4.16-py2.py3-none-any.whl (150kB)
    100% |████████████████████████████████| 153kB 3.8MB/s
Collecting python-dateutil (from kaggle)
  Downloading https://files.pythonhosted.org/packages/cf/f5/af2b09c957ace60dcfac112b669c45c8c97e32f94aa8b56da4c6d1682825/python_dateutil-2.7.3-py2.py3-none-any.whl (211kB)
    100% |████████████████████████████████| 215kB 1.1MB/s
Collecting requests (from kaggle)
  Downloading https://files.pythonhosted.org/packages/49/df/50aa1999ab9bde74656c2919d9c0c085fd2b3775fd3eca826012bef76d8c/requests-2.18.4-py2.py3-none-any.whl (88kB)
    100% |████████████████████████████████| 92kB 9.9MB/s
Collecting tqdm (from kaggle)
  Downloading https://files.pythonhosted.org/packages/93/24/6ab1df969db228aed36a648a8959d1027099ce45fad67532b9673d533318/tqdm-4.23.4-py2.py3-none-any.whl (42kB)
    100% |████████████████████████████████| 51kB 18.5MB/s
Collecting idna<2.7,>=2.5 (from requests->kaggle)
  Downloading https://files.pythonhosted.org/packages/27/cc/6dd9a3869f15c2edfab863b992838277279ce92663d334df9ecf5106f5c6/idna-2.6-py2.py3-none-any.whl (56kB)
    100% |████████████████████████████████| 61kB 15.1MB/s
Collecting chardet<3.1.0,>=3.0.2 (from requests->kaggle)
  Downloading https://files.pythonhosted.org/packages/bc/a9/01ffebfb562e4274b6487b4bb1ddec7ca55ec7510b22e4c51f14098443b8/chardet-3.0.4-py2.py3-none-any.whl (133kB)
    100% |████████████████████████████████| 143kB 7.3MB/s
requests 2.18.4 has requirement urllib3<1.23,>=1.21.1, but you'll have urllib3 1.23 which is incompatible.
Installing collected packages: urllib3, six, certifi, python-dateutil, idna, chardet, requests, tqdm, kaggle
  Running setup.py install for kaggle ... done
Successfully installed certifi-2018.4.16 chardet-3.0.4 idna-2.6 kaggle-1.3.9.1 python-dateutil-2.7.3 requests-2.18.4 six-1.11.0 tqdm-4.23.4 urllib3-1.23
$ kaggle competiton
Traceback (most recent call last):
  File "/Users/yoshifumi.seki/workspace/env/lib/python3.6/site-packages/pkg_resources/__init__.py", line 659, in _build_master
    ws.require(__requires__)
  File "/Users/yoshifumi.seki/workspace/env/lib/python3.6/site-packages/pkg_resources/__init__.py", line 967, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/Users/yoshifumi.seki/workspace/env/lib/python3.6/site-packages/pkg_resources/__init__.py", line 858, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (urllib3 1.23 (/Users/yoshifumi.seki/workspace/env/lib/python3.6/site-packages), Requirement.parse('urllib3<1.23,>=1.21.1'), {'requests'})

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/yoshifumi.seki/workspace/env/bin/kaggle", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/Users/yoshifumi.seki/workspace/env/lib/python3.6/site-packages/pkg_resources/__init__.py", line 3017, in <module>
    @_call_aside
  File "/Users/yoshifumi.seki/workspace/env/lib/python3.6/site-packages/pkg_resources/__init__.py", line 3003, in _call_aside
    f(*args, **kwargs)
  File "/Users/yoshifumi.seki/workspace/env/lib/python3.6/site-packages/pkg_resources/__init__.py", line 3030, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/Users/yoshifumi.seki/workspace/env/lib/python3.6/site-packages/pkg_resources/__init__.py", line 661, in _build_master
    return cls._build_from_requirements(__requires__)
  File "/Users/yoshifumi.seki/workspace/env/lib/python3.6/site-packages/pkg_resources/__init__.py", line 674, in _build_from_requirements
    dists = ws.resolve(reqs, Environment())
  File "/Users/yoshifumi.seki/workspace/env/lib/python3.6/site-packages/pkg_resources/__init__.py", line 858, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (urllib3 1.23 (/Users/yoshifumi.seki/workspace/env/lib/python3.6/site-packages), Requirement.parse('urllib3<1.23,>=1.21.1'), {'requests'})
```

