### PR TITLE
Show expected location when kaggle.json not found

### DIFF
--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -102,13 +102,15 @@ class KaggleApi(KaggleApi):
         # Step 1: try getting username/password from environment
         config_data = self.read_config_environment(config_data)
 
-        # Step 2: if credentials were not in environment read in configuration file
-        if self.CONFIG_NAME_USER not in config_data or self.CONFIG_NAME_KEY not in config_data:
+        # Step 2: if credentials were not in env read in configuration file
+        if self.CONFIG_NAME_USER not in config_data \
+                or self.CONFIG_NAME_KEY not in config_data:
             if os.path.exists(self.config):
                 config_data = self.read_config_file(config_data)
             else:
-                raise IOError('Could not find kaggle.json. Make sure it\'s located in {}.'
-                              ' Or use the environment method.'.format(self.config_dir))
+                raise IOError('Could not find {}. Make sure it\'s located in'
+                              ' {}. Or use the environment method.'
+                              .format(self.config_file, self.config_dir))
 
         # Step 3: load into configuration!
         self._load_config(config_data)

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -103,7 +103,7 @@ class KaggleApi(KaggleApi):
         config_data = self.read_config_environment(config_data)
 
         # Step 2: if credentials were not in environment read in configuration file
-        if 'username' not in config_data or 'key' not in config_data:
+        if self.CONFIG_NAME_USER not in config_data or self.CONFIG_NAME_KEY not in config_data:
             if os.path.exists(self.config):
                 config_data = self.read_config_file(config_data)
             else:

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -99,12 +99,16 @@ class KaggleApi(KaggleApi):
 
         config_data = {}
 
-        # Step 1: read in configuration file, if it exists
-        if os.path.exists(self.config):
-            config_data = self.read_config_file(config_data)
-
-        # Step 2:, get username/password from environment
+        # Step 1: try getting username/password from environment
         config_data = self.read_config_environment(config_data)
+
+        # Step 2: if credentials were not in environment read in configuration file
+        if 'username' not in config_data or 'key' not in config_data:
+            if os.path.exists(self.config):
+                config_data = self.read_config_file(config_data)
+            else:
+                raise IOError('Could not find kaggle.json. Make sure it\'s located in {}.'
+                              ' Or use the environment method.'.format(self.config_dir))
 
         # Step 3: load into configuration!
         self._load_config(config_data)


### PR DESCRIPTION
If kaggle.json is not found and the credentials were also not set in the environment, raise an error showing the expected location of kaggle.json.

This solves the problem of exotic user folders. For example in my Python distribution the user folder is located inside of the distribution. I found that out by checking the value in `KaggleApi.config_dir`.

Before this PR, first the config file was read, followed by the environment. If there were credentials in the environment they would overwrite the ones from the config file. This behavior has been preserved, even though the environment is now read first. The config file is only checked if credentials were not found in the environment.

This is a small change, but I hope the more telling error message will help users quickly find the issue in their setup.