### PR TITLE
Unzip files after download for kaggle competitions command

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ optional arguments:
   -w, --wp              Download files to current working path
   -o, --force           Skip check whether local version of file is up to date, force file download
   -q, --quiet           Suppress printing information about the upload/download progress
-  -z, --unzip           Unzip downloaded competition files in format on data page of competition
+  -z, --unzip           Unzip downloaded zip files
 ```
 
 Examples:

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ optional arguments:
   -w, --wp              Download files to current working path
   -o, --force           Skip check whether local version of file is up to date, force file download
   -q, --quiet           Suppress printing information about the upload/download progress
+  -z, --unzip           Unzip downloaded competition files in format on data page of competition
 ```
 
 Examples:

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -710,10 +710,16 @@ class KaggleApi(KaggleApi):
         if force or self.download_needed(response, outfile, quiet):
             self.download_file(response, outfile, quiet)
         if unzip:
-            import glob
-            for zip_file in glob.glob(effective_path+"/*.zip"):
-                with zipfile.ZipFile(zip_file, 'r') as zipped:
-                    zipped.extractall("./"+zip_file[:-4])
+            import fnmatch
+            for file in os.listdir(effective_path):
+                if fnmatch.fnmatch(file, "*.zip"):
+                    with zipfile.ZipFile(os.path.join(effective_path, file), 'r') as zipped:
+                        zipped.extractall("./"+file[:-4])
+            for root, dirs, files in os.walk(effective_path):
+                for filename in file:
+                    if fnmatch.fnmatch(filename, "*.zip"):
+                        with zipfile.ZipFile(os.path.join(root, dirs, filename), 'r') as zipped:
+                            zipped.extractall(os.path.join(root, dirs, filename[:-4]))
 
 
     def competition_download_cli(self,

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -101,7 +101,7 @@ class KaggleApi(KaggleApi):
         'scoreAscending', 'scoreDescending', 'viewCount', 'voteCount'
     ]
 
