### PR TITLE
Fixes the bug when upgrading to Python 3.7

### DIFF
--- a/kaggle/api/kaggle_api.py
+++ b/kaggle/api/kaggle_api.py
@@ -132,7 +132,7 @@ class KaggleApi(object):
             files=local_var_files,
             response_type='Result',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronously=params.get('async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -221,7 +221,7 @@ class KaggleApi(object):
             files=local_var_files,
             response_type='Result',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronously=params.get('async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -318,7 +318,7 @@ class KaggleApi(object):
             files=local_var_files,
             response_type='Result',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronously=params.get('async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -411,7 +411,7 @@ class KaggleApi(object):
             files=local_var_files,
             response_type='Result',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronously=params.get('async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -504,7 +504,7 @@ class KaggleApi(object):
             files=local_var_files,
             response_type='Result',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronously=params.get('async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -601,7 +601,7 @@ class KaggleApi(object):
             files=local_var_files,
             response_type='Result',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronously=params.get('async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -714,7 +714,7 @@ class KaggleApi(object):
             files=local_var_files,
             response_type='Result',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronously=params.get('async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -835,7 +835,7 @@ class KaggleApi(object):
             files=local_var_files,
             response_type='Result',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronously=params.get('async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -944,7 +944,7 @@ class KaggleApi(object):
             files=local_var_files,
             response_type='Result',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronously=params.get('async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1041,7 +1041,7 @@ class KaggleApi(object):
             files=local_var_files,
             response_type='Result',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronously=params.get('async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1154,7 +1154,7 @@ class KaggleApi(object):
             files=local_var_files,
             response_type='Result',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronously=params.get('async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1267,7 +1267,7 @@ class KaggleApi(object):
             files=local_var_files,
             response_type='Result',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronously=params.get('async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1360,7 +1360,7 @@ class KaggleApi(object):
             files=local_var_files,
             response_type='Result',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronously=params.get('async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1461,7 +1461,7 @@ class KaggleApi(object):
             files=local_var_files,
             response_type='Result',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronously=params.get('async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1574,7 +1574,7 @@ class KaggleApi(object):
             files=local_var_files,
             response_type='Result',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronously=params.get('async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1675,7 +1675,7 @@ class KaggleApi(object):
             files=local_var_files,
             response_type='Result',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            asynchronously=params.get('async'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/kaggle/api_client.py
+++ b/kaggle/api_client.py
@@ -286,12 +286,12 @@ class ApiClient(object):
     def call_api(self, resource_path, method,
                  path_params=None, query_params=None, header_params=None,
                  body=None, post_params=None, files=None,
-                 response_type=None, auth_settings=None, async=None,
+                 response_type=None, auth_settings=None, asynchronously=None,
                  _return_http_data_only=None, collection_formats=None,
                  _preload_content=True, _request_timeout=None):
         """Makes the HTTP request (synchronous) and returns deserialized data.
 
-        To make an async request, set the async parameter.
+        To make an async request, set the asynchronously parameter.
 
         :param resource_path: Path to method endpoint.
         :param method: Method to call.
@@ -306,7 +306,7 @@ class ApiClient(object):
         :param response: Response data type.
         :param files dict: key -> filename, value -> filepath,
             for `multipart/form-data`.
-        :param async bool: execute request asynchronously
+        :param asynchronously bool: execute request asynchronously
         :param _return_http_data_only: response data without head status code
                                        and headers
         :param collection_formats: dict of collection formats for path, query,
@@ -325,7 +325,7 @@ class ApiClient(object):
             If parameter async is False or missing,
             then the method will return the response directly.
         """
-        if not async:
+        if not asynchronously:
             return self.__call_api(resource_path, method,
                                    path_params, query_params, header_params,
                                    body, post_params, files,


### PR DESCRIPTION
Python 3.7 seems to handle the async keyword differently than 3.5 and 3.6, thus syntax errors occurred when upgrading to Python 3.7. 

This renames the async parameter in the call_api method of the api_client to asynchronously in order to fix this bug.

This fixes #39 and #64