### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Supported Versions
+
+Security updates are applied only to the latest release.
+
+## Reporting a Vulnerability
+
+If you have discovered a security vulnerability in this project, please report it privately. **Do not disclose it as a public issue.** This gives us time to work with you to fix the issue before public exposure, reducing the chance that the exploit will be used before a patch is released.
+
+Please disclose it at [security advisory](https://github.com/Kaggle/kaggle-api/security/advisories/new).
+
+The vulnerabilities will be addressed as soon as possible, with a maximum of 90 days before a public exposure.


### PR DESCRIPTION
Closes #527 

As per the linked issue, this PR adds a security policy to the repository.

The policy currently requests that vulnerabilities be reported to GitHub's [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/repository-security-advisories/configuring-private-vulnerability-reporting-for-a-repository) feature.

This feature should be enabled in order for it to start working:
1. Open the repo's settings
2. Click on [Code security & analysis](https://github.com/Kaggle/kaggle-api/settings/security_analysis)
3. Click "Enable" for "Private vulnerability reporting (Beta)"

Let me know if there are any changes you'd like to make to the security policy to be more precise.
