### PR TITLE
Bootstrap integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,19 @@ hello Kaggle CLI update
 Next Page Token = [...]
 ```
 
+### Integration Tests
+
+To run integration tests on your local machine, you need to set up your Kaggle API credentials. You can do this in one of these two ways described in the earlier sections of this document. Refer to the sections: 
+- [Using environment variables](#option-2-read-credentials-from-environment-variables)
+- [Using credentials file](#option-3-read-credentials-from-kagglejson)
+
+After setting up your credentials by any of these methods, you can run the integration tests as follows:
+
+```sh
+# Run all tests
+hatch run integration-test
+```
+
 ## License
 
 The Kaggle API is released under the [Apache 2.0 license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ Next Page Token = [...]
 
 ### Integration Tests
 
-To run integration tests on your local machine, you need to set up your Kaggle API credentials. You can do this in one of these two ways described in the earlier sections of this document. Refer to the sections: 
-- [Using environment variables](#option-2-read-credentials-from-environment-variables)
-- [Using credentials file](#option-3-read-credentials-from-kagglejson)
+To run integration tests on your local machine, you need to set up your Kaggle API credentials. You can do this in one of these two ways described [this doc](docs/README.md). Refer to the sections: 
+- Using environment variables
+- Using credentials file
 
 After setting up your credentials by any of these methods, you can run the integration tests as follows:
 

--- a/integration_tests/test_models.py
+++ b/integration_tests/test_models.py
@@ -1,0 +1,22 @@
+import os
+import unittest
+from typing import List
+
+from kaggle.api.kaggle_api_extended import KaggleApi
+
+MODEL_HANDLE = "keras/bert"
+MODEL_ID = 2819
+
+
+class TestModels(unittest.TestCase):
+    def setUp(self):
+        self.api = KaggleApi()
+        self.api.authenticate()
+
+    def test_list_models(self) -> None:
+        models = self.api.model_list()
+        self.assertGreater(len(models), 0)
+
+    def test_get_model(self) -> None:
+        model = self.api.model_get(MODEL_HANDLE)
+        self.assertEqual(MODEL_ID, model['id'])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,11 @@ dependencies = [
 [tool.hatch.version]
 path = "src/__init__.py"
 
+[tool.hatch.envs.default]
+dependencies = [
+  "pytest",
+]
+
 [tool.hatch.envs.default.scripts]
 install-autogen = """curl -fsSL --output /tmp/autogen.zip "https://github.com/mbrukman/autogen/archive/refs/heads/master.zip" && 
   rm -rf /tmp/autogen && mkdir -p /tmp/autogen && unzip -qo /tmp/autogen.zip -d /tmp/autogen && 
@@ -51,6 +56,8 @@ install-autogen = """curl -fsSL --output /tmp/autogen.zip "https://github.com/mb
 # TODO: install in Mac/Windows
 install-yapf = """sudo apt-get install -y yapf3 python3-yapf || echo 'yapf could not be installed'"""
 install-deps = "hatch run install-autogen && hatch run install-yapf"
+
+integration-test = "pytest {args:integration_tests}"
 
 compile = "./tools/GeneratePythonLibrary.sh"
 install = "./tools/GeneratePythonLibrary.sh --install"

--- a/tools/cicd/integration-tests.yaml
+++ b/tools/cicd/integration-tests.yaml
@@ -1,0 +1,28 @@
+steps:
+   # Access and store the secret in a file on a shared volume
+  - name: 'gcr.io/cloud-builders/gcloud'
+    id: 'download-secrets'
+    script: |
+      #!/usr/bin/env bash
+      gcloud secrets versions access latest --secret=integration-tests --project=464139560241 > /root/secrets.sh
+    volumes:
+    - name: 'root'
+      path: /root
+
+
+  # Source the secrets and run integration tests using the built Python image
+  - name: us-docker.pkg.dev/$PROJECT_ID/tools/hatch:$_PYTHON_VERSION
+    id: integration-tests
+    waitFor: ['download-secrets']
+    script: |
+      #!/usr/bin/env bash
+      export KAGGLE_USERNAME
+      export KAGGLE_KEY
+      source /root/secrets.sh
+      hatch run integration-test
+    volumes:
+    - name: 'root'
+      path: /root
+
+substitutions:
+  _PYTHON_VERSION: '3.11'


### PR DESCRIPTION
It uses the same setup as for kagglehub, and the same secrets.

Next: add a GCB trigger to run these tests on every PR

Obviously, the next big step is to test more surface of the CLI.

http://b/319074155