### PR TITLE
Updated kaggle_api_extended.py to support Python 2.7

### DIFF
--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -2133,7 +2133,8 @@ class KaggleApi(KaggleApi):
             outfiles.append(outfile)
             download_response = requests.get(item['url'])
             if force or self.download_needed(item, outfile, quiet):
-                os.makedirs(os.path.split(outfile)[0], exist_ok=True)
+                if not os.path.exists(os.path.split(outfile)[0]):
+                    os.makedirs(os.path.split(outfile)[0])
                 with open(outfile, 'wb') as out:
                     out.write(download_response.content)
                 if not quiet:


### PR DESCRIPTION
Python 2 function for `os.makedirs` doesn't support argument `exist_ok=True`. To extend the API to include python2, kaggle_api_extended.py has been updated to support the Python2 versions. The code also works in Python 3. 