### PR TITLE
Update filename for license

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include LICENSE.txt
+include LICENSE


### PR DESCRIPTION
The filename for [`LICENSE`](https://github.com/Kaggle/kaggle-api/blob/master/LICENSE) does not currently match what is in [`MANIFEST.in`](https://github.com/Kaggle/kaggle-api/blob/master/MANIFEST.in#L1).