### PR TITLE
Correct reporting of location of configuration values

### DIFF
--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -171,7 +171,7 @@ class KaggleApi(KaggleApi):
         print(prefix + name + separator + value_out)
 
     def print_config_values(self):
-        print('Configuration values from ' + self.get_config_path())
+        print('Configuration values from ' + self.config_path)
         self.print_config_value(self.CONFIG_NAME_USER, prefix='- ')
         self.print_config_value(self.CONFIG_NAME_PATH, prefix='- ')
         self.print_config_value(self.CONFIG_NAME_PROXY, prefix='- ')


### PR DESCRIPTION
After a fresh installation, the command
```
$ kaggle config view
```
shows output similar to:
```
Configuration values from /home/bcsharp/.kaggle
- username: bcsharp
- path: None
- proxy: None
- competition: None
```
The first line indicates where `kaggle.json` is located. However, after setting the data path to another location, e.g.:
```
$ kaggle config set --name path --value /opt/my/kaggle/data
path is now set to: /opt/my/kaggle/data
```
`kaggle config view` will show an incorrect location of its configuration values:
```
Configuration values from /opt/my/kaggle/data
- username: bcsharp
- path: /opt/my/kaggle/data
- proxy: None
- competition: None
```
The root cause of the problem is probably a misleadingly named function `get_config_path`, which I think is better named `get_data_path`. I am guessing that `get_config_path` was intended to mean "get path from the config file" rather than "get path of the config file", but it is not how it is used in some places.

This PR fixes the output, but I would like to change the name of the function too, to prevent this problem from creeping back in the future.

Also, I would like to report the name of the json file in the printed output, this would make things more explicit, e.g.:
```
Configuration values from /home/bcsharp/.kaggle/kaggle.json
```
This change is also not in this PR yet, awaiting comments.
