### PR TITLE
Configurable location of Kaggle config dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you run into a `kaggle: command not found` error, ensure that your python bin
 
 ## API credentials
 
-To use the Kaggle API, sign up for a Kaggle account at https://www.kaggle.com. Then go to the 'Account' tab of your user profile (`https://www.kaggle.com/<username>/account`) and select 'Create API Token'. This will trigger the download of `kaggle.json`, a file containing your API credentials. Place this file in the location `~/.kaggle/kaggle.json` (on Windows in the location `C:\Users\<Windows-username>\.kaggle\kaggle.json`).
+To use the Kaggle API, sign up for a Kaggle account at https://www.kaggle.com. Then go to the 'Account' tab of your user profile (`https://www.kaggle.com/<username>/account`) and select 'Create API Token'. This will trigger the download of `kaggle.json`, a file containing your API credentials. Place this file in the location `~/.kaggle/kaggle.json` (on Windows in the location `C:\Users\<Windows-username>\.kaggle\kaggle.json`). You can define a shell environment variable `KAGGLE_CONFIG_DIR` to change this location to `$KAGGLE_CONFIG_DIR/kaggle.json` (on Windows it will be `%KAGGLE_CONFIG_DIR%\kaggle.json`).
 
 For your security, ensure that other users of your computer do not have read access to your credentials. On Unix-based systems you can do this with the following command: 
 

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -66,7 +66,7 @@ class KaggleApi(KaggleApi):
   HEADER_API_VERSION = 'X-Kaggle-ApiVersion'
   METADATA_FILE = 'datapackage.json'
 
-  config_path = os.path.join(expanduser('~'), '.kaggle')
+  config_path = os.environ.get('KAGGLE_CONFIG_DIR') or os.path.join(expanduser('~'), '.kaggle')
   if not os.path.exists(config_path):
     os.makedirs(config_path)
   config_file = 'kaggle.json'


### PR DESCRIPTION
Kaggle searches for its configuration file at `~/.kaggle/kaggle.json`. This path is hard-coded in Kaggle. I am looking for ways to reduce the number of dot-files and dot-dirs in my overcrowded home directory and wanted to move kaggle configuration from `~` to `~/.config`, where most other packages have their user configuration.

While a full-fledged support for a flexible location of Kaggle's configuration directory, with fallbacks to `XDG_CONFIG_DIR`, `~/.config/kaggle` and `~/.kaggle`, may be an overkill for this package, a minimum solution is to allow the user to define their own directory for `kaggle.json` through an environment variable.

This PR introduces the possibility of changing the Kaggle's configuration directory by defining a `KAGGLE_CONFIG_DIR` environment variable. `README.md` is updated as well to mention this possibility.