### PR TITLE
Add info about kernels API

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The command line tool supports the following commands:
 ``` 
 kaggle competitions {list,files,download,submit,submissions,leaderboard}
 kaggle datasets {list, files, download, create, version, init}
+kaggle kernels {list, init, push, pull, output, status}
 kaggle config {view, set, unset}
 ```
 


### PR DESCRIPTION
In the following phrase there was no mention of the kernels API so I added it in myself.

The command line tool supports the following commands:

``` 
kaggle competitions {list,files,download,submit,submissions,leaderboard}
kaggle datasets {list, files, download, create, version, init}
kaggle kernels {list, init, push, pull, output, status}
kaggle config {view, set, unset}
```