### PR TITLE
Support for uploading datasets with subfolders

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,8 @@ optional arguments:
   -u, --public          Create publicly (default is private)
   -q, --quiet           Suppress printing information about the upload/download progress
   -t, --keep-tabular    Do not convert tabular files to CSV (default is to convert)
+  -r {skip,zip}, --dir-mode {skip,zip}
+                        What to do with directories: "skip" - ignore; "zip" - compress and upload
 ```
 
 Example:
@@ -334,6 +336,8 @@ optional arguments:
                         Folder for upload, containing data files and a special dataset-metadata.json file (https://github.com/Kaggle/kaggle-api/wiki/Dataset-Metadata). Defaults to current working directory
   -q, --quiet           Suppress printing information about the upload/download progress
   -t, --keep-tabular    Do not convert tabular files to CSV (default is to convert)
+  -r {skip,zip}, --dir-mode {skip,zip}
+                        What to do with directories: "skip" - ignore; "zip" - compress and upload
   -d, --delete-old-versions
                         Delete old versions of this dataset
 ```

--- a/README.md
+++ b/README.md
@@ -312,8 +312,8 @@ optional arguments:
   -u, --public          Create publicly (default is private)
   -q, --quiet           Suppress printing information about the upload/download progress
   -t, --keep-tabular    Do not convert tabular files to CSV (default is to convert)
-  -r {skip,zip}, --dir-mode {skip,zip}
-                        What to do with directories: "skip" - ignore; "zip" - compress and upload
+  -r {skip,zip,tar}, --dir-mode {skip,zip,tar}
+                        What to do with directories: "skip" - ignore; "zip" - compressed upload; "tar" - uncompressed upload
 ```
 
 Example:
@@ -336,8 +336,8 @@ optional arguments:
                         Folder for upload, containing data files and a special dataset-metadata.json file (https://github.com/Kaggle/kaggle-api/wiki/Dataset-Metadata). Defaults to current working directory
   -q, --quiet           Suppress printing information about the upload/download progress
   -t, --keep-tabular    Do not convert tabular files to CSV (default is to convert)
-  -r {skip,zip}, --dir-mode {skip,zip}
-                        What to do with directories: "skip" - ignore; "zip" - compress and upload
+  -r {skip,zip,tar}, --dir-mode {skip,zip,tar}
+                        What to do with directories: "skip" - ignore; "zip" - compressed upload; "tar" - uncompressed upload
   -d, --delete-old-versions
                         Delete old versions of this dataset
 ```

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -2222,12 +2222,12 @@ class KaggleApi(KaggleApi):
                 if exitcode:
                     return
             elif os.path.isdir(full_path):
-                if dir_mode == 'zip':
+                if dir_mode in ['zip', 'tar']:
                     temp_dir = tempfile.mkdtemp()
                     try:
                         _, dir_name = os.path.split(full_path)
-                        archive_path = shutil.make_archive(os.path.join(temp_dir, dir_name), "zip",
-                                                           full_path)
+                        archive_path = shutil.make_archive(os.path.join(temp_dir, dir_name),
+                                                           dir_mode, full_path)
                         _, archive_name = os.path.split(archive_path)
                         exitcode = self._upload_file(archive_name, archive_path, quiet, request,
                                                      resources)
@@ -2236,8 +2236,7 @@ class KaggleApi(KaggleApi):
                     if exitcode:
                         return
                 elif not quiet:
-                    print("Skipping folder: " + file_name + "; use '--dir-mode zip' to upload "
-                                                            "folders")
+                    print("Skipping folder: " + file_name + "; use '--dir-mode' to upload folders")
             else:
                 if not quiet:
                     print('Skipping: ' + file_name)

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -2236,7 +2236,7 @@ class KaggleApi(KaggleApi):
             file_name: name of the file to upload
             full_path: path to the file to upload
             request: the prepared request
-            resources: the files to upload
+            resources: optional file metadata
             quiet: suppress verbose output
             :return: True - upload unsuccessful; False - upload successful
         """

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -1199,6 +1199,7 @@ class KaggleApi(KaggleApi):
             quiet: suppress verbose output (default is False)
             convert_to_csv: on upload, if data should be converted to csv
             delete_old_versions: if True, do that (default False)
+            dir_mode: What to do with directories: "skip" - ignore; "zip" - compress and upload
         """
         if not os.path.isdir(folder):
             raise ValueError('Invalid folder: ' + folder)
