### PR TITLE
Add/environment token and documentation of functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ For your security, ensure that other users of your computer do not have read acc
 
 `chmod 600 ~/.kaggle/kaggle.json`
 
+You can also choose to export your Kaggle username and token to the environment:
+
+```bash
+export KAGGLE_USERNAME=datadinosaur
+export KAGGLE_TOKEN=xxxxxxxxxxxxxx
+```
+
 ## Commands
 
 The command line tool supports the following commands:

--- a/README.md
+++ b/README.md
@@ -27,9 +27,15 @@ For your security, ensure that other users of your computer do not have read acc
 You can also choose to export your Kaggle username and token to the environment:
 
 ```bash
-export KAGGLE_USERNAME=datadinosaur
+export KAGGLE_USER=datadinosaur
 export KAGGLE_TOKEN=xxxxxxxxxxxxxx
 ```
+
+In addition, you can export any other configuration value that normally would be in
+the `$HOME/.kaggle/kaggle.json` in the format 'KAGGLE_<VARIABLE>' (note uppercase).  
+For example, if the file had the variable "proxy" you would export `KAGGLE_PROXY`
+and it would be discovered by the client.
+
 
 ## Commands
 

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -49,828 +49,1477 @@ import six
 from tqdm import tqdm
 
 try:
-  unicode  # Python 2
+    unicode  # Python 2
 except NameError:
-  unicode = str  # Python 3
+    unicode = str  # Python 3
 
 
 class KaggleApi(KaggleApi):
-  __version__ = '1.3.10'
+    __version__ = '1.3.10'
 
-  CONFIG_NAME_PROXY = 'proxy'
-  CONFIG_NAME_COMPETITION = 'competition'
-  CONFIG_NAME_PATH = 'path'
-  CONFIG_NAME_USER = 'username'
-  CONFIG_NAME_KEY = 'key'
+    CONFIG_NAME_PROXY = 'proxy'
+    CONFIG_NAME_COMPETITION = 'competition'
+    CONFIG_NAME_PATH = 'path'
+    CONFIG_NAME_USER = 'username'
+    CONFIG_NAME_KEY = 'key'
 
-  HEADER_API_VERSION = 'X-Kaggle-ApiVersion'
-  METADATA_FILE = 'datapackage.json'
+    HEADER_API_VERSION = 'X-Kaggle-ApiVersion'
+    METADATA_FILE = 'datapackage.json'
 
-  config_path = os.path.join(expanduser('~'), '.kaggle')
-  if not os.path.exists(config_path):
-    os.makedirs(config_path)
-  config_file = 'kaggle.json'
-  config = os.path.join(config_path, config_file)
-  config_values = {}
-  already_printed_version_warning = False
+    config_path = os.path.join(expanduser('~'), '.kaggle')
+    if not os.path.exists(config_path):
+        os.makedirs(config_path)
+    config_file = 'kaggle.json'
+    config = os.path.join(config_path, config_file)
+    config_values = {}
+    already_printed_version_warning = False
 
-  # Hack for https://github.com/Kaggle/kaggle-api/issues/22 / b/78194015
-  if six.PY2:
-    reload(sys)
-    sys.setdefaultencoding('latin1')
+    # Hack for https://github.com/Kaggle/kaggle-api/issues/22 / b/78194015
 
-  def _authenticate_environment(self):
-      '''autheticate environment is the first effort to get a username
-         and key to authenticate to the Kaggle API.
-      '''
-      username = os.environ.get('KAGGLE_USERNAME')
-      key = os.environ.get('KAGGLE_KEY')
-      if None not in [key, username]:
+    if six.PY2:
+        reload(sys)
+        sys.setdefaultencoding('latin1')
 
 
-  def authenticate(self):
-    try:
-      configuration = Configuration()
+## Authentication
 
-      # Option 1:, get configuration values from environment
-      # STOPPED HERE - break into functions...
-      
 
-      # Option 2: read in configuration file
+    def authenticate(self):
+        '''authenticate the user with the Kaggle API. This method will generate
+           a configuration, first checking the environment for credential
+           variables, and falling back to looking for the .kaggle/kaggle.json
+           configuration file.
+        '''
+        config_data = {}
 
-      elif os.name != 'nt':
-        permissions = os.stat(self.config).st_mode
-        if (permissions & 4) or (permissions & 32):
-          print('Warning: Your Kaggle API key is readable by other users on ' +
-                'this system! To fix this, you can run \'chmod 600 {}\''.format(
-                    self.config))
-      with open(self.config, 'r') as f:
-        config_data = json.load(f)
+        # Step 1: read in configuration file, if it exists
+        if os.path.exists(self.config):
+            config_data = self._authenticate_config(config_data)
 
-      self.copy_config_value(self.CONFIG_NAME_PROXY, config_data)
-      self.copy_config_value(self.CONFIG_NAME_PATH, config_data)
-      self.copy_config_value(self.CONFIG_NAME_COMPETITION, config_data)
-      self.copy_config_value(self.CONFIG_NAME_USER, config_data)
+        # Step 2:, get username/password from environment
+        config_data = self._authenticate_environment(config_data)
 
-      configuration.username = config_data[self.CONFIG_NAME_USER]
-      configuration.password = config_data[self.CONFIG_NAME_KEY]
-      if self.CONFIG_NAME_PROXY in config_data:
-        configuration.proxy = config_data[self.CONFIG_NAME_PROXY]
-      self.api_client = ApiClient(configuration)
 
-    except Exception as error:
-      if 'Proxy' in type(error).__name__:
-        sys.exit('The specified proxy ' + config_data[self.CONFIG_NAME_PROXY] +
-                 ' is not valid, please check your proxy settings')
-      else:
-        sys.exit(
-            'Unauthorized: you must download an API key from https://www.kaggle.com/<username>/account\nThen put '
-            + self.config_file + ' in the folder ' + self.config_path)
+        # Step 3: load into configuration!
+        self._load_config(config_data)
 
-  def set_config_value(self, name, value, quiet=False):
-    try:
-      with open(self.config, 'r') as f:
-        config_data = json.load(f)
-      if value is not None:
-        config_data[name] = value
+
+    def _authenticate_environment(self, config_data=None, quiet=False):
+        '''autheticate environment is the second effort to get a username
+           and key to authenticate to the Kaggle API. The environment keys
+           are equivalent to the kaggle.json file, but with "KAGGLE_" prefix
+           to define a unique namespace.
+
+           Parameters
+           ==========
+           configuration: the Configuration object to save a username and
+                          password, if defined
+           config_data: a partially loaded configuration dictionary (optional)
+           quiet: add verbosity
+
+        '''
+
+        if config_data == None:
+            config_data = {}
+
+        # Add all variables that start with KAGGLE_ to config data
+
+        for key,val in os.environ.items():
+            if key.startswith('KAGGLE_'):
+                config_key = key.replace('KAGGLE_','',1).lower()
+                config_data[config_key] = val
+
+        return config_data
+
+
+## Configuration
+
+    def _load_config(self, config_data):
+        '''the final step of the authenticate steps, where we load the values
+           from config_data into the Configuration object.
+
+           Parameters
+           ==========
+           config_data: a dictionary with configuration values (keys) to read
+                        into self.config_values
+
+        '''
+        # Username and password are required.
+
+        for item in [self.CONFIG_NAME_USER, self.CONFIG_NAME_KEY]:
+            if item not in config_data:
+                print('Error: Missing %s in configuration.' % item)
+                sys.exit(1)
+
+        configuration = Configuration()
+
+        # Add to the final configuration (required)
+
+        configuration.username = config_data[self.CONFIG_NAME_USER]
+        configuration.password = config_data[self.CONFIG_NAME_KEY]
+
+        # Proxy
+
+        if self.CONFIG_NAME_PROXY in config_data:
+            configuration.proxy = config_data[self.CONFIG_NAME_PROXY]
+
+        # Keep config values with class instance, and load api client!
+
+        self.config_values = config_data
+
+        try:
+            self.api_client = ApiClient(configuration)
+
+        except Exception as error:
+
+            if 'Proxy' in type(error).__name__:
+                sys.exit('The specified proxy ' + 
+                         config_data[self.CONFIG_NAME_PROXY] +
+                         ' is not valid, please check your proxy settings')
+            else:
+                sys.exit('Unauthorized: you must download an API key or export '
+                         'credentials to the environment. Please see\n ' +
+                         'https://github.com/Kaggle/kaggle-api#api-credentials '
+                          + 'for instructions.')
+
+
+    def _authenticate_config(self, quiet=False):
+        '''autheticate config is the first effort to get a username
+           and key to authenticate to the Kaggle API. Since we can get the
+           username and password from the environment, it's not required.
+
+           Parameters
+           ==========
+           configuration: the Configuration object to save a username and
+                          password, if defined
+           quiet: add verbosity
+        '''
+        config_data = {}
+
+        if os.path.exists(self.config):
+
+            try:
+                if os.name != 'nt':
+                    permissions = os.stat(self.config).st_mode
+                    if (permissions & 4) or (permissions & 32):
+                        print('Warning: Your Kaggle API key is readable by other' 
+                              'users on this system! To fix this, you can run' + 
+                              '\'chmod 600 {}\''.format(self.config))
+
+                with open(self.config, 'r') as f:
+                    config_data = json.load(f)
+            except:
+                pass
+
+        else:
+
+            # Warn the user that configuration will be reliant on environment
+            if not quiet:
+                print('No Kaggle API config file found, will use environment.')
+
+        return config_data
+
+  
+    def _read_config(self):
+        '''read in the configuration file, a json file defined at self.confi'''
+        
+        try:
+            with open(self.config, 'r') as f:
+                config_data = json.load(f)
+        except FileNotFoundError:
+            config_data = {}
+
+        return config_data
+
+
+    def _write_config(self, config_data, indent=1):
+        '''write config data to file.
+        '''
         with open(self.config, 'w') as f:
-          json.dump(config_data, f)
-      if name in config_data:
-        self.config_values[name] = config_data[name]
-    except:
-      pass
-    if not quiet:
-      self.print_config_value(name, separator=' is now set to: ')
+            json.dump(config_data, f, indent=indent)
 
-  def unset_config_value(self, name, quiet=False):
-    try:
-      with open(self.config, 'r') as f:
-        config_data = json.load(f)
-      config_data[name] = None
-      with open(self.config, 'w') as f:
-        json.dump(config_data, f)
-      self.config_values[name] = None
-    except:
-      pass
-    if not quiet:
-      self.print_config_value(name, separator=' is now set to: ')
 
-  def copy_config_value(self, name, values):
-    if name in values:
-      self.config_values[name] = values[name]
+    def set_config_value(self, name, value, quiet=False):
+        '''a client helper function to set a configuration value, meaning
+           reading in the configuration file (if it exists), saving a new
+           config value, and then writing back
+        '''
 
-  def get_config_value(self, name):
-    if name in self.config_values:
-      return self.config_values[name]
-    return None
+        config_data = self._read_config()
+   
+        # If defined by client, set and save!
+        self._write_config(config_data)
 
-  def get_config_path(self):
-    path = self.get_config_value(self.CONFIG_NAME_PATH)
-    if path is None:
-      return self.config_path
-    return path
+        if value is not None:
 
-  def print_config_value(self, name, prefix='', separator=': '):
-    value_out = 'None'
-    if name in self.config_values and self.config_values[name] is not None:
-      value_out = self.config_values[name]
-    print(prefix + name + separator + value_out)
+            # Update the config file with the value
+            config_data[name] = value
 
-  def print_config_values(self):
-    print('Configuration values from ' + self.get_config_path())
-    self.print_config_value(self.CONFIG_NAME_USER, prefix='- ')
-    self.print_config_value(self.CONFIG_NAME_PATH, prefix='- ')
-    self.print_config_value(self.CONFIG_NAME_PROXY, prefix='- ')
-    self.print_config_value(self.CONFIG_NAME_COMPETITION, prefix='- ')
+            # Update the instance with the value
+            self.config_values[name] = value
 
-  def competitions_list(self, page=1, search=''):
-    if search is None:
-      search = ''
-    competitions_list_result = self.process_response(
-        self.competitions_list_with_http_info(page=page, search=search))
-    return [Competition(c) for c in competitions_list_result]
+            if not quiet:
+                self.print_config_value(name, separator=' is now set to: ')
 
-  def competitions_list_cli(self, page=1, search='', csv_display=False):
-    competitions = self.competitions_list(page, search)
-    fields = [
-        'ref', 'deadline', 'category', 'reward', 'teamCount', 'userHasEntered'
-    ]
-    if competitions:
-      if csv_display:
-        self.print_csv(competitions, fields)
-      else:
-        self.print_table(competitions, fields)
-    else:
-      print('No competitions found')
 
-  def competition_submit(self, file_name, message, competition, quiet=False):
-    if competition is None:
-      competition = self.get_config_value(self.CONFIG_NAME_COMPETITION)
-      if competition is not None and not quiet:
-        print('Using competition: ' + competition)
+    def unset_config_value(self, name, quiet=False):
+        '''unset a configuration value'''
 
-    if competition is None:
-      sys.exit('No competition specified')
-    else:
-      url_result = self.process_response(
-          self.competitions_submissions_url_with_http_info(
-              file_name=os.path.basename(file_name),
-              content_length=os.path.getsize(file_name),
-              last_modified_date_utc=int(os.path.getmtime(file_name) * 1000)))
-      url_result_list = url_result['createUrl'].split('/')
-      upload_result = self.process_response(
-          self.competitions_submissions_upload_with_http_info(
-              file=file_name,
-              guid=url_result_list[-3],
-              content_length=url_result_list[-2],
-              last_modified_date_utc=url_result_list[-1]))
-      upload_result_token = upload_result['token']
-      submit_result = self.process_response(
+        config_data = self._read_config()
+
+        # Remove it, if exists, both from loaded file and client
+
+        del self.config_values[name] # is there reason this was None?
+
+        if name in config_data:
+            del config_data[name]
+
+            self._write_config(config_data)
+
+            if not quiet:
+                self.print_config_value(name, separator=' is now set to: ')
+
+    def get_config_value(self, name):
+        ''' return a config value (with key name) if it's in the config_values,
+            otherwise return None
+ 
+            Parameters
+            ==========
+            name: the config value key to get
+
+        '''
+        if name in self.config_values:
+            return self.config_values[name]
+
+    def get_config_path(self):
+        '''get the path configuration value, otherwise return default.
+        '''
+        path = self.get_config_value(self.CONFIG_NAME_PATH)
+        if path is None:
+            return self.config_path
+        return path
+
+    def print_config_value(self, name, prefix='', separator=': '):
+        '''print a single configuration value, based on a prefix and separator
+
+           Parameters
+           ==========
+           name: the key of the config valur in self.config_values to print
+           prefix: the prefix to print
+           separator: the separator to use (default is : )
+        '''
+        value_out = 'None'
+        if name in self.config_values and self.config_values[name] is not None:
+            value_out = self.config_values[name]
+        print(prefix + name + separator + value_out)
+
+    def print_config_values(self):
+        '''a wrapper to print_config_value to print all configuration values
+        '''
+        print('Configuration values from ' + self.get_config_path())
+        self.print_config_value(self.CONFIG_NAME_USER, prefix='- ')
+        self.print_config_value(self.CONFIG_NAME_PATH, prefix='- ')
+        self.print_config_value(self.CONFIG_NAME_PROXY, prefix='- ')
+        self.print_config_value(self.CONFIG_NAME_COMPETITION, prefix='- ')
+
+
+## Competitions
+
+    ## List and Get Competitions
+
+    def competitions_list(self, page=1, search=''):
+        '''make call to list competitions, format the response, and return
+           a list of Competition instances
+
+           Parameters
+           ==========
+           page: the page to return (default is 1)
+           search: a search term to use (default is empty string)
+
+        '''    
+
+        # Make sure search isn't None
+
+        search = search or ''
+
+        # Get the listing of competitions
+
+        response = self.competitions_list_with_http_info(page=page,
+                                                         search=search)
+        # Process the response
+
+        competitions_list_result = self.process_response(response)
+
+        return [Competition(c) for c in competitions_list_result]
+
+
+    def competitions_list_cli(self, page=1, search='', csv_display=False):
+        '''a wrapper for competitions_list for the client
+        
+           Paramters
+           =========
+           page: the page to return (default is 1)
+           search: a default search term
+           csv_display: if True, print comma separated values
+
+        '''
+
+        competitions = self.competitions_list(page, search)
+
+        fields = ['ref', 
+                  'deadline', 
+                  'category', 
+                  'reward', 
+                  'teamCount', 
+                  'userHasEntered']
+
+        self.print_result(competitions, fields, 'competitions', csv_display)
+
+
+    def _competition_get_or_exit(self, competition):
+        '''if a competition is None, look for the name in the config values.
+           If it's still None, exit.
+
+           competition: the name of the competition (str)
+        '''
+
+        if competition is None:
+            competition = self.get_config_value(self.CONFIG_NAME_COMPETITION)
+        if competition is not None and not quiet:
+            print('Using competition: ' + competition)
+
+        if competition is None:
+            sys.exit('No competition specified')
+
+        return competition
+
+
+    ## Submit
+
+    def competition_submit(self, file_name, message, competition, quiet=False):
+        '''submit a competition!
+      
+           Parameters
+           ==========
+           file_name: the competition metadata file 
+           message: the submission description
+           competition: the competition name
+           
+        '''
+        if competition is None:
+            competition = self.get_config_value(self.CONFIG_NAME_COMPETITION)
+        elif competition is not None and not quiet:
+            print('Using competition: ' + competition)
+
+        # If still None, wasn't obtained in configuration, exit
+        if competition is None:
+            sys.exit('No competition specified')
+
+        # Calculate the date last modified of the file
+
+        last_modified_date = int(os.path.getmtime(file_name) * 1000)
+
+        # Step 1: Get the URL for the submission
+        url_result = self.process_response(
+            self.competitions_submissions_url_with_http_info(
+                file_name=os.path.basename(file_name),
+                content_length=os.path.getsize(file_name),
+                last_modified_date_utc=last_modified_date))
+
+        url_result_list = url_result['createUrl'].split('/')
+
+        # Step 2: Upload the result
+        upload_result = self.process_response(
+            self.competitions_submissions_upload_with_http_info(
+                file=file_name,
+                guid=url_result_list[-3],
+                content_length=url_result_list[-2],
+                last_modified_date_utc=url_result_list[-1]))
+        upload_result_token = upload_result['token']
+
+        # Step 3: Submit!
+        submit_result = self.process_response(
           self.competitions_submissions_submit_with_http_info(
-              id=competition,
-              blob_file_tokens=upload_result_token,
-              submission_description=message))
-      return SubmitResult(submit_result)
+                  id=competition,
+                  blob_file_tokens=upload_result_token,
+                  submission_description=message))
+  
+        return SubmitResult(submit_result)
 
-  def competition_submit_cli(self, file_name, message, competition, quiet=False):
-    try:
-      submit_result = self.competition_submit(file_name, message, competition, quiet)
-    except ApiException as e:
-      if e.status == 404:
-        print(
-            'Could not find competition - please verify that you entered the correct competition ID and that the competition is still accepting submissions.'
-        )
-        return None
-      else:
-        raise e
-    return submit_result
 
