### PR TITLE
allow call with `python -m kaggle`

### DIFF
--- a/kaggle/__main__.py
+++ b/kaggle/__main__.py
@@ -1,0 +1,4 @@
+from kaggle.cli import main
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     author_email='support@kaggle.com',
     url='https://github.com/Kaggle/kaggle-api',
     keywords=['Kaggle', 'API'],
-    entry_points={'console_scripts': ['kaggle = kaggle.cli:main']},
+    entry_points={'console_scripts': ['kaggle = kaggle.__main__:main']},
     install_requires=[
         'six >= 1.10',
         'certifi',


### PR DESCRIPTION
In some environments it is lot allowed to install to bin or when it is installed it not updated within the particular run, so allowing calling Kaggle as python method overcome this limitation