### PR TITLE
Fix environment variables for Kaggle username and key

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ For your security, ensure that other users of your computer do not have read acc
 You can also choose to export your Kaggle username and token to the environment:
 
 ```bash
-export KAGGLE_USER=datadinosaur
-export KAGGLE_TOKEN=xxxxxxxxxxxxxx
+export KAGGLE_USERNAME=datadinosaur
+export KAGGLE_KEY=xxxxxxxxxxxxxx
 ```
 In addition, you can export any other configuration value that normally would be in
 the `$HOME/.kaggle/kaggle.json` in the format 'KAGGLE_<VARIABLE>' (note uppercase).  


### PR DESCRIPTION
The environment variables currently on the README for user and auth don't seem to work but these do. Maybe needs an update?