-  def competition_submissions(self, competition):
-    submissions_result = self.process_response(
-        self.competitions_submissions_list_with_http_info(id=competition))
-    return [Submission(s) for s in submissions_result]
+    def competition_submit_cli(self, file_name, message, competition, quiet=False):
+        '''submit a competition using the client. Arguments are same as for
+           competition_submit
+        '''
+        try:
+            submit_result = self.competition_submit(file_name, message, competition, quiet)
+        except ApiException as e:
+            if e.status == 404:
+                print('Could not find competition - please verify that you ' +
+                      'entered the correct competition ID and that the ' +
+                      'competition is still accepting submissions.')
+                return None
+            raise e
 
-  def competition_submissions_cli(self,
-                                  competition=None,
-                                  csv_display=False,
-                                  quiet=False):
-    if competition is None:
-      competition = self.get_config_value(self.CONFIG_NAME_COMPETITION)
-      if competition is not None and not quiet:
-        print('Using competition: ' + competition)
+        return submit_result
 
-    if competition is None:
-      sys.exit('No competition specified')
-    else:
-      submissions = self.competition_submissions(competition)
-      fields = [
-          'fileName', 'date', 'description', 'status', 'publicScore',
-          'privateScore'
-      ]
-      if submissions:
-        if csv_display:
-          self.print_csv(submissions, fields)
-        else:
-          self.print_table(submissions, fields)
-      else:
-        print('No submissions found')
+    ## Submissions
 
-  def competition_list_files(self, competition):
-    competition_list_files_result = self.process_response(
-        self.competitions_data_list_files_with_http_info(id=competition))
-    return [File(f) for f in competition_list_files_result]
+    def competition_submissions(self, competition):
+        '''get the list of Submission for a particular competition
 
-  def competition_list_files_cli(self,
+           Parameters
+           ==========
+           competition: the name of the competition
+
+        '''
+        submissions_result = self.process_response(
+            self.competitions_submissions_list_with_http_info(id=competition))
+        return [Submission(s) for s in submissions_result]
+
+
+    def competition_submissions_cli(self,
+                                    competition=None,
+                                    csv_display=False,
+                                    quiet=False):
+        '''wrapper to competition_submission, will return either json or csv
+           to the user
+
+           Parameters
+           ==========
+           competition: the name of the competition. If None, look to config
+           csv_display: if True, print comma separated values
+           
+        '''
+ 
+        competition = self._competition_get_or_exit(competition)
+
+        submissions = self.competition_submissions(competition)
+        fields = [ 'fileName', 
+                   'date', 
+                   'description', 
+                   'status', 
+                   'publicScore',
+                   'privateScore']
+
+        self.print_result(submissions, fields, 'submissions', csv_display)
+
+
+    ## Files
+
+    def competition_list_files(self, competition):
+        '''list files for competition
+
+           Parameters
+           ==========
+           competition: the name of the competition
+
+        '''
+        competition_list_files_result = self.process_response(
+            self.competitions_data_list_files_with_http_info(id=competition))
+        return [File(f) for f in competition_list_files_result]
+
+
+    def competition_list_files_cli(self,
+                                   competition,
+                                   csv_display=False,
+                                   quiet=False):
+
+        '''List files for a competition, if it exists
+
+           Parameters
+           ==========
+           competition: the name of the competition. If None, look to config
+           csv_display: if True, print comma separated values
+        '''
+
+        competition = self._competition_get_or_exit(competition)
+
+        files = self.competition_list_files(competition)
+        fields = ['name', 'size', 'creationDate']
+
+        self.print_result(files, fields, 'files', csv_display)
+
+
+## Download
+
+
+    def _get_download_path(self, path, subfolders):
+        '''Get the download path for a file. If not defined, return default 
+           from config.
+
+           Parameters
+           ==========
+           path: a path defined by the user, doesn't have to be defined
+           subfolders: a single (or list of) subfolders under the basepath
+
+        '''
+        effective_path = path
+        if path is None:
+ 
+            # explode this into os.path.join so it can be arbitrary length
+            if not isinstance(subfolders,list):
+                subfolders = [subfolders]
+
+            effective_path = os.path.join(self.get_config_path(), *subfolders)
+
+        return effective_path
+        
+
+    ## Files
+
+    def competition_download_cli(self,
                                  competition,
-                                 csv_display=False,
+                                 file_name=None,
+                                 path=None,
+                                 force=False,
                                  quiet=False):
-    if competition is None:
-      competition = self.get_config_value(self.CONFIG_NAME_COMPETITION)
-      if competition is not None and not quiet:
-        print('Using competition: ' + competition)
 
-    if competition is None:
-      sys.exit('No competition specified')
-    else:
-      files = self.competition_list_files(competition)
-      fields = ['name', 'size', 'creationDate']
-      if files:
-        if csv_display:
-          self.print_csv(files, fields)
+        '''a wrapper to competition_download_files, but first will parse input
+           from API client.
+
+           Parameters
+           =========
+           competition: the name of the competition
+           file_name: the configuration file name
+           path: a path to download the file to
+
+        '''
+        competition = self._competition_get_or_exit(competition)
+
+        if file_name is None:
+            self.competition_download_files(competition, path, force, quiet)
         else:
-          self.print_table(files, fields)
-      else:
-        print('No files found')
+            self.competition_download_file(competition, 
+                                           file_name=file_name, 
+                                           path=path, 
+                                           force=force,
+                                           quiet=quiet)
 
