### PR TITLE
Prevent a misleading server error + feature: ability to init kernel metadata with specific values using CLI

### DIFF
--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -1696,8 +1696,11 @@ class KaggleApi(KaggleApi):
             meta_data = json.load(f)
 
         title = self.get_or_default(meta_data, 'title', None)
-        if title and len(title) < 5:
-            raise ValueError('Title must be at least five characters')
+        if title:
+            if len(title) < 5:
+                raise ValueError('Title must be at least five characters')
+            elif len(title) > 50:
+                raise ValueError('Title must be at most fifty characters')
 
         code_path = self.get_or_default(meta_data, 'code_file', '')
         if not code_path:
@@ -1764,6 +1767,10 @@ class KaggleApi(KaggleApi):
                         cell['outputs'] = []
             script_body = json.dumps(json_body)
 
+        print('id:', id_no)
+        print('slug:', slug)
+        print('title:', title)
+        print('new_title:', self.get_or_default(meta_data, 'title', None))
         kernel_push_request = KernelPushRequest(
             id=id_no,
             slug=slug,

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -1767,10 +1767,6 @@ class KaggleApi(KaggleApi):
                         cell['outputs'] = []
             script_body = json.dumps(json_body)
 
-        print('id:', id_no)
-        print('slug:', slug)
-        print('title:', title)
-        print('new_title:', self.get_or_default(meta_data, 'title', None))
         kernel_push_request = KernelPushRequest(
             id=id_no,
             slug=slug,

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -1631,7 +1631,9 @@ class KaggleApi(KaggleApi):
         else:
             print('No kernels found')
 
-    def kernels_initialize(self, folder):
+    def kernels_initialize(self, folder, slug, title, code_file,
+                           language, k_type, is_private, gpu, internet,
+                           datasets, competitions, kernels):
         """ create a new kernel in a specified folder from template, including
             json metadata that grabs values from the configuration.
              Parameters
@@ -1647,17 +1649,17 @@ class KaggleApi(KaggleApi):
 
         username = self.get_config_value(self.CONFIG_NAME_USER)
         meta_data = {
-            'id': username + '/INSERT_KERNEL_SLUG_HERE',
-            'title': 'INSERT_TITLE_HERE',
-            'code_file': 'INSERT_CODE_FILE_PATH_HERE',
-            'language': 'INSERT_LANGUAGE_HERE',
-            'kernel_type': 'INSERT_KERNEL_TYPE_HERE',
-            'is_private': 'true',
-            'enable_gpu': 'false',
-            'enable_internet': 'false',
-            'dataset_sources': [],
-            'competition_sources': [],
-            'kernel_sources': [],
+            'id': username + '/' + slug,
+            'title': title,
+            'code_file': code_file,
+            'language': language,
+            'kernel_type': k_type,
+            'is_private': is_private,
+            'enable_gpu': gpu,
+            'enable_internet': internet,
+            'dataset_sources': datasets,
+            'competition_sources': competitions,
+            'kernel_sources': kernels
         }
         meta_file = os.path.join(folder, self.KERNEL_METADATA_FILE)
         with open(meta_file, 'w') as f:
@@ -1665,7 +1667,9 @@ class KaggleApi(KaggleApi):
 
         return meta_file
 
-    def kernels_initialize_cli(self, folder=None):
+    def kernels_initialize_cli(self, folder, slug, title, code_file, language,
+                               k_type, public, gpu, internet, datasets,
+                               competitions, kernels):
         """ client wrapper for kernels_initialize, takes same arguments but
             sets default folder to be None. If None, defaults to present
             working directory.
@@ -1674,7 +1678,11 @@ class KaggleApi(KaggleApi):
             folder: the path of the folder (None defaults to ${PWD})
         """
         folder = folder or os.getcwd()
-        meta_file = self.kernels_initialize(folder)
+        is_private = 'false' if public else 'true'
+        meta_file = self.kernels_initialize(folder, slug, title, code_file,
+                                            language, k_type, is_private, gpu,
+                                            internet, datasets, competitions,
+                                            kernels)
         print('Kernel metadata template written to: ' + meta_file)
 
     def kernels_push(self, folder):

--- a/kaggle/cli.py
+++ b/kaggle/cli.py
@@ -711,7 +711,95 @@ def parse_kernels(subparsers):
         '--path',
         dest='folder',
         required=False,
+        default=None,
         help=Help.param_kernel_upfile)
+    parser_kernels_init_optional.add_argument(
+        '-s',
+        '--slug',
+        dest='slug',
+        required=False,
+        default='INSERT_KERNEL_SLUG_HERE',
+        help=Help.param_kernel_init_slug)
+    parser_kernels_init_optional.add_argument(
+        '-t',
+        '--title',
+        dest='title',
+        required=False,
+        default='INSERT_TITLE_HERE',
+        help=Help.param_kernel_init_title)
+    parser_kernels_init_optional.add_argument(
+        '-f',
+        '--code-file',
+        dest='code_file',
+        required=False,
+        default='INSERT_CODE_FILE_PATH_HERE',
+        help=Help.param_kernel_init_code_file)
+    parser_kernels_init_optional.add_argument(
+        '-l',
+        '--language',
+        dest='language',
+        required=False,
+        choices=['r', 'rmarkdown', 'python'],
+        default='INSERT_LANGUAGE_HERE',
+        help=Help.param_kernel_init_language)
+    parser_kernels_init_optional.add_argument(
+        '-e',
+        '--type',
+        dest='k_type',
+        required=False,
+        choices=['script', 'notebook'],
+        default='INSERT_KERNEL_TYPE_HERE',
+        help=Help.param_kernel_init_script)
+    parser_kernels_init_optional.add_argument(
+        '-b',
+        '--public',
+        dest='public',
+        required=False,
+        default=False,
+        action='store_true',
+        help=Help.param_kernel_init_public)
+    parser_kernels_init_optional.add_argument(
+        '-g',
+        '--gpu',
+        dest='gpu',
+        required=False,
+        default='false',
+        action='store_const',
+        const='true',
+        help=Help.param_kernel_init_gpu)
+    parser_kernels_init_optional.add_argument(
+        '-i',
+        '--internet',
+        dest='internet',
+        required=False,
+        default='false',
+        action='store_const',
+        const='true',
+        help=Help.param_kernel_init_internet)
+    parser_kernels_init_optional.add_argument(
+        '-d',
+        '--datasets',
+        dest='datasets',
+        required=False,
+        nargs='*',
+        default=[],
+        help=Help.param_kernel_init_datasets)
+    parser_kernels_init_optional.add_argument(
+        '-c',
+        '--competitions',
+        dest='competitions',
+        required=False,
+        nargs='*',
+        default=[],
+        help=Help.param_kernel_init_comp)
+    parser_kernels_init_optional.add_argument(
+        '-k',
+        '--kernels',
+        dest='kernels',
+        required=False,
+        nargs='*',
+        default=[],
+        help=Help.param_kernel_init_kernels)
     parser_kernels_init._action_groups.append(parser_kernels_init_optional)
     parser_kernels_init.set_defaults(func=api.kernels_initialize_cli)
 
@@ -1047,6 +1135,17 @@ class Help(object):
         'special kernel-metadata.json file '
         '(https://github.com/Kaggle/kaggle-api/wiki/Kernel-Metadata). '
         'Defaults to current working directory')
+    param_kernel_init_slug = 'kernel slug, what comes after the `username/`, default: kernel title slug'
+    param_kernel_init_title = 'kernel title, must be more than 5 characters and less or equal to 50 characters long'
+    param_kernel_init_code_file = 'code file filename'
+    param_kernel_init_language = 'set kernel programming language'
+    param_kernel_init_script = 'set kernel type to script, default: notebook'
+    param_kernel_init_public = 'make the kernel public, default private'
+    param_kernel_init_gpu = 'enable GPU training for the kernel, default: False'
+    param_kernel_init_internet = 'enable internet access for kernel, default: False'
+    param_kernel_init_datasets = 'add kernel data sources from kaggle datasets'
+    param_kernel_init_comp = 'add kernel data source from competitions'
+    param_kernel_init_kernels = 'add kernel data sources from kernel output'
     param_kernel_parent = 'Find children of the specified parent kernel'
     param_kernel_competition = 'Find kernels for a given competition slug'
     param_kernel_dataset = ('Find kernels for a given dataset slug. Format is '

--- a/kaggle/cli.py
+++ b/kaggle/cli.py
@@ -749,7 +749,7 @@ def parse_kernels(subparsers):
         required=False,
         choices=['script', 'notebook'],
         default='INSERT_KERNEL_TYPE_HERE',
-        help=Help.param_kernel_init_script)
+        help=Help.param_kernel_init_type)
     parser_kernels_init_optional.add_argument(
         '-b',
         '--public',
@@ -1139,10 +1139,10 @@ class Help(object):
     param_kernel_init_title = 'kernel title, must be more than 5 characters and less or equal to 50 characters long'
     param_kernel_init_code_file = 'code file filename'
     param_kernel_init_language = 'set kernel programming language'
-    param_kernel_init_script = 'set kernel type to script, default: notebook'
+    param_kernel_init_type = 'set kernel type to script or notebook'
     param_kernel_init_public = 'make the kernel public, default private'
     param_kernel_init_gpu = 'enable GPU training for the kernel, default: False'
-    param_kernel_init_internet = 'enable internet access for kernel, default: False'
+    param_kernel_init_internet = 'enable internet access for kernel, default: false'
     param_kernel_init_datasets = 'add kernel data sources from kaggle datasets'
     param_kernel_init_comp = 'add kernel data source from competitions'
     param_kernel_init_kernels = 'add kernel data sources from kernel output'


### PR DESCRIPTION
## Part 1

When you try to push a kernel with a name that is longer than 50 characters you will receive this error message:

> 500 - An internal server error occurred. Please ensure that your API client is up to date. If it is, please report a bug at github.com/Kaggle/kaggle-api

The error message is misleading and the real reason for the failure of the request is that the kernel name, defined in the metadata file, is longer than 50 character.

## Part 2:

I have added 11 optional arguments to the command `kaggle kernels init`:

* -s --slug: kernel slug, what comes after the `username/`, default: kernel title slug
* -t --title: kernel title, must be more than 5 characters and less or equal to 50 characters long
* -f --cold-file: code file filename
* -l --language: set kernel programming language
* -e --type: set kernel type to script or notebook
* -b --public: make the kernel public, default private
* -g --gpu: enable GPU training for the kernel, default: false
* -i --internet: enable internet access for kernel, default: false
* -d --datasets: add kernel data sources from kaggle datasets, you can add multiple datasets, separated by space
* -c --competitions: add kernel data source from competitions, you can add multiple values separated by space
* -k --kernels: add kernel data sources from kernel outputs, you can add multiple values separated by space

**This feature is backward compatible**, meaning if you run the command `kaggle kernels init` without specifying any of the new arguments you will get exactly the same result as before.

---

*I apologize for the non-specific pull requests, this is my first open source contribution, and I didn't think that pushing to master branch will automatically add the new commits to the pull requests. Next time I should use a different branch for pull requests.*
