### PR TITLE
Allow custom ca_cert files.

### DIFF
--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -69,6 +69,7 @@ class KaggleApi(KaggleApi):
     CONFIG_NAME_PATH = 'path'
     CONFIG_NAME_USER = 'username'
     CONFIG_NAME_KEY = 'key'
+    CONFIG_NAME_CERT_FILE = 'cert_file'
 
     HEADER_API_VERSION = 'X-Kaggle-ApiVersion'
     DATASET_METADATA_FILE = 'dataset-metadata.json'
@@ -170,6 +171,11 @@ class KaggleApi(KaggleApi):
         if self.CONFIG_NAME_PROXY in config_data:
             configuration.proxy = config_data[self.CONFIG_NAME_PROXY]
 
+        # Cert File
+            
+        if self.CONFIG_NAME_PROXY in config_data:
+            configuration.cert_file = config_data[self.CONFIG_NAME_CERT_FILE]
+            
         # Keep config values with class instance, and load api client!
 
         self.config_values = config_data

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -69,7 +69,7 @@ class KaggleApi(KaggleApi):
     CONFIG_NAME_PATH = 'path'
     CONFIG_NAME_USER = 'username'
     CONFIG_NAME_KEY = 'key'
-    CONFIG_NAME_CERT_FILE = 'cert_file'
+    CONFIG_NAME_CA_CERTS = 'ca_certs'
 
     HEADER_API_VERSION = 'X-Kaggle-ApiVersion'
     DATASET_METADATA_FILE = 'dataset-metadata.json'
@@ -173,8 +173,8 @@ class KaggleApi(KaggleApi):
 
         # Cert File
             
-        if self.CONFIG_NAME_PROXY in config_data:
-            configuration.cert_file = config_data[self.CONFIG_NAME_CERT_FILE]
+        if self.CONFIG_NAME_CA_CERTS in config_data:
+            configuration.ca_certs = config_data[self.CONFIG_NAME_CA_CERTS]
             
         # Keep config values with class instance, and load api client!
 

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -69,7 +69,7 @@ class KaggleApi(KaggleApi):
     CONFIG_NAME_PATH = 'path'
     CONFIG_NAME_USER = 'username'
     CONFIG_NAME_KEY = 'key'
-    CONFIG_NAME_CA_CERTS = 'ca_certs'
+    CONFIG_NAME_SSL_CA_CERT = 'ssl_ca_cert'
 
     HEADER_API_VERSION = 'X-Kaggle-ApiVersion'
     DATASET_METADATA_FILE = 'dataset-metadata.json'
@@ -174,7 +174,7 @@ class KaggleApi(KaggleApi):
         # Cert File
             
         if self.CONFIG_NAME_CA_CERTS in config_data:
-            configuration.ca_certs = config_data[self.CONFIG_NAME_CA_CERTS]
+            configuration.ssl_ca_cert = config_data[self.CONFIG_NAME_SSL_CA_CERT]
             
         # Keep config values with class instance, and load api client!
 

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -173,7 +173,7 @@ class KaggleApi(KaggleApi):
 
         # Cert File
             
-        if self.CONFIG_NAME_CA_CERTS in config_data:
+        if self.CONFIG_NAME_SSL_CA_CERT in config_data:
             configuration.ssl_ca_cert = config_data[self.CONFIG_NAME_SSL_CA_CERT]
             
         # Keep config values with class instance, and load api client!


### PR DESCRIPTION
Looked like most of the framework was there, I just added the configuration file parser changes to pick up the `ssl_ca_cert` from the `kaggle.json` file.

**Example Usage:**

```
{"username":"my_cool_username",
  "key":"profile_api_key",
  "ssl_ca_cert": "/Users/my_cool_username/evil_corp_ca_cert.pem",
  "proxy": "http://proxy.evilcorp.com:80"}
```

This fixes #19