### PR TITLE
fix competitions leaderboard download for stream contents

### DIFF
--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -1581,7 +1581,10 @@ class KaggleApi(KaggleApi):
         outpath = os.path.dirname(outfile)
         if not os.path.exists(outpath):
             os.makedirs(outpath)
-        size = int(response.headers['Content-Length'])
+        if 'Content-Length' not in response.headers:
+            size=chunk_size
+        else:
+            size = int(response.headers['Content-Length'])
         size_read = 0
         if not quiet:
             print('Downloading ' + os.path.basename(outfile) + ' to ' +


### PR DESCRIPTION
`kaggle competitions leaderboard favorita-grocery-sales-forecasting -d` returns stream data and it raises a key error on `size = int(response.headers['Content-Length'])` because server doesn't return  'Content-Length' in `headers`.