### PR TITLE
Obtain credentials from environment - attempt # 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ For your security, ensure that other users of your computer do not have read acc
 
 `chmod 600 ~/.kaggle/kaggle.json`
 
+You can also choose to export your Kaggle username and token to the environment:
+
+```bash
+export KAGGLE_USER=datadinosaur
+export KAGGLE_TOKEN=xxxxxxxxxxxxxx
+```
+In addition, you can export any other configuration value that normally would be in
+the `$HOME/.kaggle/kaggle.json` in the format 'KAGGLE_<VARIABLE>' (note uppercase).  
+For example, if the file had the variable "proxy" you would export `KAGGLE_PROXY`
+and it would be discovered by the client.
+
+
 ## Commands
 
 The command line tool supports the following commands:

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -76,6 +76,7 @@ class KaggleApi(KaggleApi):
         expanduser('~'), '.kaggle')
     if not os.path.exists(config_dir):
         os.makedirs(config_dir)
+
     config_file = 'kaggle.json'
     config = os.path.join(config_dir, config_file)
     config_values = {}
@@ -98,7 +99,7 @@ class KaggleApi(KaggleApi):
 
         # Step 1: read in configuration file, if it exists
         if os.path.exists(self.config):
-            config_data = self._authenticate_config(config_data)
+            config_data = self._auth_from_config(config_data)
 
         # Step 2:, get username/password from environment
         config_data = self._auth_from_environment(config_data)
@@ -187,7 +188,7 @@ class KaggleApi(KaggleApi):
                           + 'for instructions.')
 
 
-    def _authenticate_config(self, config_data, quiet=False):
+    def _auth_from_config(self, config_data, quiet=False):
         '''autheticate config is the first effort to get a username
            and key to authenticate to the Kaggle API. Since we can get the
            username and password from the environment, it's not required.
@@ -236,7 +237,7 @@ class KaggleApi(KaggleApi):
         return config_data
 
 
-    def _write_config(self, config_data, indent=1):
+    def _write_config_file(self, config_data, indent=2):
         '''write config data to file.
         '''
         with open(self.config, 'w') as f:
@@ -260,7 +261,7 @@ class KaggleApi(KaggleApi):
             self.config_values[name] = value
 
             # If defined by client, set and save!
-            self._write_config(config_data)
+            self._write_config_file(config_data)
 
             if not quiet:
                 self.print_config_value(name, separator=' is now set to: ')
@@ -271,14 +272,11 @@ class KaggleApi(KaggleApi):
 
         config_data = self._read_config_file()
 
-        # Remove it, if exists, both from loaded file and client
-
-        del self.config_values[name] # is there reason this was None?
-
         if name in config_data:
+
             del config_data[name]
 
-            self._write_config(config_data)
+            self._write_config_file(config_data)
 
             if not quiet:
                 self.print_config_value(name, separator=' is now set to: ')
@@ -295,12 +293,12 @@ class KaggleApi(KaggleApi):
         if name in self.config_values:
             return self.config_values[name]
 
-    def get_config_path(self):
+    def get_config_dir(self):
         '''get the path configuration value, otherwise return default.
         '''
         path = self.get_config_value(self.CONFIG_NAME_PATH)
         if path is None:
-            return self.config_path
+            return self.config_dir
         return path
 
     def print_config_value(self, name, prefix='', separator=': '):
@@ -320,7 +318,7 @@ class KaggleApi(KaggleApi):
     def print_config_values(self):
         '''a wrapper to print_config_value to print all configuration values
         '''
-        print('Configuration values from ' + self.get_config_path())
+        print('Configuration values from ' + self.get_config_dir())
         self.print_config_value(self.CONFIG_NAME_USER, prefix='- ')
         self.print_config_value(self.CONFIG_NAME_PATH, prefix='- ')
         self.print_config_value(self.CONFIG_NAME_PROXY, prefix='- ')

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -104,12 +104,11 @@ class KaggleApi(KaggleApi):
         # Step 2:, get username/password from environment
         config_data = self._auth_from_environment(config_data)
 
-
         # Step 3: load into configuration!
         self._load_config(config_data)
 
 
-    def _auth_from_environment(self, config_data=None, quiet=False):
+    def _auth_from_environment(self, config_data={}, quiet=False):
         '''autheticate environment is the second effort to get a username
            and key to authenticate to the Kaggle API. The environment keys
            are equivalent to the kaggle.json file, but with "KAGGLE_" prefix
