### PR TITLE
Allow to specify dataset version number to download.

### DIFF
--- a/kaggle/api/kaggle_api.py
+++ b/kaggle/api/kaggle_api.py
@@ -1447,7 +1447,7 @@ class KaggleApi(object):
             path_params['datasetSlug'] = params['dataset_slug']  # noqa: E501
 
         query_params = []
-        if 'dataset_version_number' in params:
+        if 'dataset_version_number' in params and params['dataset_version_number'] is not None:
             query_params.append(('datasetVersionNumber', params['dataset_version_number']))  # noqa: E501
 
         header_params = {}
@@ -1560,7 +1560,7 @@ class KaggleApi(object):
             path_params['fileName'] = params['file_name']  # noqa: E501
 
         query_params = []
-        if 'dataset_version_number' in params:
+        if 'dataset_version_number' in params and params['dataset_version_number'] is not None:
             query_params.append(('datasetVersionNumber', params['dataset_version_number']))  # noqa: E501
 
         header_params = {}

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -1191,6 +1191,8 @@ class KaggleApi(KaggleApi):
         url = response.retries.history[0].redirect_location.split('?')[0]
         outfile = os.path.join(effective_path, url.split('/')[-1])
         if force or self.download_needed(response, outfile, quiet):
+            if not quiet:
+                print(f'Downloading from {owner_slug}/{dataset_slug}, version {version or version_slug or "latest"}')
             self.download_file(response, outfile, quiet)
             return True
         else:
@@ -1241,6 +1243,8 @@ class KaggleApi(KaggleApi):
 
         outfile = os.path.join(effective_path, dataset_slug + '.zip')
         if force or self.download_needed(response, outfile, quiet):
+            if not quiet:
+                print(f'Downloading from {owner_slug}/{dataset_slug}, version {version or version_slug or "latest"}')
             self.download_file(response, outfile, quiet)
             downloaded = True
         else:

--- a/kaggle/cli.py
+++ b/kaggle/cli.py
@@ -449,6 +449,11 @@ def parse_datasets(subparsers):
                                                    dest='dataset_opt',
                                                    required=False,
                                                    help=argparse.SUPPRESS)
+    parser_datasets_download_optional.add_argument('-v',
+                                                   '--version',
+                                                   dest='version',
+                                                   required=False,
+                                                   help=Help.param_dataset_version)
     parser_datasets_download_optional.add_argument(
         '-f',
         '--file',
@@ -1010,8 +1015,10 @@ class Help(object):
 
     # Datasets paramas
     param_dataset = (
-        'Dataset URL suffix in format <owner>/<dataset-name> (use '
+        'Dataset URL suffix in format <owner>/<dataset-name>[/version/<version-number>] (use '
         '"kaggle datasets list" to show options)')
+    param_dataset_version = (
+        'Dataset version number (if not provided, latest will be used)')
     param_dataset_file = (
         'File name, all files downloaded if not provided\n(use '
         '"kaggle datasets files -d <dataset>" to show options)')


### PR DESCRIPTION
To download a specific version of a dataset one can use either of the following commands.
To align with URLs formatting:
`https://www.kaggle.com/username/datasetname/version/2`
```bash
kaggle datasets download username/datasetname/version/2
```
```bash
kaggle datasets download username/datasetname -v 2
```
```bash
kaggle datasets download username/datasetname --version 2
```