### PR TITLE
Add project links to the pypi page

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,11 @@ setup(
     author='Kaggle',
     author_email='support@kaggle.com',
     url='https://github.com/Kaggle/kaggle-api',
+    project_urls={
+        'Documentation': 'https://www.kaggle.com/docs/api',
+        'GitHub': 'https://github.com/Kaggle/kaggle-api',
+        'Tracker': 'https://github.com/Kaggle/kaggle-api/issues',
+    },
     keywords=['Kaggle', 'API'],
     entry_points={'console_scripts': ['kaggle = kaggle.cli:main']},
     install_requires=[


### PR DESCRIPTION
The official URLs will be added to the Project links section in the [pypi page](https://pypi.org/project/kaggle/).