@@ -124,14 +123,11 @@ class KaggleApi(KaggleApi):
 
         '''
 
-        if config_data == None:
-            config_data = {}
-
         # Add all variables that start with KAGGLE_ to config data
 
         for key,val in os.environ.items():
             if key.startswith('KAGGLE_'):
-                config_key = key.replace('KAGGLE_','',1).lower()
+                config_key = key.replace('KAGGLE_', '', 1).lower()
                 config_data[config_key] = val
 
         return config_data

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -290,7 +290,7 @@ class KaggleApi(KaggleApi):
         if name in self.config_values:
             return self.config_values[name]
 
-    def get_default_download_dir(self):
+    def get_default_download_dir(self, *subdirs):
         '''get the path configuration value, otherwise return default.
         '''
         # Look up value for key "path" in the config
@@ -300,7 +300,7 @@ class KaggleApi(KaggleApi):
         if path is None:
             return os.getcwd()
 
-        return path
+        return os.path.join(path, *subdirs)
 
     def print_config_value(self, name, prefix='', separator=': '):
         '''print a single configuration value, based on a prefix and separator

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -100,16 +100,16 @@ class KaggleApi(KaggleApi):
 
         # Step 1: read in configuration file, if it exists
         if os.path.exists(self.config):
-            config_data = self._auth_from_config(config_data)
+            config_data = self.read_config_file(config_data)
 
         # Step 2:, get username/password from environment
-        config_data = self._auth_from_environment(config_data)
+        config_data = self.read_config_environment(config_data)
 
         # Step 3: load into configuration!
         self._load_config(config_data)
 
 