-    # Competitoins valid types
+    # Competitions valid types
     valid_competition_groups = ['general', 'entered', 'inClass']
     valid_competition_categories = [
         'all', 'featured', 'research', 'recruitment', 'gettingStarted',
@@ -661,6 +661,7 @@ class KaggleApi(KaggleApi):
             path: a path to download the file to
             force: force the download if the file already exists (default False)
             quiet: suppress verbose output (default is False)
+            unzip: unzip zip files to format found on competitions page on Kaggle
         """
         if path is None:
             effective_path = self.get_default_download_dir(
@@ -675,13 +676,14 @@ class KaggleApi(KaggleApi):
         outfile = os.path.join(effective_path, url.split('/')[-1])
 
         if force or self.download_needed(response, outfile, quiet):
-            self.download_file(response, outfile, quiet)
+            self.download_file(response, outfile, quiet, unzip)
 
     def competition_download_files(self,
                                    competition,
                                    path=None,
                                    force=False,
-                                   quiet=True):
+                                   quiet=True,
+                                   unzip=False):
         """ downloads all competition files.
 
             Parameters
@@ -690,6 +692,7 @@ class KaggleApi(KaggleApi):
             path: a path to download the file to
             force: force the download if the file already exists (default False)
             quiet: suppress verbose output (default is True)
+            unzip: unzip zip files to format found on competitions page on Kaggle
         """
         if path is None:
             effective_path = self.get_default_download_dir(
@@ -706,6 +709,12 @@ class KaggleApi(KaggleApi):
 
         if force or self.download_needed(response, outfile, quiet):
             self.download_file(response, outfile, quiet)
+        if unzip:
+            import glob
+            for zipfile in glob.glob(effective_path+"/*.zip"):
+                with zipfile.Zipfile(zipfile, 'r') as zipped:
+                    zipped.extract_all(effective_path+"/"+zipfile)
+
 
     def competition_download_cli(self,
                                  competition,
@@ -713,7 +722,8 @@ class KaggleApi(KaggleApi):
                                  file_name=None,
                                  path=None,
                                  force=False,
-                                 quiet=False):
+                                 quiet=False,
+                                 unzip=False):
         """ a wrapper to competition_download_files, but first will parse input
             from API client. Additional parameters are listed here, see
             competition_download for remaining.
@@ -726,6 +736,7 @@ class KaggleApi(KaggleApi):
             path: a path to download the file to
             force: force the download if the file already exists (default False)
             quiet: suppress verbose output (default is False)
+            unzip: unzip zip files to format found on competitions page on Kaggle
         """
         competition = competition or competition_opt
         if competition is None:
@@ -738,7 +749,7 @@ class KaggleApi(KaggleApi):
         else:
             if file_name is None:
                 self.competition_download_files(competition, path, force,
-                                                quiet)
+                                                quiet, unzip)
             else:
                 self.competition_download_file(competition, file_name, path,
                                                force, quiet)

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -711,9 +711,9 @@ class KaggleApi(KaggleApi):
             self.download_file(response, outfile, quiet)
         if unzip:
             import glob
-            for zipfile in glob.glob(effective_path+"/*.zip"):
-                with zipfile.Zipfile(zipfile, 'r') as zipped:
-                    zipped.extract_all(effective_path+"/"+zipfile)
+            for zip_file in glob.glob(effective_path+"/*.zip"):
+                with zipfile.ZipFile(zip_file, 'r') as zipped:
+                    zipped.extractall("./"+zip_file[:-4])
 
 
     def competition_download_cli(self,

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -713,14 +713,18 @@ class KaggleApi(KaggleApi):
             import fnmatch
             for file in os.listdir(effective_path):
                 if fnmatch.fnmatch(file, "*.zip"):
-                    with zipfile.ZipFile(os.path.join(effective_path, file), 'r') as zipped:
+                    filepath=os.path.join(effective_path, file)
+                    with zipfile.ZipFile(filepath, 'r') as zipped:
                         zipped.extractall(os.path.join(effective_path,file[:-4]))
+                    os.remove(filepath)
             for dirname, _, filenames in os.walk(effective_path):
                 for filename in filenames:
                     if fnmatch.fnmatch(filename, "*.zip"):
                         print("Unzipping", filename)
-                        with zipfile.ZipFile(os.path.join(dirname, filename), 'r') as zipped:
+                        filepath=os.path.join(dirname, filename)
+                        with zipfile.ZipFile(filepath, 'r') as zipped:
                             zipped.extractall(dirname)
+                        os.remove(filepath)
 
 
     def competition_download_cli(self,

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -714,12 +714,13 @@ class KaggleApi(KaggleApi):
             for file in os.listdir(effective_path):
                 if fnmatch.fnmatch(file, "*.zip"):
                     with zipfile.ZipFile(os.path.join(effective_path, file), 'r') as zipped:
-                        zipped.extractall("./"+file[:-4])
+                        zipped.extractall(os.path.join(effective_path,file[:-4]))
             for dirname, _, filenames in os.walk(effective_path):
                 for filename in filenames:
                     if fnmatch.fnmatch(filename, "*.zip"):
+                        print("Unzipping", filename)
                         with zipfile.ZipFile(os.path.join(dirname, filename), 'r') as zipped:
-                            zipped.extractall(os.path.join(dirname, filename[:-4]))
+                            zipped.extractall(dirname)
 
 
     def competition_download_cli(self,

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -715,11 +715,11 @@ class KaggleApi(KaggleApi):
                 if fnmatch.fnmatch(file, "*.zip"):
                     with zipfile.ZipFile(os.path.join(effective_path, file), 'r') as zipped:
                         zipped.extractall("./"+file[:-4])
-            for root, dirs, files in os.walk(effective_path):
-                for filename in file:
+            for dirname, _, filenames in os.walk(effective_path):
+                for filename in filenames:
                     if fnmatch.fnmatch(filename, "*.zip"):
-                        with zipfile.ZipFile(os.path.join(root, dirs, filename), 'r') as zipped:
-                            zipped.extractall(os.path.join(root, dirs, filename[:-4]))
+                        with zipfile.ZipFile(os.path.join(dirname, filename), 'r') as zipped:
+                            zipped.extractall(os.path.join(dirname, filename[:-4]))
 
 
     def competition_download_cli(self,

--- a/kaggle/cli.py
+++ b/kaggle/cli.py
@@ -198,6 +198,11 @@ def parse_competitions(subparsers):
                                                        dest='quiet',
                                                        action='store_true',
                                                        help=Help.param_quiet)
+    parser_competitions_download_optional.add_argument('-z',
+                                                       '--unzip',
+                                                       dest='unzip',
+                                                       action='store_true' ,
+                                                       help=Help.param_unzip)
     parser_competitions_download._action_groups.append(
         parser_competitions_download_optional)
     parser_competitions_download.set_defaults(
@@ -451,10 +456,6 @@ def parse_datasets(subparsers):
                                                    const='.',
                                                    required=False,
                                                    help=Help.param_wp)
-    parser_datasets_download_optional.add_argument('--unzip',
-                                                   dest='unzip',
-                                                   action='store_true',
-                                                   help=Help.param_unzip)
     parser_datasets_download_optional.add_argument('-o',
                                                    '--force',
                                                    dest='force',
@@ -465,6 +466,10 @@ def parse_datasets(subparsers):
                                                    dest='quiet',
                                                    action='store_true',
                                                    help=Help.param_quiet)
+    parser_datasets_download_optional.add_argument('--unzip',
+                                                   dest='unzip',
+                                                   action='store_true',
+                                                   help=Help.param_unzip)
     parser_datasets_download._action_groups.append(
         parser_datasets_download_optional)
     parser_datasets_download.set_defaults(func=api.dataset_download_cli)
@@ -945,6 +950,7 @@ class Help(object):
     param_proxy = 'Proxy for HTTP requests'
     param_quiet = (
         'Suppress printing information about the upload/download progress')
+    param_unzip = 'Unzip files into competition file structure on Kaggle'
     param_public = 'Create publicly (default is private)'
     param_keep_tabular = (
         'Do not convert tabular files to CSV (default is to convert)')

--- a/kaggle/cli.py
+++ b/kaggle/cli.py
@@ -950,7 +950,7 @@ class Help(object):
     param_proxy = 'Proxy for HTTP requests'
     param_quiet = (
         'Suppress printing information about the upload/download progress')
-    param_unzip = 'Unzip files into competition file structure on Kaggle'
+    param_unzip = 'Unzip downloaded zip files automatically'
     param_public = 'Create publicly (default is private)'
     param_keep_tabular = (
         'Do not convert tabular files to CSV (default is to convert)')


### PR DESCRIPTION
Fixes #9 and Fixes #158 
This PR adds a flag to the Kaggle competitions download command that unzips all downloaded zip files into the format found on the competitions data page. 

Tested with Python 3 and Aerial Cactus Identification competition. 