### PR TITLE
Fix GeneratePythonLibrary.sh script flow (`hatch run compile`)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,12 @@ dependencies = [
   "webencodings"
 ]
 
+[project.scripts]
+kaggle = "kaggle.cli:main"
+
 [project.urls]
-"Homepage" = "https://github.com/Kaggle/kaggle-api"
-"Bug Tracker" = "https://github.com/Kaggle/kaggle-api/issues"
+Homepage = "https://github.com/Kaggle/kaggle-api"
+Issues = "https://github.com/Kaggle/kaggle-api/issues"
 
 [tool.hatch.version]
 path = "src/__init__.py"

--- a/tools/GeneratePythonLibrary.sh
+++ b/tools/GeneratePythonLibrary.sh
@@ -118,7 +118,7 @@ function generate-from-swagger {
   if [[ -f "kaggle/configuration.py" ]]; then
     # Replace the hard-coded endpoint URL with an environment variable in configuration.py
     # to allow talking to localhost, staging, prod etc.
-    sed -i .bak 's|self.host = "http|self.host = _get_endpoint_from_env() or "http|g' kaggle/configuration.py
+    sed -i 's|self.host = "http|self.host = _get_endpoint_from_env() or "http|g' kaggle/configuration.py
     echo -e "\n" >> kaggle/configuration.py
     cat <<-END >> kaggle/configuration.py
 def _get_endpoint_from_env():


### PR DESCRIPTION
Issues:
- `hatch run install`: properly generate the CLI executable. http://b/333027353
- `hatch run compile` (`GeneratePythonLibrary.sh`) doesn't finish, and we're left with a mess of diffs.
![image](https://github.com/Kaggle/kaggle-api/assets/1621643/87ad2355-29ee-4469-ad92-873cd7b11816)

Fix:
  - I compared the script before and after move ([Webdiff](https://diff.googleplex.com/#key=8rusDEtbOkP2))
  - Auditing all line diffs, one line caused the error pictured above. It seems `sed -i .bak` doesn't work for all versions of `sed`, and it was crashing the script, preventing the full compile flow from running.
  - Some linux versions seem to require `sed -i.bak` (without the space). Removing the `.bak` functionality allowed the script to finish.
  - FWIW I think it's fine to not create backups of the modified files, because we're version controlled anyways. 🤷 

Screen capture of the flow after this change was made:
![k-api-compile-fixed](https://github.com/Kaggle/kaggle-api/assets/1621643/ee9c1674-8799-487a-8e56-940ffabb23ee)

note at the end there's no generated diffs compared to what's checked in! 🙌 