### PR TITLE
Fix async incompatibility with Python 3.7.0

### DIFF
--- a/kaggle/api/kaggle_api.py
+++ b/kaggle/api/kaggle_api.py
@@ -53,18 +53,18 @@ class KaggleApi(object):
         """Download competition leaderboard  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.competition_download_leaderboard(id, async=True)
+        _asynchronous HTTP request, please pass _async=True
+        >>> thread = api.competition_download_leaderboard(id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str id: Competition name (required)
         :return: Result
-                 If the method is called asynchronously,
+                 If the method is called _asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.competition_download_leaderboard_with_http_info(id, **kwargs)  # noqa: E501
         else:
             (data) = self.competition_download_leaderboard_with_http_info(id, **kwargs)  # noqa: E501
@@ -74,19 +74,19 @@ class KaggleApi(object):
         """Download competition leaderboard  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.competition_download_leaderboard_with_http_info(id, async=True)
+        _asynchronous HTTP request, please pass _async=True
+        >>> thread = api.competition_download_leaderboard_with_http_info(id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str id: Competition name (required)
         :return: Result
-                 If the method is called asynchronously,
+                 If the method is called _asynchronously,
                  returns the request thread.
         """
 
         all_params = ['id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -132,7 +132,7 @@ class KaggleApi(object):
             files=local_var_files,
             response_type='Result',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -142,18 +142,18 @@ class KaggleApi(object):
         """VIew competition leaderboard  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.competition_view_leaderboard(id, async=True)
+        _asynchronous HTTP request, please pass _async=True
+        >>> thread = api.competition_view_leaderboard(id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str id: Competition name (required)
         :return: Result
-                 If the method is called asynchronously,
+                 If the method is called _asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.competition_view_leaderboard_with_http_info(id, **kwargs)  # noqa: E501
         else:
             (data) = self.competition_view_leaderboard_with_http_info(id, **kwargs)  # noqa: E501
@@ -163,19 +163,19 @@ class KaggleApi(object):
         """VIew competition leaderboard  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.competition_view_leaderboard_with_http_info(id, async=True)
+        _asynchronous HTTP request, please pass _async=True
+        >>> thread = api.competition_view_leaderboard_with_http_info(id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str id: Competition name (required)
         :return: Result
-                 If the method is called asynchronously,
+                 If the method is called _asynchronously,
                  returns the request thread.
         """
 
         all_params = ['id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -221,7 +221,7 @@ class KaggleApi(object):
             files=local_var_files,
             response_type='Result',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -231,19 +231,19 @@ class KaggleApi(object):
         """Download competition data file  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.competitions_data_download_file(id, file_name, async=True)
+        _asynchronous HTTP request, please pass _async=True
+        >>> thread = api.competitions_data_download_file(id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str id: Competition name (required)
         :param str file_name: Competition name (required)
         :return: Result
-                 If the method is called asynchronously,
+                 If the method is called _asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.competitions_data_download_file_with_http_info(id, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.competitions_data_download_file_with_http_info(id, file_name, **kwargs)  # noqa: E501
@@ -253,20 +253,20 @@ class KaggleApi(object):
         """Download competition data file  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.competitions_data_download_file_with_http_info(id, file_name, async=True)
+        _asynchronous HTTP request, please pass _async=True
+        >>> thread = api.competitions_data_download_file_with_http_info(id, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str id: Competition name (required)
         :param str file_name: Competition name (required)
         :return: Result
-                 If the method is called asynchronously,
+                 If the method is called _asynchronously,
                  returns the request thread.
         """
 
         all_params = ['id', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -318,7 +318,7 @@ class KaggleApi(object):
             files=local_var_files,
             response_type='Result',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -328,18 +328,18 @@ class KaggleApi(object):
         """List competition data files  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.competitions_data_list_files(id, async=True)
+        _asynchronous HTTP request, please pass _async=True
+        >>> thread = api.competitions_data_list_files(id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str id: Competition name (required)
         :return: Result
-                 If the method is called asynchronously,
+                 If the method is called _asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.competitions_data_list_files_with_http_info(id, **kwargs)  # noqa: E501
         else:
             (data) = self.competitions_data_list_files_with_http_info(id, **kwargs)  # noqa: E501
@@ -349,19 +349,19 @@ class KaggleApi(object):
         """List competition data files  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.competitions_data_list_files_with_http_info(id, async=True)
+        _asynchronous HTTP request, please pass _async=True
+        >>> thread = api.competitions_data_list_files_with_http_info(id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str id: Competition name (required)
         :return: Result
-                 If the method is called asynchronously,
+                 If the method is called _asynchronously,
                  returns the request thread.
         """
 
         all_params = ['id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -411,7 +411,7 @@ class KaggleApi(object):
             files=local_var_files,
             response_type='Result',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -421,19 +421,19 @@ class KaggleApi(object):
         """List competitions  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.competitions_list(async=True)
+        _asynchronous HTTP request, please pass _async=True
+        >>> thread = api.competitions_list(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int page: Page number
         :param str search: Search terms
         :return: Result
-                 If the method is called asynchronously,
+                 If the method is called _asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.competitions_list_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.competitions_list_with_http_info(**kwargs)  # noqa: E501
@@ -443,20 +443,20 @@ class KaggleApi(object):
         """List competitions  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.competitions_list_with_http_info(async=True)
+        _asynchronous HTTP request, please pass _async=True
+        >>> thread = api.competitions_list_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int page: Page number
         :param str search: Search terms
         :return: Result
-                 If the method is called asynchronously,
+                 If the method is called _asynchronously,
                  returns the request thread.
         """
 
         all_params = ['page', 'search']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -504,7 +504,7 @@ class KaggleApi(object):
             files=local_var_files,
             response_type='Result',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -514,19 +514,19 @@ class KaggleApi(object):
         """List competition submissions  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.competitions_submissions_list(id, async=True)
+        _asynchronous HTTP request, please pass _async=True
+        >>> thread = api.competitions_submissions_list(id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str id: Competition name (required)
         :param int page: Page number
         :return: Result
-                 If the method is called asynchronously,
+                 If the method is called _asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.competitions_submissions_list_with_http_info(id, **kwargs)  # noqa: E501
         else:
             (data) = self.competitions_submissions_list_with_http_info(id, **kwargs)  # noqa: E501
@@ -536,20 +536,20 @@ class KaggleApi(object):
         """List competition submissions  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.competitions_submissions_list_with_http_info(id, async=True)
+        _asynchronous HTTP request, please pass _async=True
+        >>> thread = api.competitions_submissions_list_with_http_info(id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str id: Competition name (required)
         :param int page: Page number
         :return: Result
-                 If the method is called asynchronously,
+                 If the method is called _asynchronously,
                  returns the request thread.
         """
 
         all_params = ['id', 'page']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -601,7 +601,7 @@ class KaggleApi(object):
             files=local_var_files,
             response_type='Result',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -611,20 +611,20 @@ class KaggleApi(object):
         """Submit to competition  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.competitions_submissions_submit(blob_file_tokens, submission_description, id, async=True)
+        _asynchronous HTTP request, please pass _async=True
+        >>> thread = api.competitions_submissions_submit(blob_file_tokens, submission_description, id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str blob_file_tokens: Token identifying location of uploaded submission file (required)
         :param str submission_description: Description of competition submission (required)
         :param str id: Competition name (required)
         :return: Result
-                 If the method is called asynchronously,
+                 If the method is called _asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.competitions_submissions_submit_with_http_info(blob_file_tokens, submission_description, id, **kwargs)  # noqa: E501
         else:
             (data) = self.competitions_submissions_submit_with_http_info(blob_file_tokens, submission_description, id, **kwargs)  # noqa: E501
@@ -634,21 +634,21 @@ class KaggleApi(object):
         """Submit to competition  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.competitions_submissions_submit_with_http_info(blob_file_tokens, submission_description, id, async=True)
+        _asynchronous HTTP request, please pass _async=True
+        >>> thread = api.competitions_submissions_submit_with_http_info(blob_file_tokens, submission_description, id, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str blob_file_tokens: Token identifying location of uploaded submission file (required)
         :param str submission_description: Description of competition submission (required)
         :param str id: Competition name (required)
         :return: Result
-                 If the method is called asynchronously,
+                 If the method is called _asynchronously,
                  returns the request thread.
         """
 
         all_params = ['blob_file_tokens', 'submission_description', 'id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -714,7 +714,7 @@ class KaggleApi(object):
             files=local_var_files,
             response_type='Result',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -724,21 +724,21 @@ class KaggleApi(object):
         """Upload competition submission file  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.competitions_submissions_upload(file, guid, content_length, last_modified_date_utc, async=True)
+        _asynchronous HTTP request, please pass _async=True
+        >>> thread = api.competitions_submissions_upload(file, guid, content_length, last_modified_date_utc, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param file file: Competition submission file (required)
         :param str guid: Location where submission should be uploaded (required)
         :param int content_length: Content length of file in bytes (required)
         :param int last_modified_date_utc: Last modified date of file in milliseconds since epoch in UTC (required)
         :return: Result
-                 If the method is called asynchronously,
+                 If the method is called _asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.competitions_submissions_upload_with_http_info(file, guid, content_length, last_modified_date_utc, **kwargs)  # noqa: E501
         else:
             (data) = self.competitions_submissions_upload_with_http_info(file, guid, content_length, last_modified_date_utc, **kwargs)  # noqa: E501
@@ -748,22 +748,22 @@ class KaggleApi(object):
         """Upload competition submission file  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.competitions_submissions_upload_with_http_info(file, guid, content_length, last_modified_date_utc, async=True)
+        _asynchronous HTTP request, please pass _async=True
+        >>> thread = api.competitions_submissions_upload_with_http_info(file, guid, content_length, last_modified_date_utc, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param file file: Competition submission file (required)
         :param str guid: Location where submission should be uploaded (required)
         :param int content_length: Content length of file in bytes (required)
         :param int last_modified_date_utc: Last modified date of file in milliseconds since epoch in UTC (required)
         :return: Result
-                 If the method is called asynchronously,
+                 If the method is called _asynchronously,
                  returns the request thread.
         """
 
         all_params = ['file', 'guid', 'content_length', 'last_modified_date_utc']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -835,7 +835,7 @@ class KaggleApi(object):
             files=local_var_files,
             response_type='Result',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -845,20 +845,20 @@ class KaggleApi(object):
         """Generate competition submission URL  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.competitions_submissions_url(content_length, last_modified_date_utc, async=True)
+        _asynchronous HTTP request, please pass _async=True
+        >>> thread = api.competitions_submissions_url(content_length, last_modified_date_utc, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int content_length: Content length of file in bytes (required)
         :param int last_modified_date_utc: Last modified date of file in milliseconds since epoch in UTC (required)
         :param str file_name: Competition submission file name
         :return: Result
-                 If the method is called asynchronously,
+                 If the method is called _asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.competitions_submissions_url_with_http_info(content_length, last_modified_date_utc, **kwargs)  # noqa: E501
         else:
             (data) = self.competitions_submissions_url_with_http_info(content_length, last_modified_date_utc, **kwargs)  # noqa: E501
@@ -868,21 +868,21 @@ class KaggleApi(object):
         """Generate competition submission URL  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.competitions_submissions_url_with_http_info(content_length, last_modified_date_utc, async=True)
+        _asynchronous HTTP request, please pass _async=True
+        >>> thread = api.competitions_submissions_url_with_http_info(content_length, last_modified_date_utc, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int content_length: Content length of file in bytes (required)
         :param int last_modified_date_utc: Last modified date of file in milliseconds since epoch in UTC (required)
         :param str file_name: Competition submission file name
         :return: Result
-                 If the method is called asynchronously,
+                 If the method is called _asynchronously,
                  returns the request thread.
         """
 
         all_params = ['content_length', 'last_modified_date_utc', 'file_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -944,7 +944,7 @@ class KaggleApi(object):
             files=local_var_files,
             response_type='Result',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -954,18 +954,18 @@ class KaggleApi(object):
         """Create a new dataset  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.datasets_create_new(dataset_new_request, async=True)
+        _asynchronous HTTP request, please pass _async=True
+        >>> thread = api.datasets_create_new(dataset_new_request, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param DatasetNewRequest dataset_new_request: Information for creating a new dataset (required)
         :return: Result
-                 If the method is called asynchronously,
+                 If the method is called _asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.datasets_create_new_with_http_info(dataset_new_request, **kwargs)  # noqa: E501
         else:
             (data) = self.datasets_create_new_with_http_info(dataset_new_request, **kwargs)  # noqa: E501
@@ -975,19 +975,19 @@ class KaggleApi(object):
         """Create a new dataset  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.datasets_create_new_with_http_info(dataset_new_request, async=True)
+        _asynchronous HTTP request, please pass _async=True
+        >>> thread = api.datasets_create_new_with_http_info(dataset_new_request, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param DatasetNewRequest dataset_new_request: Information for creating a new dataset (required)
         :return: Result
-                 If the method is called asynchronously,
+                 If the method is called _asynchronously,
                  returns the request thread.
         """
 
         all_params = ['dataset_new_request']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1041,7 +1041,7 @@ class KaggleApi(object):
             files=local_var_files,
             response_type='Result',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1051,20 +1051,20 @@ class KaggleApi(object):
         """Create a new dataset version  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.datasets_create_version(owner_slug, dataset_slug, dataset_new_version_request, async=True)
+        _asynchronous HTTP request, please pass _async=True
+        >>> thread = api.datasets_create_version(owner_slug, dataset_slug, dataset_new_version_request, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str owner_slug: Dataset owner (required)
         :param str dataset_slug: Dataset name (required)
         :param DatasetNewVersionRequest dataset_new_version_request: Information for creating a new dataset version (required)
         :return: Result
-                 If the method is called asynchronously,
+                 If the method is called _asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.datasets_create_version_with_http_info(owner_slug, dataset_slug, dataset_new_version_request, **kwargs)  # noqa: E501
         else:
             (data) = self.datasets_create_version_with_http_info(owner_slug, dataset_slug, dataset_new_version_request, **kwargs)  # noqa: E501
@@ -1074,21 +1074,21 @@ class KaggleApi(object):
         """Create a new dataset version  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.datasets_create_version_with_http_info(owner_slug, dataset_slug, dataset_new_version_request, async=True)
+        _asynchronous HTTP request, please pass _async=True
+        >>> thread = api.datasets_create_version_with_http_info(owner_slug, dataset_slug, dataset_new_version_request, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str owner_slug: Dataset owner (required)
         :param str dataset_slug: Dataset name (required)
         :param DatasetNewVersionRequest dataset_new_version_request: Information for creating a new dataset version (required)
         :return: Result
-                 If the method is called asynchronously,
+                 If the method is called _asynchronously,
                  returns the request thread.
         """
 
         all_params = ['owner_slug', 'dataset_slug', 'dataset_new_version_request']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1154,7 +1154,7 @@ class KaggleApi(object):
             files=local_var_files,
             response_type='Result',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1164,21 +1164,21 @@ class KaggleApi(object):
         """Download dataset file  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.datasets_download_file(owner_slug, dataset_slug, file_name, async=True)
+        _asynchronous HTTP request, please pass _async=True
+        >>> thread = api.datasets_download_file(owner_slug, dataset_slug, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str owner_slug: Dataset owner (required)
         :param str dataset_slug: Dataset name (required)
         :param str file_name: File name (required)
         :param str dataset_version_number: Dataset version number
         :return: Result
-                 If the method is called asynchronously,
+                 If the method is called _asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.datasets_download_file_with_http_info(owner_slug, dataset_slug, file_name, **kwargs)  # noqa: E501
         else:
             (data) = self.datasets_download_file_with_http_info(owner_slug, dataset_slug, file_name, **kwargs)  # noqa: E501
@@ -1188,22 +1188,22 @@ class KaggleApi(object):
         """Download dataset file  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.datasets_download_file_with_http_info(owner_slug, dataset_slug, file_name, async=True)
+        _asynchronous HTTP request, please pass _async=True
+        >>> thread = api.datasets_download_file_with_http_info(owner_slug, dataset_slug, file_name, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str owner_slug: Dataset owner (required)
         :param str dataset_slug: Dataset name (required)
         :param str file_name: File name (required)
         :param str dataset_version_number: Dataset version number
         :return: Result
-                 If the method is called asynchronously,
+                 If the method is called _asynchronously,
                  returns the request thread.
         """
 
         all_params = ['owner_slug', 'dataset_slug', 'file_name', 'dataset_version_number']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1267,7 +1267,7 @@ class KaggleApi(object):
             files=local_var_files,
             response_type='Result',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1277,19 +1277,19 @@ class KaggleApi(object):
         """List datasets  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.datasets_list(async=True)
+        _asynchronous HTTP request, please pass _async=True
+        >>> thread = api.datasets_list(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int page: Page number
         :param str search: Search terms
         :return: Result
-                 If the method is called asynchronously,
+                 If the method is called _asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.datasets_list_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.datasets_list_with_http_info(**kwargs)  # noqa: E501
@@ -1299,20 +1299,20 @@ class KaggleApi(object):
         """List datasets  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.datasets_list_with_http_info(async=True)
+        _asynchronous HTTP request, please pass _async=True
+        >>> thread = api.datasets_list_with_http_info(_async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param int page: Page number
         :param str search: Search terms
         :return: Result
-                 If the method is called asynchronously,
+                 If the method is called _asynchronously,
                  returns the request thread.
         """
 
         all_params = ['page', 'search']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1360,7 +1360,7 @@ class KaggleApi(object):
             files=local_var_files,
             response_type='Result',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1370,19 +1370,19 @@ class KaggleApi(object):
         """List dataset files  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.datasets_list_files(owner_slug, dataset_slug, async=True)
+        _asynchronous HTTP request, please pass _async=True
+        >>> thread = api.datasets_list_files(owner_slug, dataset_slug, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str owner_slug: Dataset owner (required)
         :param str dataset_slug: Dataset name (required)
         :return: Result
-                 If the method is called asynchronously,
+                 If the method is called _asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.datasets_list_files_with_http_info(owner_slug, dataset_slug, **kwargs)  # noqa: E501
         else:
             (data) = self.datasets_list_files_with_http_info(owner_slug, dataset_slug, **kwargs)  # noqa: E501
@@ -1392,20 +1392,20 @@ class KaggleApi(object):
         """List dataset files  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.datasets_list_files_with_http_info(owner_slug, dataset_slug, async=True)
+        _asynchronous HTTP request, please pass _async=True
+        >>> thread = api.datasets_list_files_with_http_info(owner_slug, dataset_slug, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str owner_slug: Dataset owner (required)
         :param str dataset_slug: Dataset name (required)
         :return: Result
-                 If the method is called asynchronously,
+                 If the method is called _asynchronously,
                  returns the request thread.
         """
 
         all_params = ['owner_slug', 'dataset_slug']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1461,7 +1461,7 @@ class KaggleApi(object):
             files=local_var_files,
             response_type='Result',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1471,20 +1471,20 @@ class KaggleApi(object):
         """Get URL and token to start uploading a data file  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.datasets_upload_file(file_name, content_length, last_modified_date_utc, async=True)
+        _asynchronous HTTP request, please pass _async=True
+        >>> thread = api.datasets_upload_file(file_name, content_length, last_modified_date_utc, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str file_name: Dataset file name (required)
         :param int content_length: Content length of file in bytes (required)
         :param int last_modified_date_utc: Last modified date of file in milliseconds since epoch in UTC (required)
         :return: Result
-                 If the method is called asynchronously,
+                 If the method is called _asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.datasets_upload_file_with_http_info(file_name, content_length, last_modified_date_utc, **kwargs)  # noqa: E501
         else:
             (data) = self.datasets_upload_file_with_http_info(file_name, content_length, last_modified_date_utc, **kwargs)  # noqa: E501
@@ -1494,21 +1494,21 @@ class KaggleApi(object):
         """Get URL and token to start uploading a data file  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.datasets_upload_file_with_http_info(file_name, content_length, last_modified_date_utc, async=True)
+        _asynchronous HTTP request, please pass _async=True
+        >>> thread = api.datasets_upload_file_with_http_info(file_name, content_length, last_modified_date_utc, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str file_name: Dataset file name (required)
         :param int content_length: Content length of file in bytes (required)
         :param int last_modified_date_utc: Last modified date of file in milliseconds since epoch in UTC (required)
         :return: Result
-                 If the method is called asynchronously,
+                 If the method is called _asynchronously,
                  returns the request thread.
         """
 
         all_params = ['file_name', 'content_length', 'last_modified_date_utc']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1574,7 +1574,7 @@ class KaggleApi(object):
             files=local_var_files,
             response_type='Result',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1584,19 +1584,19 @@ class KaggleApi(object):
         """Show details about a dataset  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.datasets_view(owner_slug, dataset_slug, async=True)
+        _asynchronous HTTP request, please pass _async=True
+        >>> thread = api.datasets_view(owner_slug, dataset_slug, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str owner_slug: Dataset owner (required)
         :param str dataset_slug: Dataset name (required)
         :return: Result
-                 If the method is called asynchronously,
+                 If the method is called _asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('_async'):
             return self.datasets_view_with_http_info(owner_slug, dataset_slug, **kwargs)  # noqa: E501
         else:
             (data) = self.datasets_view_with_http_info(owner_slug, dataset_slug, **kwargs)  # noqa: E501
@@ -1606,20 +1606,20 @@ class KaggleApi(object):
         """Show details about a dataset  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.datasets_view_with_http_info(owner_slug, dataset_slug, async=True)
+        _asynchronous HTTP request, please pass _async=True
+        >>> thread = api.datasets_view_with_http_info(owner_slug, dataset_slug, _async=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param _async bool
         :param str owner_slug: Dataset owner (required)
         :param str dataset_slug: Dataset name (required)
         :return: Result
-                 If the method is called asynchronously,
+                 If the method is called _asynchronously,
                  returns the request thread.
         """
 
         all_params = ['owner_slug', 'dataset_slug']  # noqa: E501
-        all_params.append('async')
+        all_params.append('_async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1675,7 +1675,7 @@ class KaggleApi(object):
             files=local_var_files,
             response_type='Result',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            _async=params.get('_async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/kaggle/api/kaggle_api.py
+++ b/kaggle/api/kaggle_api.py
@@ -53,14 +53,14 @@ class KaggleApi(object):
         """Download competition leaderboard  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        _asynchronous HTTP request, please pass _async=True
+        asynchronous HTTP request, please pass _async=True
         >>> thread = api.competition_download_leaderboard(id, _async=True)
         >>> result = thread.get()
 
         :param _async bool
         :param str id: Competition name (required)
         :return: Result
-                 If the method is called _asynchronously,
+                 If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
@@ -74,14 +74,14 @@ class KaggleApi(object):
         """Download competition leaderboard  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        _asynchronous HTTP request, please pass _async=True
+        asynchronous HTTP request, please pass _async=True
         >>> thread = api.competition_download_leaderboard_with_http_info(id, _async=True)
         >>> result = thread.get()
 
         :param _async bool
         :param str id: Competition name (required)
         :return: Result
-                 If the method is called _asynchronously,
+                 If the method is called asynchronously,
                  returns the request thread.
         """
 
@@ -142,14 +142,14 @@ class KaggleApi(object):
         """VIew competition leaderboard  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        _asynchronous HTTP request, please pass _async=True
+        asynchronous HTTP request, please pass _async=True
         >>> thread = api.competition_view_leaderboard(id, _async=True)
         >>> result = thread.get()
 
         :param _async bool
         :param str id: Competition name (required)
         :return: Result
-                 If the method is called _asynchronously,
+                 If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
@@ -163,14 +163,14 @@ class KaggleApi(object):
         """VIew competition leaderboard  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        _asynchronous HTTP request, please pass _async=True
+        asynchronous HTTP request, please pass _async=True
         >>> thread = api.competition_view_leaderboard_with_http_info(id, _async=True)
         >>> result = thread.get()
 
         :param _async bool
         :param str id: Competition name (required)
         :return: Result
-                 If the method is called _asynchronously,
+                 If the method is called asynchronously,
                  returns the request thread.
         """
 
@@ -231,7 +231,7 @@ class KaggleApi(object):
         """Download competition data file  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        _asynchronous HTTP request, please pass _async=True
+        asynchronous HTTP request, please pass _async=True
         >>> thread = api.competitions_data_download_file(id, file_name, _async=True)
         >>> result = thread.get()
 
@@ -239,7 +239,7 @@ class KaggleApi(object):
         :param str id: Competition name (required)
         :param str file_name: Competition name (required)
         :return: Result
-                 If the method is called _asynchronously,
+                 If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
@@ -253,7 +253,7 @@ class KaggleApi(object):
         """Download competition data file  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        _asynchronous HTTP request, please pass _async=True
+        asynchronous HTTP request, please pass _async=True
         >>> thread = api.competitions_data_download_file_with_http_info(id, file_name, _async=True)
         >>> result = thread.get()
 
@@ -261,7 +261,7 @@ class KaggleApi(object):
         :param str id: Competition name (required)
         :param str file_name: Competition name (required)
         :return: Result
-                 If the method is called _asynchronously,
+                 If the method is called asynchronously,
                  returns the request thread.
         """
 
@@ -328,14 +328,14 @@ class KaggleApi(object):
         """List competition data files  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        _asynchronous HTTP request, please pass _async=True
+        asynchronous HTTP request, please pass _async=True
         >>> thread = api.competitions_data_list_files(id, _async=True)
         >>> result = thread.get()
 
         :param _async bool
         :param str id: Competition name (required)
         :return: Result
-                 If the method is called _asynchronously,
+                 If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
@@ -349,14 +349,14 @@ class KaggleApi(object):
         """List competition data files  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        _asynchronous HTTP request, please pass _async=True
+        asynchronous HTTP request, please pass _async=True
         >>> thread = api.competitions_data_list_files_with_http_info(id, _async=True)
         >>> result = thread.get()
 
         :param _async bool
         :param str id: Competition name (required)
         :return: Result
-                 If the method is called _asynchronously,
+                 If the method is called asynchronously,
                  returns the request thread.
         """
 
@@ -421,7 +421,7 @@ class KaggleApi(object):
         """List competitions  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        _asynchronous HTTP request, please pass _async=True
+        asynchronous HTTP request, please pass _async=True
         >>> thread = api.competitions_list(_async=True)
         >>> result = thread.get()
 
@@ -429,7 +429,7 @@ class KaggleApi(object):
         :param int page: Page number
         :param str search: Search terms
         :return: Result
-                 If the method is called _asynchronously,
+                 If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
@@ -443,7 +443,7 @@ class KaggleApi(object):
         """List competitions  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        _asynchronous HTTP request, please pass _async=True
+        asynchronous HTTP request, please pass _async=True
         >>> thread = api.competitions_list_with_http_info(_async=True)
         >>> result = thread.get()
 
@@ -451,7 +451,7 @@ class KaggleApi(object):
         :param int page: Page number
         :param str search: Search terms
         :return: Result
-                 If the method is called _asynchronously,
+                 If the method is called asynchronously,
                  returns the request thread.
         """
 
@@ -514,7 +514,7 @@ class KaggleApi(object):
         """List competition submissions  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        _asynchronous HTTP request, please pass _async=True
+        asynchronous HTTP request, please pass _async=True
         >>> thread = api.competitions_submissions_list(id, _async=True)
         >>> result = thread.get()
 
@@ -522,7 +522,7 @@ class KaggleApi(object):
         :param str id: Competition name (required)
         :param int page: Page number
         :return: Result
-                 If the method is called _asynchronously,
+                 If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
@@ -536,7 +536,7 @@ class KaggleApi(object):
         """List competition submissions  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        _asynchronous HTTP request, please pass _async=True
+        asynchronous HTTP request, please pass _async=True
         >>> thread = api.competitions_submissions_list_with_http_info(id, _async=True)
         >>> result = thread.get()
 
@@ -544,7 +544,7 @@ class KaggleApi(object):
         :param str id: Competition name (required)
         :param int page: Page number
         :return: Result
-                 If the method is called _asynchronously,
+                 If the method is called asynchronously,
                  returns the request thread.
         """
 
@@ -611,7 +611,7 @@ class KaggleApi(object):
         """Submit to competition  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        _asynchronous HTTP request, please pass _async=True
+        asynchronous HTTP request, please pass _async=True
         >>> thread = api.competitions_submissions_submit(blob_file_tokens, submission_description, id, _async=True)
         >>> result = thread.get()
 
@@ -620,7 +620,7 @@ class KaggleApi(object):
         :param str submission_description: Description of competition submission (required)
         :param str id: Competition name (required)
         :return: Result
-                 If the method is called _asynchronously,
+                 If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
@@ -634,7 +634,7 @@ class KaggleApi(object):
         """Submit to competition  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        _asynchronous HTTP request, please pass _async=True
+        asynchronous HTTP request, please pass _async=True
         >>> thread = api.competitions_submissions_submit_with_http_info(blob_file_tokens, submission_description, id, _async=True)
         >>> result = thread.get()
 
@@ -643,7 +643,7 @@ class KaggleApi(object):
         :param str submission_description: Description of competition submission (required)
         :param str id: Competition name (required)
         :return: Result
-                 If the method is called _asynchronously,
+                 If the method is called asynchronously,
                  returns the request thread.
         """
 
@@ -724,7 +724,7 @@ class KaggleApi(object):
         """Upload competition submission file  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        _asynchronous HTTP request, please pass _async=True
+        asynchronous HTTP request, please pass _async=True
         >>> thread = api.competitions_submissions_upload(file, guid, content_length, last_modified_date_utc, _async=True)
         >>> result = thread.get()
 
@@ -734,7 +734,7 @@ class KaggleApi(object):
         :param int content_length: Content length of file in bytes (required)
         :param int last_modified_date_utc: Last modified date of file in milliseconds since epoch in UTC (required)
         :return: Result
-                 If the method is called _asynchronously,
+                 If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
@@ -748,7 +748,7 @@ class KaggleApi(object):
         """Upload competition submission file  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        _asynchronous HTTP request, please pass _async=True
+        asynchronous HTTP request, please pass _async=True
         >>> thread = api.competitions_submissions_upload_with_http_info(file, guid, content_length, last_modified_date_utc, _async=True)
         >>> result = thread.get()
 
@@ -758,7 +758,7 @@ class KaggleApi(object):
         :param int content_length: Content length of file in bytes (required)
         :param int last_modified_date_utc: Last modified date of file in milliseconds since epoch in UTC (required)
         :return: Result
-                 If the method is called _asynchronously,
+                 If the method is called asynchronously,
                  returns the request thread.
         """
 
@@ -845,7 +845,7 @@ class KaggleApi(object):
         """Generate competition submission URL  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        _asynchronous HTTP request, please pass _async=True
+        asynchronous HTTP request, please pass _async=True
         >>> thread = api.competitions_submissions_url(content_length, last_modified_date_utc, _async=True)
         >>> result = thread.get()
 
@@ -854,7 +854,7 @@ class KaggleApi(object):
         :param int last_modified_date_utc: Last modified date of file in milliseconds since epoch in UTC (required)
         :param str file_name: Competition submission file name
         :return: Result
-                 If the method is called _asynchronously,
+                 If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
@@ -868,7 +868,7 @@ class KaggleApi(object):
         """Generate competition submission URL  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        _asynchronous HTTP request, please pass _async=True
+        asynchronous HTTP request, please pass _async=True
         >>> thread = api.competitions_submissions_url_with_http_info(content_length, last_modified_date_utc, _async=True)
         >>> result = thread.get()
 
@@ -877,7 +877,7 @@ class KaggleApi(object):
         :param int last_modified_date_utc: Last modified date of file in milliseconds since epoch in UTC (required)
         :param str file_name: Competition submission file name
         :return: Result
-                 If the method is called _asynchronously,
+                 If the method is called asynchronously,
                  returns the request thread.
         """
 
@@ -954,14 +954,14 @@ class KaggleApi(object):
         """Create a new dataset  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        _asynchronous HTTP request, please pass _async=True
+        asynchronous HTTP request, please pass _async=True
         >>> thread = api.datasets_create_new(dataset_new_request, _async=True)
         >>> result = thread.get()
 
         :param _async bool
         :param DatasetNewRequest dataset_new_request: Information for creating a new dataset (required)
         :return: Result
-                 If the method is called _asynchronously,
+                 If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
@@ -975,14 +975,14 @@ class KaggleApi(object):
         """Create a new dataset  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        _asynchronous HTTP request, please pass _async=True
+        asynchronous HTTP request, please pass _async=True
         >>> thread = api.datasets_create_new_with_http_info(dataset_new_request, _async=True)
         >>> result = thread.get()
 
         :param _async bool
         :param DatasetNewRequest dataset_new_request: Information for creating a new dataset (required)
         :return: Result
-                 If the method is called _asynchronously,
+                 If the method is called asynchronously,
                  returns the request thread.
         """
 
@@ -1051,7 +1051,7 @@ class KaggleApi(object):
         """Create a new dataset version  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        _asynchronous HTTP request, please pass _async=True
+        asynchronous HTTP request, please pass _async=True
         >>> thread = api.datasets_create_version(owner_slug, dataset_slug, dataset_new_version_request, _async=True)
         >>> result = thread.get()
 
@@ -1060,7 +1060,7 @@ class KaggleApi(object):
         :param str dataset_slug: Dataset name (required)
         :param DatasetNewVersionRequest dataset_new_version_request: Information for creating a new dataset version (required)
         :return: Result
-                 If the method is called _asynchronously,
+                 If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
@@ -1074,7 +1074,7 @@ class KaggleApi(object):
         """Create a new dataset version  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        _asynchronous HTTP request, please pass _async=True
+        asynchronous HTTP request, please pass _async=True
         >>> thread = api.datasets_create_version_with_http_info(owner_slug, dataset_slug, dataset_new_version_request, _async=True)
         >>> result = thread.get()
 
@@ -1083,7 +1083,7 @@ class KaggleApi(object):
         :param str dataset_slug: Dataset name (required)
         :param DatasetNewVersionRequest dataset_new_version_request: Information for creating a new dataset version (required)
         :return: Result
-                 If the method is called _asynchronously,
+                 If the method is called asynchronously,
                  returns the request thread.
         """
 
@@ -1164,7 +1164,7 @@ class KaggleApi(object):
         """Download dataset file  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        _asynchronous HTTP request, please pass _async=True
+        asynchronous HTTP request, please pass _async=True
         >>> thread = api.datasets_download_file(owner_slug, dataset_slug, file_name, _async=True)
         >>> result = thread.get()
 
@@ -1174,7 +1174,7 @@ class KaggleApi(object):
         :param str file_name: File name (required)
         :param str dataset_version_number: Dataset version number
         :return: Result
-                 If the method is called _asynchronously,
+                 If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
@@ -1188,7 +1188,7 @@ class KaggleApi(object):
         """Download dataset file  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        _asynchronous HTTP request, please pass _async=True
+        asynchronous HTTP request, please pass _async=True
         >>> thread = api.datasets_download_file_with_http_info(owner_slug, dataset_slug, file_name, _async=True)
         >>> result = thread.get()
 
@@ -1198,7 +1198,7 @@ class KaggleApi(object):
         :param str file_name: File name (required)
         :param str dataset_version_number: Dataset version number
         :return: Result
-                 If the method is called _asynchronously,
+                 If the method is called asynchronously,
                  returns the request thread.
         """
 
@@ -1277,7 +1277,7 @@ class KaggleApi(object):
         """List datasets  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        _asynchronous HTTP request, please pass _async=True
+        asynchronous HTTP request, please pass _async=True
         >>> thread = api.datasets_list(_async=True)
         >>> result = thread.get()
 
@@ -1285,7 +1285,7 @@ class KaggleApi(object):
         :param int page: Page number
         :param str search: Search terms
         :return: Result
-                 If the method is called _asynchronously,
+                 If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
@@ -1299,7 +1299,7 @@ class KaggleApi(object):
         """List datasets  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        _asynchronous HTTP request, please pass _async=True
+        asynchronous HTTP request, please pass _async=True
         >>> thread = api.datasets_list_with_http_info(_async=True)
         >>> result = thread.get()
 
@@ -1307,7 +1307,7 @@ class KaggleApi(object):
         :param int page: Page number
         :param str search: Search terms
         :return: Result
-                 If the method is called _asynchronously,
+                 If the method is called asynchronously,
                  returns the request thread.
         """
 
@@ -1370,7 +1370,7 @@ class KaggleApi(object):
         """List dataset files  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        _asynchronous HTTP request, please pass _async=True
+        asynchronous HTTP request, please pass _async=True
         >>> thread = api.datasets_list_files(owner_slug, dataset_slug, _async=True)
         >>> result = thread.get()
 
@@ -1378,7 +1378,7 @@ class KaggleApi(object):
         :param str owner_slug: Dataset owner (required)
         :param str dataset_slug: Dataset name (required)
         :return: Result
-                 If the method is called _asynchronously,
+                 If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
@@ -1392,7 +1392,7 @@ class KaggleApi(object):
         """List dataset files  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        _asynchronous HTTP request, please pass _async=True
+        asynchronous HTTP request, please pass _async=True
         >>> thread = api.datasets_list_files_with_http_info(owner_slug, dataset_slug, _async=True)
         >>> result = thread.get()
 
@@ -1400,7 +1400,7 @@ class KaggleApi(object):
         :param str owner_slug: Dataset owner (required)
         :param str dataset_slug: Dataset name (required)
         :return: Result
-                 If the method is called _asynchronously,
+                 If the method is called asynchronously,
                  returns the request thread.
         """
 
@@ -1471,7 +1471,7 @@ class KaggleApi(object):
         """Get URL and token to start uploading a data file  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        _asynchronous HTTP request, please pass _async=True
+        asynchronous HTTP request, please pass _async=True
         >>> thread = api.datasets_upload_file(file_name, content_length, last_modified_date_utc, _async=True)
         >>> result = thread.get()
 
@@ -1480,7 +1480,7 @@ class KaggleApi(object):
         :param int content_length: Content length of file in bytes (required)
         :param int last_modified_date_utc: Last modified date of file in milliseconds since epoch in UTC (required)
         :return: Result
-                 If the method is called _asynchronously,
+                 If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
@@ -1494,7 +1494,7 @@ class KaggleApi(object):
         """Get URL and token to start uploading a data file  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        _asynchronous HTTP request, please pass _async=True
+        asynchronous HTTP request, please pass _async=True
         >>> thread = api.datasets_upload_file_with_http_info(file_name, content_length, last_modified_date_utc, _async=True)
         >>> result = thread.get()
 
@@ -1503,7 +1503,7 @@ class KaggleApi(object):
         :param int content_length: Content length of file in bytes (required)
         :param int last_modified_date_utc: Last modified date of file in milliseconds since epoch in UTC (required)
         :return: Result
-                 If the method is called _asynchronously,
+                 If the method is called asynchronously,
                  returns the request thread.
         """
 
@@ -1584,7 +1584,7 @@ class KaggleApi(object):
         """Show details about a dataset  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        _asynchronous HTTP request, please pass _async=True
+        asynchronous HTTP request, please pass _async=True
         >>> thread = api.datasets_view(owner_slug, dataset_slug, _async=True)
         >>> result = thread.get()
 
@@ -1592,7 +1592,7 @@ class KaggleApi(object):
         :param str owner_slug: Dataset owner (required)
         :param str dataset_slug: Dataset name (required)
         :return: Result
-                 If the method is called _asynchronously,
+                 If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
@@ -1606,7 +1606,7 @@ class KaggleApi(object):
         """Show details about a dataset  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        _asynchronous HTTP request, please pass _async=True
+        asynchronous HTTP request, please pass _async=True
         >>> thread = api.datasets_view_with_http_info(owner_slug, dataset_slug, _async=True)
         >>> result = thread.get()
 
@@ -1614,7 +1614,7 @@ class KaggleApi(object):
         :param str owner_slug: Dataset owner (required)
         :param str dataset_slug: Dataset name (required)
         :return: Result
-                 If the method is called _asynchronously,
+                 If the method is called asynchronously,
                  returns the request thread.
         """
 

--- a/kaggle/api_client.py
+++ b/kaggle/api_client.py
@@ -306,7 +306,7 @@ class ApiClient(object):
         :param response: Response data type.
         :param files dict: key -> filename, value -> filepath,
             for `multipart/form-data`.
-        :param _async bool: execute request _asynchronously
+        :param _async bool: execute request asynchronously
         :param _return_http_data_only: response data without head status code
                                        and headers
         :param collection_formats: dict of collection formats for path, query,
@@ -320,7 +320,7 @@ class ApiClient(object):
                                  (connection, read) timeouts.
         :return:
             If _async parameter is True,
-            the request will be called _asynchronously.
+            the request will be called asynchronously.
             The method will return the request thread.
             If parameter _async is False or missing,
             then the method will return the response directly.

--- a/kaggle/api_client.py
+++ b/kaggle/api_client.py
@@ -286,12 +286,12 @@ class ApiClient(object):
     def call_api(self, resource_path, method,
                  path_params=None, query_params=None, header_params=None,
                  body=None, post_params=None, files=None,
-                 response_type=None, auth_settings=None, async=None,
+                 response_type=None, auth_settings=None, _async=None,
                  _return_http_data_only=None, collection_formats=None,
                  _preload_content=True, _request_timeout=None):
         """Makes the HTTP request (synchronous) and returns deserialized data.
 
-        To make an async request, set the async parameter.
+        To make an _async request, set the _async parameter.
 
         :param resource_path: Path to method endpoint.
         :param method: Method to call.
@@ -306,7 +306,7 @@ class ApiClient(object):
         :param response: Response data type.
         :param files dict: key -> filename, value -> filepath,
             for `multipart/form-data`.
-        :param async bool: execute request asynchronously
+        :param _async bool: execute request _asynchronously
         :param _return_http_data_only: response data without head status code
                                        and headers
         :param collection_formats: dict of collection formats for path, query,
@@ -319,13 +319,13 @@ class ApiClient(object):
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
         :return:
-            If async parameter is True,
-            the request will be called asynchronously.
+            If _async parameter is True,
+            the request will be called _asynchronously.
             The method will return the request thread.
-            If parameter async is False or missing,
+            If parameter _async is False or missing,
             then the method will return the response directly.
         """
-        if not async:
+        if not _async:
             return self.__call_api(resource_path, method,
                                    path_params, query_params, header_params,
                                    body, post_params, files,
@@ -333,7 +333,7 @@ class ApiClient(object):
                                    _return_http_data_only, collection_formats,
                                    _preload_content, _request_timeout)
         else:
-            thread = self.pool.apply_async(self.__call_api, (resource_path,
+            thread = self.pool.apply__async(self.__call_api, (resource_path,
                                            method, path_params, query_params,
                                            header_params, body,
                                            post_params, files,


### PR DESCRIPTION
Python 3.7.0 puts async and await as reserved words [https://docs.python.org/3.7/whatsnew/3.7.html](https://docs.python.org/3.7/whatsnew/3.7.html)