@@ -1271,6 +1272,7 @@ class KaggleApi(KaggleApi):
             quiet: suppress verbose output (default is False)
             convert_to_csv: on upload, if data should be converted to csv
             delete_old_versions: if True, do that (default False)
+            dir_mode: What to do with directories: "skip" - ignore; "zip" - compress and upload
         """
         folder = folder or os.getcwd()
         result = self.dataset_create_version(
@@ -1337,6 +1339,7 @@ class KaggleApi(KaggleApi):
             public: should the dataset be public?
             quiet: suppress verbose output (default is False)
             convert_to_csv: if True, convert data to comma separated value
+            dir_mode: What to do with directories: "skip" - ignore; "zip" - compress and upload
         """
         if not os.path.isdir(folder):
             raise ValueError('Invalid folder: ' + folder)
@@ -1415,6 +1418,7 @@ class KaggleApi(KaggleApi):
             public: should the dataset be public?
             quiet: suppress verbose output (default is False)
             convert_to_csv: if True, convert data to comma separated value
+            dir_mode: What to do with directories: "skip" - ignore; "zip" - compress and upload
         """
         folder = folder or os.getcwd()
         result = self.dataset_create_new(folder, public, quiet, convert_to_csv, dir_mode)

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -1188,7 +1188,8 @@ class KaggleApi(KaggleApi):
                                version_notes,
                                quiet=False,
                                convert_to_csv=True,
-                               delete_old_versions=False):
+                               delete_old_versions=False,
+                               dir_mode='skip'):
         """ create a version of a dataset
 
             Parameters
@@ -1231,7 +1232,7 @@ class KaggleApi(KaggleApi):
             convert_to_csv=convert_to_csv,
             category_ids=keywords,
             delete_old_versions=delete_old_versions)
-        self.upload_files(request, resources, folder, quiet)
+        self.upload_files(request, resources, folder, quiet, dir_mode)
 
         if id_no:
             result = DatasetNewVersionResponse(
@@ -1260,7 +1261,8 @@ class KaggleApi(KaggleApi):
                                    version_notes,
                                    quiet=False,
                                    convert_to_csv=True,
-                                   delete_old_versions=False):
+                                   delete_old_versions=False,
+                                   dir_mode='skip'):
         """ client wrapper for creating a version of a dataset
              Parameters
             ==========
@@ -1276,7 +1278,8 @@ class KaggleApi(KaggleApi):
             version_notes,
             quiet=quiet,
             convert_to_csv=convert_to_csv,
-            delete_old_versions=delete_old_versions)
+            delete_old_versions=delete_old_versions,
+            dir_mode=dir_mode)
         if result.invalidTags:
             print(
                 ('The following are not valid tags and could not be added to '
@@ -1324,7 +1327,8 @@ class KaggleApi(KaggleApi):
                            folder,
                            public=False,
                            quiet=False,
-                           convert_to_csv=True):
+                           convert_to_csv=True,
+                           dir_mode='skip'):
         """ create a new dataset, meaning the same as creating a version but
             with extra metadata like license and user/owner.
              Parameters
@@ -1402,7 +1406,8 @@ class KaggleApi(KaggleApi):
                                folder=None,
                                public=False,
                                quiet=False,
-                               convert_to_csv=True):
+                               convert_to_csv=True,
+                               dir_mode='skip'):
         """ client wrapper for creating a new dataset
              Parameters
             ==========
@@ -1412,7 +1417,7 @@ class KaggleApi(KaggleApi):
             convert_to_csv: if True, convert data to comma separated value
         """
         folder = folder or os.getcwd()
-        result = self.dataset_create_new(folder, public, quiet, convert_to_csv)
+        result = self.dataset_create_new(folder, public, quiet, convert_to_csv, dir_mode)
         if result.invalidTags:
             print('The following are not valid tags and could not be added to '
                   'the dataset: ' + str(result.invalidTags))
@@ -2192,7 +2197,7 @@ class KaggleApi(KaggleApi):
 
         return True
 
