### PR TITLE
Increase urllib3 version restriction

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,11 +31,9 @@ setup(
     keywords=['Kaggle', 'API'],
     entry_points={'console_scripts': ['kaggle = kaggle.cli:main']},
     install_requires=[
-        # Restriction that urllib3's version is less than 1.23.0 needed to avoid
-        # requests dependency problem. This restriction will be removed after
-        # request release later than 2.18.4.
-        # ref: https://github.com/Kaggle/kaggle-api/pull/49
-        'urllib3 >= 1.15, < 1.23.0',
+        # Restriction that urllib3's version is less than 1.25 needed to avoid
+        # requests dependency problem.
+        'urllib3 >= 1.21.1, < 1.25',
         'six >= 1.10',
         'certifi',
         'python-dateutil',


### PR DESCRIPTION
Closes #147 

This increases urllib3 version restriction to `<1.25` as the one done by [requests](https://github.com/requests/requests/blob/v2.20.0/setup.py#L47). 