### PR TITLE
Updated urllib3 version restrictions to match requests dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,8 @@ setup(
     keywords=['Kaggle', 'API'],
     entry_points={'console_scripts': ['kaggle = kaggle.cli:main']},
     install_requires=[
-        # Restriction that urllib3's version is less than 1.25 needed to avoid
-        # requests dependency problem.
-        'urllib3 >= 1.21.1, < 1.25',
+        # requests dependency has restrictions on urllib3 versions
+        'urllib3 >= 1.21.1, < 1.26, != 1.25.0, != 1.25.1',
         'six >= 1.10',
         'certifi',
         'python-dateutil',


### PR DESCRIPTION
This modifies urllib3 version restrictions to >=1.21.1, <1.26, !=1.25.0, !=1.25.1 to [match requests](https://github.com/psf/requests/blob/master/setup.py).

Looks like the version restriction change was approved in [#204](https://github.com/Kaggle/kaggle-api/pull/204), but wasn't merged and is now out of date, if I'm reading correctly.