-  def competition_download_file(self,
+
+    def competition_download_file(self,
                                 competition,
                                 file_name,
                                 path=None,
                                 force=False,
                                 quiet=False):
-    if path is None:
-      effective_path = os.path.join(self.get_config_path(), 'competitions',
-                                    competition)
-    else:
-      effective_path = path
+        '''download a competition file to a designated location, or use
+           a default location
 
-    response = self.process_response(
-        self.competitions_data_download_file_with_http_info(
-            id=competition, file_name=file_name, _preload_content=False))
-    url = response.retries.history[0].redirect_location.split('?')[0]
-    outfile = os.path.join(effective_path, url.split('/')[-1])
+           Paramters
+           =========
+           competition: the name of the competition
+           file_name: the configuration file name
+           path: a path to download the file to
+          
+        '''
 
-    if force or self.download_needed(response, outfile, quiet):
-      self.download_file(response, outfile, quiet)
+        subfolders = [competition, 'competitions']
+        effective_path = self._get_download_path(path, subfolders)
 
-  def competition_download_files(self,
-                                 competition,
-                                 path=None,
-                                 force=False,
-                                 quiet=True):
-    files = self.competition_list_files(competition)
-    if not files:
-      print('This competitoin does not have any available data files')
-    for file_name in files:
-      self.competition_download_file(competition, file_name.ref, path, force,
-                                     quiet)
+        response = self.process_response(
+            self.competitions_data_download_file_with_http_info(
+                id=competition, 
+                file_name=file_name, 
+                _preload_content=False))
 
-  def competition_download_cli(self,
-                               competition,
-                               file_name=None,
-                               path=None,
-                               force=False,
-                               quiet=False):
-    if competition is None:
-      competition = self.get_config_value(self.CONFIG_NAME_COMPETITION)
-      if competition is not None and not quiet:
-        print('Using competition: ' + competition)
+        url = response.retries.history[0].redirect_location.split('?')[0]
+        outfile = os.path.join(effective_path, url.split('/')[-1])
 
-    if competition is None:
-      sys.exit('No competition specified')
-    else:
-      if file_name is None:
-        self.competition_download_files(competition, path, force, quiet)
-      else:
-        self.competition_download_file(competition, file_name, path, force,
-                                       quiet)
+        if force or self.download_needed(response, outfile, quiet):
+            self.download_file(response, outfile, quiet)
 
-  def competition_leaderboard_download(self, competition, path, quiet=True):
-    response = self.process_response(
-        self.competition_download_leaderboard_with_http_info(
-            competition, _preload_content=False))
 
-    if path is None:
-      effective_path = os.path.join(self.get_config_path(), 'competitions',
-                                    competition)
-    else:
-      effective_path = path
+    def competition_download_files(self,
+                                   competition,
+                                   path=None,
+                                   force=False,
+                                   quiet=True):
+        '''a wrapper to competition_download_file to download all competition
+           files.
 
-    file_name = competition + '.zip'
-    outfile = os.path.join(effective_path, file_name)
-    self.download_file(response, outfile, quiet)
+           Parameters
+           =========
+           competition: the name of the competition
+           file_name: the configuration file name
+           path: a path to download the file to
+        '''
 
-  def competition_leaderboard_view(self, competition):
-    result = self.process_response(
-        self.competition_view_leaderboard_with_http_info(competition))
-    return [LeaderboardEntry(e) for e in result['submissions']]
+        files = self.competition_list_files(competition)
+        if not files:
+            print('This competition does not have any available data files')
+        for file_name in files:
+            self.competition_download_file(competition, 
+                                           file_name=file_name.ref, 
+                                           path=path, 
+                                           force=force,
+                                           quiet=quiet)
 
-  def competition_leaderboard_cli(self,
-                                  competition,
-                                  path=None,
-                                  view=False,
-                                  download=False,
-                                  csv_display=False,
-                                  quiet=False):
-    if not view and not download:
-      sys.exit('Either --show or --download must be specified')
 
-    if competition is None:
-      competition = self.get_config_value(self.CONFIG_NAME_COMPETITION)
-      if competition is not None and not quiet:
-        print('Using competition: ' + competition)
+    ## Leaderboards
 
-    if competition is None:
-      sys.exit('No competition specified')
+    def competition_leaderboard_download(self, competition, path, quiet=True):
+        ''' Download competition leaderboards
+ 
+            Parameters
+            =========
+            competition: the name of the competition
+            file_name: the configuration file name
+            path: a path to download the file to
 
-    if download:
-      self.competition_leaderboard_download(competition, path, quiet)
+        '''
+        response = self.process_response(
+            self.competition_download_leaderboard_with_http_info(
+                competition, _preload_content=False))
 
-    if view:
-      results = self.competition_leaderboard_view(competition)
-      fields = ['teamId', 'teamName', 'submissionDate', 'score']
-      if results:
-        if csv_display:
-          self.print_csv(results, fields)
+        subfolders = [competition, 'competitions']
+        effective_path = self._get_download_path(path, subfolders)
+
+        file_name = competition + '.zip'
+        outfile = os.path.join(effective_path, file_name)
+        self.download_file(response, outfile, quiet)
+
+
+    def competition_leaderboard_view(self, competition):
+        '''view a leaderboard based on a competition name
+ 
+           Parameters
+           ==========
+           competition: the competition name to view leadboard for
+
+        '''
+        result = self.process_response(
+            self.competition_view_leaderboard_with_http_info(competition))
+        return [LeaderboardEntry(e) for e in result['submissions']]
+
+
+    def competition_leaderboard_cli(self,
+                                    competition,
+                                    path=None,
+                                    view=False,
+                                    download=False,
+                                    csv_display=False,
+                                    quiet=False):
+
+        '''a wrapper for competition_leaderbord_view that will print the
+           results as a table or comma separated values
+
+           Parameters
+           ==========
+           competition: the competition name to view leadboard for
+           path: a path to download to, if download is True
+           view: if True, show the results in the terminal as csv or table
+           csv_display: if True, print comma separated values instead of table
+
+        '''
+ 
+        if not view and not download:
+            sys.exit('Either --show or --download must be specified')
+
+        competition = self._competition_get_or_exit(competition)
+
+        if download is True:
+            self.competition_leaderboard_download(competition, path, quiet)
+
+        if view is True:
+            results = self.competition_leaderboard_view(competition)
+            fields = ['teamId', 'teamName', 'submissionDate', 'score']
+            self.print_result(results, fields, 'results', csv_display)
+
+
+## Datasets
+
+    def datasets_list(self, page=1, search=''):
+        '''return a list of datasets!
+
+           Parameters
+           ==========
+           page: the page to return (default is 1)
+           search: a search term to use (default is empty string)
+
+        '''
+        # Make sure search isn't None
+        search = search or ''
+
+        datasets_list_result = self.process_response(
+            self.datasets_list_with_http_info(page=page, search=search))
+        return [Dataset(d) for d in datasets_list_result]
+
+
+    def _dataset_get_or_exit(self, dataset):
+        '''return the owner (user or organization) of a dataset, or exit
+           on error (meaning the user didn't provide the entire URI)
+
+           Parameters
+           ==========
+           dataset: the string identified of the dataset
+                    should be in format [owner]/[dataset-name]   
+ 
+        '''
+        try:
+            dataset_urls = dataset.split('/')
+            owner_slug = dataset_urls[0]
+            dataset_slug = dataset_urls[1]
+
+        except IndexError:
+            print('%s is an invalid dataset name, should be in format ' +
+                  ' [owner]/[dataset-name]' % dataset)
+            sys.exit(1)
+
+        return owner_slug, dataset_slug
+
+
+    def datasets_view(self, dataset):
+        '''view metadata for a dataset.
+          
+           Parameters
+           ==========
+           dataset: the string identified of the dataset
+                    should be in format [owner]/[dataset-name]   
+        '''
+
+        owner_slug, dataset_slug = self._dataset_get_or_exit(dataset)
+
+        result = self.process_response(
+            self.datasets_view_with_http_info(owner_slug, dataset_slug))
+        return Dataset(result)
+
+    def datasets_list_cli(self, page=1, search='', csv_display=False):
+        '''a wrapper to datasets_list for the client.
+
+           Parameters
+           ==========
+           page: the page to return (default is 1)
+           search: a search term to use (default is empty string)
+
+        '''
+        datasets = self.datasets_list(page, search)
+        fields = ['ref', 'title', 'size', 'lastUpdated', 'downloadCount']
+        self.print_result(datasets, fields, 'datasets', csv_display)
+
+
+    ## Files
+
+    def dataset_list_files(self, dataset):
+        '''list files for a dataset
+
+           Parameters
+           ==========
+           dataset: the string identified of the dataset
+                    should be in format [owner]/[dataset-name]   
+
+        '''
+        owner_slug, dataset_slug = self._dataset_get_or_exit(dataset)
+
+        dataset_list_files_result = self.process_response(
+            self.datasets_list_files_with_http_info(
+                owner_slug=owner_slug, 
+                dataset_slug=dataset_slug))
+        return ListFilesResult(dataset_list_files_result)
+
+
+    def dataset_list_files_cli(self, dataset, csv_display=False):
+        '''a wrapper to dataset_list_files for the client 
+           (list files for a dataset)
+
+           Parameters
+           ==========
+           csv_display: if True, print comma separated values instead of table
+           dataset: the string identified of the dataset
+                    should be in format [owner]/[dataset-name]   
+
+        '''
+
+        result = self.dataset_list_files(dataset)
+    
+        # There was an error in listing the files.
+        if result:
+            if result.error_message:
+                print(result.error_message)
+
+        # No error, print away!
         else:
-          self.print_table(results, fields)
-      else:
-        print('No results found')
+            fields = ['name', 'size', 'creationDate']
+            self.print_result(result.files, fields, 'files', csv_display)
 
-  def datasets_list(self, page=1, search=''):
-    if search is None:
-      search = ''
-    datasets_list_result = self.process_response(
-        self.datasets_list_with_http_info(page=page, search=search))
-    return [Dataset(d) for d in datasets_list_result]
 
-  def datasets_view(self, dataset):
-    dataset_urls = dataset.split('/')
-    owner_slug = dataset_urls[0]
-    dataset_slug = dataset_urls[1]
+    ## Download
 
-    result = self.process_response(
-        self.datasets_view_with_http_info(owner_slug, dataset_slug))
-    return Dataset(result)
+    def dataset_download_file(self,
+                              dataset,
+                              file_name,
+                              path=None,
+                              force=False,
+                              quiet=True):
+        
+        '''download a single file for a dataset
 
-  def datasets_list_cli(self, page=1, search='', csv_display=False):
-    datasets = self.datasets_list(page, search)
-    fields = ['ref', 'title', 'size', 'lastUpdated', 'downloadCount']
-    if datasets:
-      if csv_display:
-        self.print_csv(datasets, fields)
-      else:
-        self.print_table(datasets, fields)
-    else:
-      print('No datasets found')
+           Parameters
+           ==========
+           dataset: the string identified of the dataset
+                    should be in format [owner]/[dataset-name]   
+           file_name: the dataset configuration file
+           path: if defined, download to this location
+     
+        '''
 
-  def dataset_list_files(self, dataset):
-    dataset_url_list = dataset.split('/')
-    owner_slug = dataset_url_list[0]
-    dataset_slug = dataset_url_list[1]
-    dataset_list_files_result = self.process_response(
-        self.datasets_list_files_with_http_info(
-            owner_slug=owner_slug, dataset_slug=dataset_slug))
-    return ListFilesResult(dataset_list_files_result)
+        owner_slug, dataset_slug = self._dataset_get_or_exit(dataset)
 
-  def dataset_list_files_cli(self, dataset, csv_display=False):
-    result = self.dataset_list_files(dataset)
-    if result:
-      if result.error_message:
-        print(result.error_message)
-      else:
-        fields = ['name', 'size', 'creationDate']
-        if csv_display:
-          self.print_csv(result.files, fields)
+        # Get the effective path for the dataset
+
+        subfolders = ['datasets', owner_slug, dataset_slug]
+        effective_path = self._get_download_path(path, subfolders)
+
+        response = self.process_response(
+            self.datasets_download_file_with_http_info(
+                owner_slug=owner_slug,
+                dataset_slug=dataset_slug,
+                file_name=file_name,
+                _preload_content=False))
+
+        url = response.retries.history[0].redirect_location.split('?')[0]
+        outfile = os.path.join(effective_path, url.split('/')[-1])
+
+        # Return True if download, False if not
+
+        if force or self.download_needed(response, outfile, quiet):
+            self.download_file(response, outfile, quiet)
+            return True
         else:
-          self.print_table(result.files, fields)
-    else:
-      print('No files found')
+            return False
 
-  def dataset_download_file(self,
-                            dataset,
-                            file_name,
-                            path=None,
-                            force=False,
-                            quiet=True):
-    dataset_url_list = dataset.split('/')
-    owner_slug = dataset_url_list[0]
-    dataset_slug = dataset_url_list[1]
+    def dataset_download_files(self, 
+                               dataset, 
+                               path=None, 
+                               force=False, 
+                               quiet=True):
+        '''download all files for a dataset
+         
+           Parameters
+           ==========
+           dataset: the string identified of the dataset
+                    should be in format [owner]/[dataset-name]   
+           path: the path to download the dataset to
+         
+        '''
 
-    if path is None:
-      effective_path = os.path.join(self.get_config_path(), 'datasets',
-                                    owner_slug, dataset_slug)
-    else:
-      effective_path = path
+        owner_slug, dataset_slug = self._dataset_get_or_exit(dataset)
 
-    response = self.process_response(
-        self.datasets_download_file_with_http_info(
-            owner_slug=owner_slug,
-            dataset_slug=dataset_slug,
-            file_name=file_name,
-            _preload_content=False))
-    url = response.retries.history[0].redirect_location.split('?')[0]
-    outfile = os.path.join(effective_path, url.split('/')[-1])
-    if force or self.download_needed(response, outfile, quiet):
-      self.download_file(response, outfile, quiet)
-      return True
-    else:
-      return False
+        subfolders = ['datasets', owner_slug, dataset_slug]
+        effective_path = self._get_download_path(path, subfolders)
 
-  def dataset_download_files(self, dataset, path=None, force=False, quiet=True):
-    dataset_url_list = dataset.split('/')
-    owner_slug = dataset_url_list[0]
-    dataset_slug = dataset_url_list[1]
+        downloaded = self.dataset_download_file(dataset, dataset_slug + '.zip',
+                                                path, force, quiet)
+        if downloaded is True:
+            outfile = os.path.join(effective_path, dataset_slug + '.zip')
+            with zipfile.ZipFile(outfile) as z:
+                z.extractall(effective_path)
 
-    if path is None:
-      effective_path = os.path.join(self.get_config_path(), 'datasets',
-                                    owner_slug, dataset_slug)
-    else:
-      effective_path = path
+    def dataset_download_cli(self,
+                             dataset,
+                             file_name=None,
+                             path=None,
+                             force=False,
+                             quiet=False):
+        '''client wrapper for dataset_download_files to download dataset files
+         
+           Parameters
+           ==========
+           dataset: the string identified of the dataset
+                    should be in format [owner]/[dataset-name]   
+           path: the path to download the dataset to
+         
+        '''
 
-    downloaded = self.dataset_download_file(dataset, dataset_slug + '.zip',
-                                            path, force, quiet)
-    if downloaded:
-      outfile = os.path.join(effective_path, dataset_slug + '.zip')
-      with zipfile.ZipFile(outfile) as z:
-        z.extractall(effective_path)
+        if file_name is None:
+            self.dataset_download_files(dataset, path, force, quiet)
+        else:
+            self.dataset_download_file(dataset, file_name, path, force, quiet)
 
-  def dataset_download_cli(self,
-                           dataset,
-                           file_name=None,
-                           path=None,
-                           force=False,
-                           quiet=False):
-    if file_name is None:
-      self.dataset_download_files(dataset, path, force, quiet)
-    else:
-      self.dataset_download_file(dataset, file_name, path, force, quiet)
+    def dataset_upload_file(self, path, quiet):
+        '''upload a dataset file
 
-  def dataset_upload_file(self, path, quiet):
-    file_name = os.path.basename(path)
-    content_length = os.path.getsize(path)
-    last_modified_date_utc = int(os.path.getmtime(path))
-    result = FileUploadInfo(
-        self.process_response(
-            self.datasets_upload_file_with_http_info(file_name, content_length,
-                                                     last_modified_date_utc)))
+           Parameters
+           ==========
+           path: the complete path to upload
 
-    success = self.upload_complete(path, result.createUrl, quiet)
+        '''
+ 
+        file_name = os.path.basename(path)
+        content_length = os.path.getsize(path)
+        last_modified_date_utc = int(os.path.getmtime(path))
 
-    if success:
-      return result.token
-    return None
+        # Do the upload and get a result
+        result = FileUploadInfo(
+            self.process_response(
+                self.datasets_upload_file_with_http_info(file_name, content_length,
+                                                         last_modified_date_utc)))
 
-  def dataset_create_version(self,
-                             folder,
-                             version_notes,
-                             quiet=False,
-                             convert_to_csv=True,
-                             delete_old_versions=False):
-    if not os.path.isdir(folder):
-      sys.exit('Invalid folder: ' + folder)
+        # Returns True if successful (otherwise we return None)
+        if self.upload_complete(path, result.createUrl, quiet):
+            return result.token
+    
 
-    meta_file = os.path.join(folder, self.METADATA_FILE)
-    if not os.path.isfile(meta_file):
-      sys.exit('Metadata file not found: ' + self.METADATA_FILE)
+    def _dataset_prepare_create_request(self, folder):
+        '''prepare a dictionary with parameters to create, and also do sanity
+           checks for folder and metadata file existence. Return a dictionary
+           with values needed for the request.
+ 
+           Parameters
+           ==========
+           folder: the folder with the expected metadata file
 
-    # read json
-    with open(meta_file, 'r') as f:
-      meta_data = json.load(f)
-    ref = self.get_or_exit(meta_data, 'id')
-    ref_list = ref.split('/')
-    owner_slug = ref_list[0]
-    dataset_slug = ref_list[1]
+        '''
 
-    # validations
-    if ref == self.config_values[self.CONFIG_NAME_USER] + '/INSERT_SLUG_HERE':
-      sys.exit('Default slug detected, please change values before uploading')
+        # Folder and metadata file are required
+        if not os.path.isdir(folder):
+            sys.exit('Invalid folder: ' + folder)
+        
+        meta_file = os.path.join(folder, self.METADATA_FILE)
+        if not os.path.isfile(meta_file):
+            sys.exit('Metadata file not found: ' + self.METADATA_FILE)
+         
+        # read metadata json in dataset folder
+        with open(meta_file, 'r') as f:
+            meta_data = json.load(f)
+        ref = self.get_or_exit(meta_data, 'id')
 
-    subtitle = meta_data.get('subtitle')
-    if subtitle and (len(subtitle) < 20 or len(subtitle) > 80):
-      raise ValueError('Subtitle length must be between 20 and 80 characters')
+        # Get the owner (organization) and dataset name
+        owner_slug, dataset_slug = self._dataset_get_or_exit(ref)
+        meta_data['owner_slug'] = owner_slug
+        meta_data['dataset_slug'] = dataset_slug
 
-    description = meta_data.get('description')
-    keywords = self.get_or_default(meta_data, 'keywords', [])
+        # validations
+        missing_message = 'Default %s detected, please change before uploading'
 
-    request = DatasetNewVersionRequest(
-        version_notes=version_notes,
-        subtitle=subtitle,
-        description=description,
-        files=[],
-        convert_to_csv=convert_to_csv,
-        category_ids=keywords,
-        delete_old_versions=delete_old_versions)
-    resources = meta_data.get('resources')
-    self.upload_files(request, resources, folder, quiet)
-    result = DatasetNewVersionResponse(
-        self.process_response(
-            self.datasets_create_version_with_http_info(owner_slug,
-                                                        dataset_slug, request)))
-    return result
+        # Title and must be defined
+        if ref == self.config_values[self.CONFIG_NAME_USER] + '/INSERT_SLUG_HERE':
+            sys.exit(missing_message % 'slug')
+        if meta_data.get('title') == 'INSERT_TITLE_HERE':
+            sys.exit(missing_message % 'title')
 
-  def dataset_create_version_cli(self,
-                                 folder,
-                                 version_notes,
-                                 quiet=False,
-                                 convert_to_csv=True,
-                                 delete_old_versions=False):
-    result = self.dataset_create_version(
-        folder,
-        version_notes,
-        quiet=quiet,
-        convert_to_csv=convert_to_csv,
-        delete_old_versions=delete_old_versions)
+        # Only one license allowed
+        if len(meta_data.get('licenses')) != 1:
+            sys.exit('Please specify exactly one license')
 
-    if result.invalidTags is not None:
-      print(
-          'The following are not valid tags and could not be added to the dataset: '
-          + str(result.invalidTags))
-    if result is None:
-      print('Dataset version creation error: See previous output')
-    elif result.status == 'ok':
-      print('Dataset version is being created. Please check progress at ' +
-            result.url)
-    else:
-      print('Dataset version creation error: ' + result.error)
+        # Subtitle
+        subtitle = meta_data.get('subtitle')
+        if subtitle and (len(subtitle) < 20 or len(subtitle) > 80):
+            raise ValueError('Subtitle length must be between 20 and 80 characters')
 
-  def dataset_initialize(self, folder):
-    if not os.path.isdir(folder):
-      sys.exit('Invalid folder: ' + folder)
+        # Keywords
+        meta_data['keywords'] = self.get_or_default(meta_data, 'keywords', [])
+        return meta_data
 
-    ref = self.config_values[self.CONFIG_NAME_USER] + '/INSERT_SLUG_HERE'
-    licenses = []
-    license = {'name': 'CC0-1.0'}
-    licenses.append(license)
 
-    meta_data = {'title': 'INSERT_TITLE_HERE', 'id': ref, 'licenses': licenses}
-    meta_file = os.path.join(folder, self.METADATA_FILE)
-    with open(meta_file, 'w') as f:
-      json.dump(meta_data, f)
+    def dataset_create_version(self,
+                               folder,
+                               version_notes,
+                               quiet=False,
+                               convert_to_csv=True,
+                               delete_old_versions=False):
+         ''' create a version of a dataset
 
-    print('Data package template written to: ' + meta_file)
-    return meta_file
+             Parameters
+             ==========
+             folder: the folder with the dataset configuration / data files
+             version_notes: notes to add for the version
+             convert_to_csv: on upload, if data should be converted to csv
+             delete_old_versions: if True, do that (default False)
 
-  def dataset_create_new(self,
-                         folder,
-                         public=False,
-                         quiet=False,
-                         convert_to_csv=True):
-    if not os.path.isdir(folder):
-      sys.exit('Invalid folder: ' + folder)
+         '''
+         metadata = self._dataset_prepare_create_request(folder)
 
-    meta_file = os.path.join(folder, self.METADATA_FILE)
-    if not os.path.isfile(meta_file):
-      sys.exit('Metadata file not found: ' + self.METADATA_FILE)
+         # Make the request
+         request = DatasetNewVersionRequest(
+             version_notes=version_notes,
+             subtitle=metadata.get('subtitle'),
+             description=metadata.get('description'),
+             files=[],
+             convert_to_csv=convert_to_csv,
+             category_ids=metadata.get('keywords'),
+             delete_old_versions=delete_old_versions)
 
-    # read json
-    with open(meta_file, 'r') as f:
-      meta_data = json.load(f)
-    ref = self.get_or_exit(meta_data, 'id')
-    title = self.get_or_exit(meta_data, 'title')
-    licenses = self.get_or_exit(meta_data, 'licenses')
-    ref_list = ref.split('/')
-    owner_slug = ref_list[0]
-    dataset_slug = ref_list[1]
+         # Upload the resources
+         resources = metadata.get('resources')
+         owner = metadata.get('owner_slug')
+         slug = metadata.get('dataset_slug')
 
-    # validations
-    if ref == self.config_values[self.CONFIG_NAME_USER] + '/INSERT_SLUG_HERE':
-      sys.exit('Default slug detected, please change values before uploading')
-    if title == 'INSERT_TITLE_HERE':
-      sys.exit('Default title detected, please change values before uploading')
-    if len(licenses) != 1:
-      sys.exit('Please specify exactly one license')
+         self.upload_files(request, resources, folder, quiet)
+         result = DatasetNewVersionResponse(
+             self.process_response(
+                 self.datasets_create_version_with_http_info(owner,
+                                                             slug, 
+                                                             request)))
+         return result
 
-    license_name = self.get_or_exit(licenses[0], 'name')
-    description = meta_data.get('description')
-    keywords = self.get_or_default(meta_data, 'keywords', [])
 
-    subtitle = meta_data.get('subtitle')
-    if subtitle and (len(subtitle) < 20 or len(subtitle) > 80):
-      raise ValueError('Subtitle length must be between 20 and 80 characters')
+    def dataset_create_version_cli(self,
+                                   folder,
+                                   version_notes,
+                                   quiet=False,
+                                   convert_to_csv=True,
+                                   delete_old_versions=False):
+        ''' client wrapper for creating a version of a dataset
 
-    request = DatasetNewRequest(
-        title=title,
-        slug=dataset_slug,
-        owner_slug=owner_slug,
-        license_name=license_name,
-        subtitle=subtitle,
-        description=description,
-        files=[],
-        is_private=not public,
-        convert_to_csv=convert_to_csv,
-        category_ids=keywords)
-    resources = meta_data.get('resources')
-    self.upload_files(request, resources, folder, quiet)
-    result = DatasetNewResponse(
-        self.process_response(self.datasets_create_new_with_http_info(request)))
-    return result
+            Parameters
+            ==========
+            folder: the folder with the dataset configuration / data files
+            version_notes: notes to add for the version
+            convert_to_csv: on upload, if data should be converted to csv
+            delete_old_versions: if True, do that (default False)
 
-  def dataset_create_new_cli(self,
-                             folder,
-                             public=False,
-                             quiet=False,
-                             convert_to_csv=True):
-    result = self.dataset_create_new(folder, public, quiet, convert_to_csv)
-    if result.invalidTags is not None:
-      print(
-          'The following are not valid tags and could not be added to the dataset: '
-          + str(result.invalidTags))
-    if result.status == 'ok':
-      if public:
-        print('Your public Dataset is being created. Please check progress at '
-              + result.url)
-      else:
-        print('Your private Dataset is being created. Please check progress at '
-              + result.url)
-    else:
-      print('Dataset creation error: ' + result.error)
+        '''
 
-  def download_file(self, response, outfile, quiet=True, chunk_size=1048576):
-    outpath = os.path.dirname(outfile)
-    if not os.path.exists(outpath):
-      os.makedirs(outpath)
-    size = int(response.headers['Content-Length'])
-    size_read = 0
-    if not quiet:
-      print('Downloading ' + os.path.basename(outfile) + ' to ' + outpath)
-    with tqdm(
-        total=size, unit='B', unit_scale=True, unit_divisor=1024,
-        disable=quiet) as pbar:
-      with open(outfile, 'wb') as out:
-        while True:
-          data = response.read(chunk_size)
-          if not data:
-            break
-          out.write(data)
-          size_read = min(size, size_read + chunk_size)
-          pbar.update(len(data))
-      if not quiet:
-        print('\n', end='')
+        result = self.dataset_create_version(
+            folder,
+            version_notes,
+            quiet=quiet,
+            convert_to_csv=convert_to_csv,
+            delete_old_versions=delete_old_versions)
 
-  def download_needed(self, response, outfile, quiet=True):
-    try:
-      remote_date = datetime.strptime(response.headers['Last-Modified'],
-                                      '%a, %d %b %Y %X %Z')
-      if isfile(outfile):
-        local_date = datetime.fromtimestamp(os.path.getmtime(outfile))
-        if remote_date <= local_date:
-          if not quiet:
-            print(os.path.basename(outfile) +
-                  ': Skipping, found more recently modified local copy ' +
-                  '(use --force to force download)')
-          return False
-    except:
-      pass
-    return True
+        if result is None:
+            print('Dataset version creation error: See previous output')
 
-  def print_table(self, items, fields):
-    formats = []
-    borders = []
-    for f in fields:
-      length = max(
-          len(f), max([len(self.string(getattr(i, f))) for i in items]))
-      justify = '>' if isinstance(getattr(items[0], f),
-                                  int) or f == 'size' or f == 'reward' else '<'
-      formats.append('{:' + justify + self.string(length + 2) + '}')
-      borders.append('-' * length + '  ')
-    row_format = u''.join(formats)
-    headers = [f + '  ' for f in fields]
-    print(row_format.format(*headers))
-    print(row_format.format(*borders))
-    for i in items:
-      i_fields = [self.string(getattr(i, f)) + '  ' for f in fields]
-      print(row_format.format(*i_fields))
+        elif result.status == 'ok':
+            print('Dataset version is being created. Please check progress at ' +
+                  result.url)
 
-  def print_csv(self, items, fields):
-    writer = csv.writer(sys.stdout)
-    writer.writerow(fields)
-    for i in items:
-      i_fields = [self.string(getattr(i, f)) for f in fields]
-      writer.writerow(i_fields)
+            # We only might have invalid tags if the result isn't None
 
-  def string(self, item):
-    return item if isinstance(item, unicode) else str(item)
+            if result.invalidTags is not None:
+                print('The following are not valid tags and could not be added ' +
+                      ' to the dataset: ' + str(result.invalidTags))
 
-  def get_or_exit(self, data, key):
-    if key in data:
-      return data[key]
-    sys.exit('Key ' + key + ' not found in data')
+        # If result isn't None or status isn't ok, something else went wrong!
+        else:
+            print('Dataset version creation error: ' + result.error)
 
-  def get_or_default(self, data, key, default):
-    if key in data:
-      return data[key]
-    return default
 
-  def process_response(self, result):
-    if len(result) == 3:
-      data = result[0]
-      headers = result[2]
-      if self.HEADER_API_VERSION in headers:
-        api_version = headers[self.HEADER_API_VERSION]
-        if not self.already_printed_version_warning and self.__version__ < api_version:
-          print(
-              'Warning: Looks like you\'re using an outdated API Version, please consider updating (server '
-              + api_version + ' / client ' + self.__version__ + ')')
-          self.already_printed_version_warning = True
-      return data
-    return result
+    def dataset_initialize(self, folder, indent=1):
+        '''initialize a folder with a a dataset configuration (metadata) file
 
-  def upload_files(self, request, resources, folder, quiet):
-    for file_name in os.listdir(folder):
-      if file_name == self.METADATA_FILE:
-        continue
-      full_path = os.path.join(folder, file_name)
+            Parameters
+            ==========
+            folder: the folder to initialize the metadata file in
+        '''
 
-      if not quiet:
-        print('Starting upload for file ' + file_name)
-      if os.path.isfile(full_path):
-        content_length = os.path.getsize(full_path)
-        token = self.dataset_upload_file(full_path, quiet)
-        if token is None:
-          if not quiet:
-            print('Upload unsuccessful: ' + file_name)
-          return
+        if not os.path.isdir(folder):
+            sys.exit('Invalid folder: ' + folder)
+
+        ref = self.config_values[self.CONFIG_NAME_USER] + '/INSERT_SLUG_HERE'
+
+        meta_data = {'title': 'INSERT_TITLE_HERE', 
+                     'id': ref, 
+                     'licenses': [{'name': 'CC0-1.0'}]}
+
+        meta_file = os.path.join(folder, self.METADATA_FILE)
+        with open(meta_file, 'w') as f:
+            json.dump(meta_data, f, indent=indent)
+
+        print('Data package template written to: ' + meta_file)
+        return meta_file
+
+
+    def dataset_create_new(self,
+                           folder,
+                           public=False,
+                           quiet=False,
+                           convert_to_csv=True):
+        '''create a new dataset, meaning the same as creating a version but
+           with extra metadata like license and user/owner.
+
+           Parameters
+           ==========
+           folder: the folder to initialize the metadata file in
+           public: should the dataset be public?
+           convert_to_csv: if True, convert data to comma separated value
+
+        '''
+
+        meta_data = _dataset_prepare_create_request(folder)
+        license_name = self.get_or_exit(metadata['licenses'][0], 'name')
+
+        request = DatasetNewRequest(
+            title=meta_data.get('title'),
+            slug=meta_data['dataset_slug'],
+            owner_slug=meta_data['owner_slug'],
+            license_name=license_name,
+            subtitle=meta_data.get('subtitle'),
+            description=meta_data.get('description'),
+            files=[],
+            is_private=not public,
+            convert_to_csv=convert_to_csv,
+            category_ids=meta_data.get('keywords'))
+        resources = meta_data.get('resources')
+
+        # Do the upload, return the result
+        self.upload_files(request, resources, folder, quiet)
+        result = DatasetNewResponse(
+           self.process_response(self.datasets_create_new_with_http_info(request)))
+        return result
+
+    def dataset_create_new_cli(self,
+                               folder,
+                               public=False,
+                               quiet=False,
+                               convert_to_csv=True):
+        '''client wrapper for creating a new dataset
+
+           Parameters
+           ==========
+           folder: the folder to initialize the metadata file in
+           public: should the dataset be public?
+           convert_to_csv: if True, convert data to comma separated value
+
+        '''
+        # Convert to string to print to user
+
+        if public:
+            public = 'public'
+        else:
+            public = 'private'
+
+
+        result = self.dataset_create_new(folder, public, quiet, convert_to_csv)
+        if result.invalidTags is not None:
+            print('The following are not valid tags and could not be added ' +
+                  'to the dataset: ' + str(result.invalidTags))
+        if result.status == 'ok':
+            print('Your %s Dataset is being created. Please check ' % public
+                  + ' progress at ' + result.url)
+        else:
+            print('Dataset creation error: ' + result.error)
+
+
+## Download
+
+    def download_file(self, 
+                      response, 
+                      outfile, 
+                      quiet=True, 
+                      chunk_size=1048576):
+        '''download a file to an output file based on a chunk size
+ 
+           Parameters
+           ==========
+           response: the response to download
+           outfile: the output file to download to
+           chunk_size: the size of the chunk to strema
+
+        '''
+        outpath = os.path.dirname(outfile)
+        if not os.path.exists(outpath):
+            os.makedirs(outpath)
+
+        # Get the total size from the content length of the response
+        size = int(response.headers['Content-Length'])
+        size_read = 0
 
         if not quiet:
-          print('Upload successful: ' + file_name + ' (' +
-                File.get_size(content_length) + ')')
+            print('Downloading ' + os.path.basename(outfile) + ' to ' + outpath)
 
-        upload_file = DatasetUploadFile()
-        upload_file.token = token
-        if resources:
-          for item in resources:
-            if file_name == item.get('path'):
-              upload_file.description = item.get('description')
-              if 'schema' in item:
-                fields = self.get_or_default(item['schema'], 'fields', [])
-                processed = []
-                count = 0
-                for field in fields:
-                  processed.append(self.process_column(field))
-                  processed[count].order = count
-                  count += 1
-                upload_file.columns = processed
+        with tqdm(total=size, 
+                  unit='B', 
+                  unit_scale=True, 
+                  unit_divisor=1024,
+                  disable=quiet) as pbar:
 
-        request.files.append(upload_file)
-      else:
-        if not quiet:
-          print('Skipping: ' + file_name)
+            with open(outfile, 'wb') as out:
+                while True:
+                    data = response.read(chunk_size)
+                    if not data:
+                        break
+                    out.write(data)
+                    size_read = min(size, size_read + chunk_size)
+                    pbar.update(len(data))
 
-  def process_column(self, column):
-    processed_column = DatasetColumn(
-        name=self.get_or_exit(column, 'name'),
-        description=self.get_or_default(column, 'description', ''))
-    if 'type' in column:
-      original_type = column['type']
-      processed_column.original_type = original_type
-      if (original_type == 'string' or original_type == 'date' or
-          original_type == 'time' or original_type == 'yearmonth' or
-          original_type == 'duration' or original_type == 'geopoint' or
-          original_type == 'geojson'):
-        processed_column.type = 'string'
-      elif (original_type == 'numeric' or original_type == 'number' or
-            original_type == 'integer' or original_type == 'year'):
-        processed_column.type = 'numeric'
-      elif original_type == 'boolean':
-        processed_column.type = 'boolean'
-      elif original_type == 'datetime':
-        processed_column.type = 'datetime'
-      else:
-        processed_column.type = 'unknown'
-    return processed_column
+            if not quiet:
+                print('\n', end='')
 
-  def upload_complete(self, path, url, quiet):
-    file_size = os.path.getsize(path)
-    try:
-      with tqdm(
-          total=file_size,
-          unit='B',
-          unit_scale=True,
-          unit_divisor=1024,
-          disable=quiet) as progress_bar:
-        with open(path, 'rb', buffering=0) as fp:
-          reader = TqdmBufferedReader(fp, progress_bar)
-          session = requests.Session()
-          retries = Retry(total=10, backoff_factor=0.5)
-          adapter = HTTPAdapter(max_retries=retries)
-          session.mount('http://', adapter)
-          session.mount('https://', adapter)
-          response = session.put(url, data=reader)
-    except Exception as error:
-      print(error)
-      return False
-    return response.status_code == 200 or response.status_code == 201
+        # If we downloaded and have file, return it
+
+        if os.path.exists(outfile):
+            return outfile
+
+    def download_needed(self, 
+                        response, 
+                        outfile, 
+                        quiet=True):
+
+        '''determine if a download is needed based on timestamp. Return True
+           if needed (remote is newer) or False if local is newest.
+
+           Parameters
+           ==========
+           response: the response from the API
+           outfile: the output file to write to
+
+        '''
+        try:
+            remote_date = datetime.strptime(response.headers['Last-Modified'],
+                                            '%a, %d %b %Y %X %Z')
+            if isfile(outfile):
+                local_date = datetime.fromtimestamp(os.path.getmtime(outfile))
+
+                # The remote date is older, download not needed
+                if remote_date <= local_date:
+                    if not quiet:
+                        print(os.path.basename(outfile) +
+                              ': Skipping, found more recently modified local' +
+                              ' copy (use --force to force download)')
+                    return False
+        except:
+            pass
+        return True
+
+## Helpers
+
+    def string(self, item):
+        return item if isinstance(item, unicode) else str(item)
+
+    def get_or_exit(self, data, key):
+        if key in data:
+            return data[key]
+        sys.exit('Key ' + key + ' not found in data')
+
+    def get_or_default(self, data, key, default):
+        if key in data:
+            return data[key]
+        return default
+
+    def process_response(self, result):
+        '''process a response from the API. We check the API version against
+           the client's to see if it's old, and give them a warning (once)
+  
+           Parameters
+           ==========
+           result: the result from the API
+        '''
+        if len(result) == 3:
+            data = result[0]
+            headers = result[2]
+            if self.HEADER_API_VERSION in headers:
+                api_version = headers[self.HEADER_API_VERSION]
+                older = self.__version__ < api_version
+                if not self.already_printed_version_warning and older:
+                    print('Warning: Looks like you\'re using an outdated API ' +
+                          'Version, please consider updating (server ' + 
+                           api_version + ' / client ' + self.__version__ + ')')
+                    self.already_printed_version_warning = True
+            return data
+        return result
+
+    def upload_files(self,
+                     request, 
+                     resources, 
+                     folder, 
+                     quiet=False):
+        '''upload files in a folder
+
+           Parameters
+           ==========
+           request: the prepared request
+           resources: the files to upload
+           folder: the folder to upload from
+
+        '''
+
+        for file_name in os.listdir(folder):
+
+            # Skip the metadata file
+            if file_name == self.METADATA_FILE:
+                continue
+
+            full_path = os.path.join(folder, file_name)
+
+            if not quiet:
+                print('Starting upload for file ' + file_name)
+
+            # We can only upload with a token
+
+            if os.path.isfile(full_path):
+                content_length = os.path.getsize(full_path)
+                token = self.dataset_upload_file(full_path, quiet)
+                if token is None and not quiet:
+                    print('Upload unsuccessful: ' + file_name)
+                    return
+
+                if not quiet:
+                    print('Upload successful: ' + file_name + ' (' +
+                           File.get_size(content_length) + ')')
+
+                upload_file = DatasetUploadFile()
+                upload_file.token = token
+                if resources:
+                    for item in resources:
+                        if file_name == item.get('path'):
+                            upload_file.description = item.get('description')
+                            if 'schema' in item:
+                                fields = self.get_or_default(item['schema'], 
+                                                                  'fields', [])
+                                processed = []
+                                count = 0
+                                for field in fields:
+                                    processed.append(self.process_column(field))
+                                    processed[count].order = count
+                                    count += 1
+                                upload_file.columns = processed
+
+                request.files.append(upload_file)
+
+            # File doesn't exist!
+            else:
+                if not quiet:
+                    print('Skipping: ' + file_name)
+
+
+        # Return the request, with files added
+
+        return request
+
+
+    def process_column(self, column):
+        '''process a column, check for the type, and return the processed
+           column'''
+
+        processed_column = DatasetColumn(
+            name=self.get_or_exit(column, 'name'),
+            description=self.get_or_default(column, 'description', ''))
+
+        if 'type' in column:
+            original_type = column['type']
+            processed_column.original_type = original_type
+            if (original_type == 'string' or original_type == 'date' or
+                original_type == 'time' or original_type == 'yearmonth' or
+                original_type == 'duration' or original_type == 'geopoint' or
+                original_type == 'geojson'): 
+                processed_column.type = 'string'
+            elif (original_type == 'numeric' or original_type == 'number' or
+                  original_type == 'integer' or original_type == 'year'):
+                  processed_column.type = 'numeric'
+            elif original_type == 'boolean':
+                processed_column.type = 'boolean'
+            elif original_type == 'datetime':
+                processed_column.type = 'datetime'
+            else:
+                processed_column.type = 'unknown'
+        return processed_column
+
+    def upload_complete(self, path, url, quiet):
+        '''finish an upload, return False if an error, or True if status
+           is 200 or 201
+
+           Parameters
+           ==========
+           path: the path of the file uploaded (to get size)
+           url: the url to upload complete to
+        '''
+
+        file_size = os.path.getsize(path)
+        try:
+            with tqdm(total=file_size,
+                      unit='B',
+                      unit_scale=True,
+                      unit_divisor=1024,
+                      disable=quiet) as progress_bar:
+                with open(path, 'rb', buffering=0) as fp:
+                    reader = TqdmBufferedReader(fp, progress_bar)
+                    session = requests.Session()
+                    retries = Retry(total=10, backoff_factor=0.5)
+                    adapter = HTTPAdapter(max_retries=retries)
+                    session.mount('http://', adapter)
+                    session.mount('https://', adapter)
+                    response = session.put(url, data=reader)
+
+        except Exception as error:
+            print(error)
+            return False
+
+        return response.status_code == 200 or response.status_code == 201
+  
+
+## Printing
+
+    
+    def print_result(self, 
+                     listing, 
+                     fields, 
+                     name, 
+                     csv_display=False):
+
+        '''a wrapper to self.print_csv and self.print_table.
+           
+           Parameters
+           ==========
+           listing: the result listing to print
+           fields: a list of fields to print
+           name: the name to "pretty print" as a notification to the user
+           csv_display: If True, print comma separated values
+
+        '''
+        if listing:
+            if csv_display:
+                self.print_csv(listing, fields)
+            else:
+                self.print_table(listing, fields)
+        else:
+            print('No %s found' % name)
+
+
+    def print_table(self, items, fields):
+        '''print a table of items, for a set of fields defined
+   
+           Parameters
+           ==========
+           items: a list of items to print
+           fields: a list of fields to select from items
+
+        '''
+        formats = []
+        borders = []
+
+        # Define formats and borders for table
+
+        for f in fields:
+            length = max(
+                len(f), max([len(self.string(getattr(i, f))) for i in items]))
+
+            justify = '<'
+            if isinstance(getattr(items[0], f)) or f == 'size' or f == 'reward':
+                justify = '>'
+
+            formats.append('{:' + justify + self.string(length + 2) + '}')
+            borders.append('-' * length + '  ')
+
+        row_format = u''.join(formats)
+        headers = [f + '  ' for f in fields]
+
+        # Print the header and table borders
+
+        print(row_format.format(*headers))
+        print(row_format.format(*borders))
+
+        # Print the items
+
+        for i in items:
+            i_fields = [self.string(getattr(i, f)) + '  ' for f in fields]
+            print(row_format.format(*i_fields))
+
+
+    def print_csv(self, items, fields):
+        '''print a set of fields in a set of items using a csv.writer
+
+           Parameters
+           ==========
+           items: a list of items to print
+           fields: a list of fields to select from items
+        ''' 
+        writer = csv.writer(sys.stdout)
+        writer.writerow(fields)
+        for i in items:
+            i_fields = [self.string(getattr(i, f)) for f in fields]
+            writer.writerow(i_fields)
 
 
 class TqdmBufferedReader(io.BufferedReader):

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -376,7 +376,7 @@ class KaggleApi(KaggleApi):
         self.print_result(competitions, fields, 'competitions', csv_display)
 
 
-    def _competition_get_or_exit(self, competition):
+    def _competition_get_or_exit(self, competition, quiet=False):
         '''if a competition is None, look for the name in the config values.
            If it's still None, exit.
 
@@ -492,7 +492,7 @@ class KaggleApi(KaggleApi):
            
         '''
  
-        competition = self._competition_get_or_exit(competition)
+        competition = self._competition_get_or_exit(competition, quiet=quiet)
 
         submissions = self.competition_submissions(competition)
         fields = [ 'fileName', 
@@ -533,7 +533,7 @@ class KaggleApi(KaggleApi):
            csv_display: if True, print comma separated values
         '''
 
-        competition = self._competition_get_or_exit(competition)
+        competition = self._competition_get_or_exit(competition, quiet=quiet)
 
         files = self.competition_list_files(competition)
         fields = ['name', 'size', 'creationDate']
@@ -585,7 +585,7 @@ class KaggleApi(KaggleApi):
            path: a path to download the file to
 
         '''
-        competition = self._competition_get_or_exit(competition)
+        competition = self._competition_get_or_exit(competition, quiet=quiet)
 
         if file_name is None:
             self.competition_download_files(competition, path, force, quiet)
@@ -716,7 +716,7 @@ class KaggleApi(KaggleApi):
         if not view and not download:
             sys.exit('Either --show or --download must be specified')
 
-        competition = self._competition_get_or_exit(competition)
+        competition = self._competition_get_or_exit(competition, quiet=quiet)
 
         if download is True:
             self.competition_leaderboard_download(competition, path, quiet)
@@ -863,7 +863,8 @@ class KaggleApi(KaggleApi):
      
         '''
 
-        owner_slug, dataset_slug = self._dataset_get_or_exit(dataset)
+        owner_slug, dataset_slug = self._dataset_get_or_exit(dataset, 
+                                                             quiet=quiet)
 
         # Get the effective path for the dataset
 
@@ -903,7 +904,8 @@ class KaggleApi(KaggleApi):
          
         '''
 
-        owner_slug, dataset_slug = self._dataset_get_or_exit(dataset)
+        owner_slug, dataset_slug = self._dataset_get_or_exit(dataset,
+                                                             quiet=quiet)
 
         subfolders = ['datasets', owner_slug, dataset_slug]
         effective_path = self._get_download_path(path, subfolders)
@@ -1484,13 +1486,11 @@ class KaggleApi(KaggleApi):
         for f in fields:
             length = max(
                 len(f), max([len(self.string(getattr(i, f))) for i in items]))
-
-            justify = '<'
-            if isinstance(getattr(items[0], f)) or f == 'size' or f == 'reward':
-                justify = '>'
-
+            justify = '>' if isinstance(getattr(items[0], f),
+                                  int) or f == 'size' or f == 'reward' else '<'
             formats.append('{:' + justify + self.string(length + 2) + '}')
             borders.append('-' * length + '  ')
+
 
         row_format = u''.join(formats)
         headers = [f + '  ' for f in fields]

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -79,10 +79,26 @@ class KaggleApi(KaggleApi):
     reload(sys)
     sys.setdefaultencoding('latin1')
 
+  def _authenticate_environment(self):
+      '''autheticate environment is the first effort to get a username
+         and key to authenticate to the Kaggle API.
+      '''
+      username = os.environ.get('KAGGLE_USERNAME')
+      key = os.environ.get('KAGGLE_KEY')
+      if None not in [key, username]:
+
+
   def authenticate(self):
     try:
       configuration = Configuration()
-      if os.name != 'nt':
+
+      # Option 1:, get configuration values from environment
+      # STOPPED HERE - break into functions...
+      
+
+      # Option 2: read in configuration file
+
+      elif os.name != 'nt':
         permissions = os.stat(self.config).st_mode
         if (permissions & 4) or (permissions & 32):
           print('Warning: Your Kaggle API key is readable by other users on ' +


### PR DESCRIPTION
This PR will address #30 by giving the user the option to export an environment variable instead of (or in addition to, overwriting) the default `$HOME/kaggle/kaggle.json`, closing #30. I'm not sure any testing / CI is in place, and I'd like to offer to start writing tests and add to test this PR, @rysteboe if you want to discuss where you would like them (and connect the webhook!). In addition, the PR contains the following changes:

## Commenting

I added a lot of comments, and adjusted the spacing to be 4. This obviously has no
functional change, but is mostly for programming dinosaurs like me that need
a little more verbosity and space to better read the code.

## Environment Loading
This is the main reason for the PR (initially) and it will close #30. 
There was an issue to load configuration values from the environment, so this 
is now done, with first read (and second preference) going to a config file, and
then to the environment (first preference since it overrides the config). 
This would mean that a user **doesn't** need to have a
config file, but if there is no config or environment, we of course exit with error 
(the username/password is minimally required!). It also means that if a user wants 
to temporarily tweak something (but not change the config file) the environment
export will take preference, and this is easy to do. For the variable names, 
I decided to have them be the same as the client defaults (e.g., if
`self.CONFIG_NAME_USER` == "user" then the environment variable would be the
uppercase of that prefixed with `KAGGLE_` --> `export KAGGLE_USER=potatoman`. The prefix
`KAGGLE_ `is added simply to maintain a separate namespace, and all caps is just
a convention.

## Consolidated Functions
I noticed some operations that were done a few times, and consolidated to new
functions, and this is useful so if we make a change to the operation, we only
need to do it in one place! 

### Print Results
The first is for printing. Instead of having this repeated in the function
to list files, competitions, submissions:

```python
        if listing:
            if csv_display:
                self.print_csv(listing, fields)
            else:
                self.print_table(listing, fields)
        else:
            print('No %s found' % name)
```

It's called as a function, for example:

```python
self.print_result(files, fields, 'files', csv_display)
```

### Get Competition (or Exit)
The second thing that was done a few times was checking if a competition came in 
as None, if it didn't getting it from the config, and then exiting if it still wasn't
defined. That's now called like this:

```python
competition = self._competition_get_or_exit(competition)
```

### Download Path
This was another operation done a few times, reduced to a function that is shared.

```python
effective_path = _get_download_path(path, competition)
```
## Prepare Dataset Request
the function to create a dataset and create a dataset version had a lot of overlap, so there is a new function for that:

```python
request= _dataset_prepare_create_request(folder)
```

## Questions
I have a few more questions I'd like to discuss with the developer team, some ideas, and
some of these "I want to double check to make sure I didn't break something :) "

 - Testing! omg, we need testing. There is no way this is perfect and ready to go!
 - What's the difference between the kaggle_api.py and kaggle_api_extended.py?  The first looks like it was generated by swagger? I've used that in the past and usually wound up having preference for not using the auto-generation tool, but I'm not sure if we are using it here.
 - For the config copying, for the function that removed a config value, it set it to None instead of just using `del` on the dictionary. I wrote this function to use del instead (so the key is no longer in the dictionary). Will this muck something up?
 - Should we add a logger proper, instead of using `if quiet==True?` We could then add different levels of logging. I can offer to do this.
 - Is there any reason to put all the functions in one file? I definitely like the realization that we don't need to do extra imports, but I'm not sure if there is another way to organize so it's easier to find things (I added comment headers to help).

Looking forward to discussion! @rysteboe I know you were on vacation so definitely no rush to look here! I'll take a look at some of the other issues and see if they are easy to grab, and when you get a chance and we can discuss, I can definitely start on some tests (but I suspect we will need either to put an encrypted token in the CI environment or have a dummy one with limited permissions just for it)