-    def _auth_from_environment(self, config_data={}, quiet=False):
+    def read_config_environment(self, config_data={}, quiet=False):
         '''autheticate environment is the second effort to get a username
            and key to authenticate to the Kaggle API. The environment keys
            are equivalent to the kaggle.json file, but with "KAGGLE_" prefix
@@ -185,7 +185,7 @@ class KaggleApi(KaggleApi):
                           + 'for instructions.')
 
 
-    def _auth_from_config(self, config_data, quiet=False):
+    def read_config_file(self, config_data, quiet=False):
         '''autheticate config is the first effort to get a username
            and key to authenticate to the Kaggle API. Since we can get the
            username and password from the environment, it's not required.

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -95,6 +95,7 @@ class KaggleApi(KaggleApi):
            variables, and falling back to looking for the .kaggle/kaggle.json
            configuration file.
         '''
+
         config_data = {}
 
         # Step 1: read in configuration file, if it exists
@@ -289,12 +290,16 @@ class KaggleApi(KaggleApi):
         if name in self.config_values:
             return self.config_values[name]
 
-    def get_config_dir(self):
+    def get_default_download_dir(self):
         '''get the path configuration value, otherwise return default.
         '''
+        # Look up value for key "path" in the config
         path = self.get_config_value(self.CONFIG_NAME_PATH)
+
+        # If not set in config, default to present working directory
         if path is None:
-            return self.config_dir
+            return os.getcwd()
+
         return path
 
     def print_config_value(self, name, prefix='', separator=': '):
@@ -314,7 +319,7 @@ class KaggleApi(KaggleApi):
     def print_config_values(self):
         '''a wrapper to print_config_value to print all configuration values
         '''
-        print('Configuration values from ' + self.get_config_dir())
+        print('Configuration values from ' + self.config_dir)
         self.print_config_value(self.CONFIG_NAME_USER, prefix='- ')
         self.print_config_value(self.CONFIG_NAME_PATH, prefix='- ')
         self.print_config_value(self.CONFIG_NAME_PROXY, prefix='- ')

--- a/kaggle/tests/test_authenticate.py
+++ b/kaggle/tests/test_authenticate.py
@@ -1,5 +1,7 @@
 from kaggle.api.kaggle_api_extended import KaggleApi
 
+# python -m unittest tests.test_authenticate
+
 import os  
 import unittest
 
@@ -14,21 +16,25 @@ class TestAuthenticate(unittest.TestCase):
     # Environment
 
     def test_environment_variables(self):
-        print('testing initialization with environment variables')
-        os.putenv('KAGGLE_USER','dinosaur')
-        os.putenv('KAGGLE_KEY','xxxxxxxxxxxx')
+        os.environ['KAGGLE_USERNAME'] = 'dinosaur'
+        os.environ['KAGGLE_KEY'] = 'xxxxxxxxxxxx'
         api = KaggleApi()
-        
+
+        # We haven't authenticated yet
+        self.assertTrue("key" not in api.config_values)
+        self.assertTrue("username" not in api.config_values)
+        api.authenticate()
+
+        # Should be set from the environment
+        self.assertEqual(api.config_values['key'], 'xxxxxxxxxxxx')
+        self.assertEqual(api.config_values['username'], 'dinosaur')
+
     # Configuration Actions
 
     def test_config_actions(self):
-        print('testing default config directory is called .kaggle')
         api = KaggleApi()
 
-        assert(api.get_config_dir().endswith('.kaggle'))
-        self.assertEqual(api.get_config_dir(), api.config_dir)
-
-        print('testing that asking for non-existent value returns none')
+        self.assertTrue(api.config_dir.endswith('.kaggle'))
         self.assertEqual(api.get_config_value('doesntexist'), None)
 
  

--- a/kaggle/tests/test_authenticate.py
+++ b/kaggle/tests/test_authenticate.py
@@ -1,0 +1,36 @@
+from kaggle.api.kaggle_api_extended import KaggleApi
+
+import os  
+import unittest
+
+class TestAuthenticate(unittest.TestCase):
+ 
+    def setUp(self):
+        print("setup             class:%s" % self)
+         
+    def tearDown(self):
+        print ("teardown          class:TestStuff")
+  
+    # Environment
+
+    def test_environment_variables(self):
+        print('testing initialization with environment variables')
+        os.putenv('KAGGLE_USER','dinosaur')
+        os.putenv('KAGGLE_KEY','xxxxxxxxxxxx')
+        api = KaggleApi()
+        
+    # Configuration Actions
+
+    def test_config_actions(self):
+        print('testing default config directory is called .kaggle')
+        api = KaggleApi()
+
+        assert(api.get_config_dir().endswith('.kaggle'))
+        self.assertEqual(api.get_config_dir(), api.config_dir)
+
+        print('testing that asking for non-existent value returns none')
+        self.assertEqual(api.get_config_value('doesntexist'), None)
+
+ 
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR is mostly the same as #57, but just includes the changes to the authenticate function that (hopefully) will not be too complicated to discuss in a PR.  The design of the authenticate function is moduar so that the supporting functions can be used in different authentication flows, each of which is called from the primary authenticate:

```python

        # Step 1: read in configuration file, if it exists
        if os.path.exists(self.config):
            config_data = self._authenticate_config(config_data)

         # Step 2:, get username/password from environment
        config_data = self._authenticate_environment(config_data)

         # Step 3: load into configuration!
        self._load_config(config_data)

```
The idea is that we should have a forward thinking mindset that other methods might be wanted, and it should be easy to add here.

I'm being very conservative because I spent a lot of time on the last PR, and most of the work now needs to be redone. This will part 1 of the revisions, and I won't proceed on the others until each is gone through! Thanks for your help and guidance with this work @rysteboe - if we both hang in there we can do this together! :) 