### PR TITLE
remove a python2 conflict with python-slugify

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
         'requests',
         'tqdm',
         'python-slugify',
-        'slugify',
         'urllib3',
     ],
     packages=find_packages(),


### PR DESCRIPTION
The antiquated python2-only library `slugify-0.0.1` was added in bc19055 @jplotts 

Not clear if just removing it breaks the universe, but leaving it in broke my little corner with errors identical to #299 .