### PR TITLE
adding message to user that dataset creation takes time!

### DIFF
--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -561,6 +561,12 @@ class KaggleApi(KaggleApi):
         self.process_response(
             self.datasets_create_version_with_http_info(owner_slug,
                                                         dataset_slug, request)))
+
+    # Alert the user that dataset creation takes time beyond command
+    if not quiet:
+        print('Your Dataset is being created. Please allow time for processing.')
+        print(result)
+
     return result
 
   def dataset_create_version_cli(self,

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -565,7 +565,6 @@ class KaggleApi(KaggleApi):
     # Alert the user that dataset creation takes time beyond command
     if not quiet:
         print('Your Dataset is being created. Please allow time for processing.')
-        print(result)
 
     return result
 

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -663,6 +663,11 @@ class KaggleApi(KaggleApi):
     self.upload_files(request, resources, folder, quiet)
     result = DatasetNewResponse(
         self.process_response(self.datasets_create_new_with_http_info(request)))
+
+    # Alert the user that dataset creation takes time beyond command
+    if not quiet:
+        print('Your Dataset is being created. Please allow time for processing.')
+
     return result
 
   def dataset_create_new_cli(self,


### PR DESCRIPTION
This is another quick PR that will alert the user that the dataset creation takes time. We only print the message given that quiet is False.

Please feel free to critique the message itself, and if there are other spots in the API that need messages like this (I'd be happy to add, I haven't used the other endpoints so I don't know yet!)