### PR TITLE
Remove version pin for urllib3.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,6 @@ setup(
     keywords=['Kaggle', 'API'],
     entry_points={'console_scripts': ['kaggle = kaggle.cli:main']},
     install_requires=[
-        # Restriction that urllib3's version is less than 1.25 needed to avoid
-        # requests dependency problem.
-        'urllib3 >= 1.21.1, < 1.25',
         'six >= 1.10',
         'certifi',
         'python-dateutil',
@@ -41,6 +38,7 @@ setup(
         'tqdm',
         'python-slugify',
         'slugify',
+        'urllib3',
     ],
     packages=find_packages(),
     license='Apache 2.0')


### PR DESCRIPTION
The incompatibility with between the `requests` and `urllib3` package
has been fixed starting with 1.25.2: https://github.com/psf/requests/blob/master/setup.py#L47

Removing the pin entirely and let the restriction from `requests`
package apply.

This is required to fix the `docker-python` build. See linked bug below for context.

Testing:

```
$ docker run -it --rm -v ~/.kaggle/kaggle.json:/root/.kaggle/kaggle.json:ro -v ~/git/kaggle-api:/kaggle-api gcr.io/kaggle-images/python:latest /bin/bash
# the following commands were ran inside the container ^
pip install /kaggle-api/
pip install --upgrade urllib3
# this method is using the requests package: https://github.com/Kaggle/kaggle-api/blob/master/kaggle/api/kaggle_api_extended.py#L2134
kaggle kernels output ryanholbrook/create-your-first-submission
# succeeded with: 
# > Output file downloaded to /kaggle-api/submission.csv
# > Kernel log downloaded to /kaggle-api/create-your-first-submission.log
```

http://b/171353173