### PR TITLE
Minor tweaks for dataset creation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,11 +229,31 @@ optional arguments:
   -q, --quiet           Suppress printing information about download progress
 ```
 
+
 Examples:
 
 `kaggle datasets download -d zillow/zecon`
 
 `kaggle datasets download -d zillow/zecon -f State_time_series.csv`
+
+
+##### Initialize metadata file for dataset creation
+
+```
+usage: kaggle datasets init [-h] -p FOLDER
+
+required arguments:
+  -p FOLDER, --path FOLDER
+                        Folder for upload, containing data files and a special metadata.json file (https://github.com/Kaggle/kaggle-api/wiki/Metadata)
+
+optional arguments:
+  -h, --help            show this help message and exit
+```
+
+Example:
+
+`kaggle datasets init -p /path/to/dataset`
+
 
 
 ##### Create a new dataset
@@ -280,23 +300,6 @@ Example:
 
 `kaggle datasets version -p /path/to/dataset -m "Updated data"`
 
-
-##### Initialize metadata file for dataset creation
-
-```
-usage: kaggle datasets init [-h] -p FOLDER
-
-required arguments:
-  -p FOLDER, --path FOLDER
-                        Folder for upload, containing data files and a special metadata.json file (https://github.com/Kaggle/kaggle-api/wiki/Metadata)
-
-optional arguments:
-  -h, --help            show this help message and exit
-```
-
-Example:
-
-`kaggle datasets init -p /path/to/dataset`
 
 
 ### Config

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -603,6 +603,7 @@ class KaggleApi(KaggleApi):
       json.dump(meta_data, f)
 
     print('Data package template written to: ' + meta_file)
+    return meta_file
 
   def dataset_create_new(self,
                          folder,


### PR DESCRIPTION
This PR will make small changes to the Kaggle API to make it easier when 
working from an interactive session (or script in general).

 - returning the meta_file from the function to create it
 - ordering docs on creation in README so metadata is described first.


**dataset initialize**

Currently, when you create a metadata file, it doesn't return the path and the
user needs to set it manually, e.g.,:

```python
# Create a new metadata file
# kaggle datasets init -p /path/to/dataset
# https://github.com/Kaggle/kaggle-api/wiki/Metadata

# I'd have to know this, apriori, or read from the terminal message
meta_file = '/tmp/datapackage.json'

# This returns None
client.dataset_initialize('/tmp')
```

Returning `meta_file` will allow for this:

```python
meta_file = client.dataset_initialize('/tmp')
```

**README ordering**

Going along with the above, the old order had the two creation commands come 
first, followed by the command to create the metadata. Since the creation
would warrant the metadata first (at least in the way I am using it, 
from within an interactive session) it would make sense that the new user is informed
about this metadata before the creation step.