-    def upload_files(self, request, resources, folder, quiet=False):
+    def upload_files(self, request, resources, folder, quiet=False, dir_mode='skip'):
         """ upload files in a folder
              Parameters
             ==========
@@ -2212,7 +2217,7 @@ class KaggleApi(KaggleApi):
                 exitcode = self._upload_file(file_name, full_path, quiet, request, resources)
                 if exitcode:
                     return
-            if os.path.isdir(full_path):
+            if os.path.isdir(full_path) and dir_mode == 'zip':
                 temp_dir = tempfile.mkdtemp()
                 try:
                     _, dir_name = os.path.split(full_path)

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -2208,8 +2208,6 @@ class KaggleApi(KaggleApi):
                 continue
             full_path = os.path.join(folder, file_name)
 
-            if not quiet:
-                print('Starting upload for file ' + file_name)
             if os.path.isfile(full_path):
                 retval = self._upload_file(file_name, full_path, quiet, request, resources)
                 if retval:
@@ -2232,6 +2230,9 @@ class KaggleApi(KaggleApi):
                     print('Skipping: ' + file_name)
 
     def _upload_file(self, file_name, full_path, quiet, request, resources):
+        if not quiet:
+            print('Starting upload for file ' + file_name)
+
         content_length = os.path.getsize(full_path)
         token = self.dataset_upload_file(full_path, quiet)
         if token is None:

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -2221,19 +2221,23 @@ class KaggleApi(KaggleApi):
                 exitcode = self._upload_file(file_name, full_path, quiet, request, resources)
                 if exitcode:
                     return
-            if os.path.isdir(full_path) and dir_mode == 'zip':
-                temp_dir = tempfile.mkdtemp()
-                try:
-                    _, dir_name = os.path.split(full_path)
-                    archive_path = shutil.make_archive(os.path.join(temp_dir, dir_name), "zip",
-                                                       full_path)
-                    _, archive_name = os.path.split(archive_path)
-                    exitcode = self._upload_file(archive_name, archive_path, quiet, request,
-                                                 resources)
-                finally:
-                    shutil.rmtree(temp_dir)
-                if exitcode:
-                    return
+            elif os.path.isdir(full_path):
+                if dir_mode == 'zip':
+                    temp_dir = tempfile.mkdtemp()
+                    try:
+                        _, dir_name = os.path.split(full_path)
+                        archive_path = shutil.make_archive(os.path.join(temp_dir, dir_name), "zip",
+                                                           full_path)
+                        _, archive_name = os.path.split(archive_path)
+                        exitcode = self._upload_file(archive_name, archive_path, quiet, request,
+                                                     resources)
+                    finally:
+                        shutil.rmtree(temp_dir)
+                    if exitcode:
+                        return
+                elif not quiet:
+                    print("Skipping folder: " + file_name + "; use '--dir-mode zip' to upload "
+                                                            "folders")
             else:
                 if not quiet:
                     print('Skipping: ' + file_name)

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -1418,7 +1418,7 @@ class KaggleApi(KaggleApi):
             convert_to_csv=convert_to_csv,
             category_ids=keywords)
         resources = meta_data.get('resources')
-        self.upload_files(request, resources, folder, quiet)
+        self.upload_files(request, resources, folder, quiet, dir_mode)
         result = DatasetNewResponse(
             self.process_response(
                 self.datasets_create_new_with_http_info(request)))

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -2209,8 +2209,8 @@ class KaggleApi(KaggleApi):
             full_path = os.path.join(folder, file_name)
 
             if os.path.isfile(full_path):
-                retval = self._upload_file(file_name, full_path, quiet, request, resources)
-                if retval:
+                exitcode = self._upload_file(file_name, full_path, quiet, request, resources)
+                if exitcode:
                     return
             if os.path.isdir(full_path):
                 temp_dir = tempfile.mkdtemp()
@@ -2219,17 +2219,28 @@ class KaggleApi(KaggleApi):
                     archive_path = shutil.make_archive(os.path.join(temp_dir, dir_name), "zip",
                                                        full_path)
                     _, archive_name = os.path.split(archive_path)
-                    retval = self._upload_file(archive_name, archive_path, quiet, request,
-                                               resources)
+                    exitcode = self._upload_file(archive_name, archive_path, quiet, request,
+                                                 resources)
                 finally:
                     shutil.rmtree(temp_dir)
-                if retval:
+                if exitcode:
                     return
             else:
                 if not quiet:
                     print('Skipping: ' + file_name)
 
     def _upload_file(self, file_name, full_path, quiet, request, resources):
+        """ Helper function to upload a single file
+            Parameters
+            ==========
+            file_name: name of the file to upload
+            full_path: path to the file to upload
+            request: the prepared request
+            resources: the files to upload
+            quiet: suppress verbose output
+            :return: True - upload unsuccessful; False - upload successful
+        """
+
         if not quiet:
             print('Starting upload for file ' + file_name)
 

--- a/kaggle/cli.py
+++ b/kaggle/cli.py
@@ -500,7 +500,7 @@ def parse_datasets(subparsers):
         action='store_false',
         help=Help.param_keep_tabular)
     parser_datasets_create_optional.add_argument(
-        '-d',
+        '-r',
         '--dir-mode',
         dest='dir_mode',
         choices=['skip', 'zip'],
@@ -543,8 +543,8 @@ def parse_datasets(subparsers):
         dest='convert_to_csv',
         action='store_false',
         help=Help.param_keep_tabular)
-    parser_datasets_create_optional.add_argument(
-        '-d',
+    parser_datasets_version_optional.add_argument(
+        '-r',
         '--dir-mode',
         dest='dir_mode',
         choices=['skip', 'zip'],

--- a/kaggle/cli.py
+++ b/kaggle/cli.py
@@ -499,6 +499,13 @@ def parse_datasets(subparsers):
         dest='convert_to_csv',
         action='store_false',
         help=Help.param_keep_tabular)
+    parser_datasets_create_optional.add_argument(
+        '-d',
+        '--dir-mode',
+        dest='dir_mode',
+        choices=['skip', 'zip'],
+        default='skip',
+        help=Help.param_dir_mode)
     parser_datasets_create._action_groups.append(
         parser_datasets_create_optional)
     parser_datasets_create.set_defaults(func=api.dataset_create_new_cli)
@@ -536,6 +543,13 @@ def parse_datasets(subparsers):
         dest='convert_to_csv',
         action='store_false',
         help=Help.param_keep_tabular)
+    parser_datasets_create_optional.add_argument(
+        '-d',
+        '--dir-mode',
+        dest='dir_mode',
+        choices=['skip', 'zip'],
+        default='skip',
+        help=Help.param_dir_mode)
     parser_datasets_version_optional.add_argument(
         '-d',
         '--delete-old-versions',
@@ -934,6 +948,8 @@ class Help(object):
     param_public = 'Create publicly (default is private)'
     param_keep_tabular = (
         'Do not convert tabular files to CSV (default is to convert)')
+    param_dir_mode = (
+        'What to do with directories: "skip" - ignore; "zip" - compress and upload')
     param_delete_old_version = 'Delete old versions of this dataset'
     param_force = (
         'Skip check whether local version of file is up to date, force'

--- a/kaggle/cli.py
+++ b/kaggle/cli.py
@@ -503,7 +503,7 @@ def parse_datasets(subparsers):
         '-r',
         '--dir-mode',
         dest='dir_mode',
-        choices=['skip', 'zip'],
+        choices=['skip', 'zip', 'tar'],
         default='skip',
         help=Help.param_dir_mode)
     parser_datasets_create._action_groups.append(
@@ -547,7 +547,7 @@ def parse_datasets(subparsers):
         '-r',
         '--dir-mode',
         dest='dir_mode',
-        choices=['skip', 'zip'],
+        choices=['skip', 'zip', 'tar'],
         default='skip',
         help=Help.param_dir_mode)
     parser_datasets_version_optional.add_argument(
@@ -949,7 +949,8 @@ class Help(object):
     param_keep_tabular = (
         'Do not convert tabular files to CSV (default is to convert)')
     param_dir_mode = (
-        'What to do with directories: "skip" - ignore; "zip" - compress and upload')
+        'What to do with directories: "skip" - ignore; "zip" - compressed upload; "tar" - '
+        'uncompressed upload')
     param_delete_old_version = 'Delete old versions of this dataset'
     param_force = (
         'Skip check whether local version of file is up to date, force'


### PR DESCRIPTION
This PR enables uploading non-flat datasets that include an arbitrary number of subfolders. Each subfolder is combined into a compressed or uncompressed archive and uploaded as a zip or tar file. The files are constructed in a way that leads to the same file hierarchy after the archives are automatically uncompressed by the backend and provided to Kernels (in `../input`).
