### PR TITLE
Update kaggle_api_extended.py

### DIFF
--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -2018,6 +2018,7 @@ class KaggleApi(KaggleApi):
             outfiles.append(outfile)
             download_response = requests.get(item['url'])
             if force or self.download_needed(item, outfile, quiet):
+                os.makedirs(os.path.split(outfile)[0], exist_ok=True)
                 with open(outfile, 'wb') as out:
                     out.write(download_response.content)
                 if not quiet:


### PR DESCRIPTION
Solves issue #173: kernels output fails if the kernel is creating output subfolders