### PR TITLE
Restore lost changes from #540

### DIFF
--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -290,8 +290,17 @@ class KaggleApi(KaggleApi):
     MAX_NUM_INBOX_FILES_TO_UPLOAD = 1000
     MAX_UPLOAD_RESUME_ATTEMPTS = 10
 
-    config_dir = os.environ.get('KAGGLE_CONFIG_DIR') or os.path.join(
-        expanduser('~'), '.kaggle')
+    config_dir = os.environ.get('KAGGLE_CONFIG_DIR')
+
+    if not config_dir:
+        config_dir = os.path.join(expanduser('~'), '.kaggle')
+        # Use ~/.kaggle if it already exists for backwards compatibility,
+        # otherwise follow XDG base directory specification
+        if sys.platform.startswith('linux') and not os.path.exists(config_dir):
+            config_dir = os.path.join(
+                (os.environ.get('XDG_CONFIG_HOME')
+                 or os.path.join(expanduser('~'), '.config')), 'kaggle')
+
     if not os.path.exists(config_dir):
         os.makedirs(config_dir)
 

--- a/kaggle/test/test_authenticate.py
+++ b/kaggle/test/test_authenticate.py
@@ -51,7 +51,7 @@ class TestAuthenticate(unittest.TestCase):
     def test_config_actions(self):
         api = KaggleApi()
 
-        self.assertTrue(api.config_dir.endswith('.kaggle'))
+        self.assertTrue(api.config_dir.endswith('kaggle'))
         self.assertEqual(api.get_config_value('doesntexist'), None)
 
 

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -274,8 +274,17 @@ class KaggleApi(KaggleApi):
     MAX_NUM_INBOX_FILES_TO_UPLOAD = 1000
     MAX_UPLOAD_RESUME_ATTEMPTS = 10
 
-    config_dir = os.environ.get('KAGGLE_CONFIG_DIR') or os.path.join(
-        expanduser('~'), '.kaggle')
+    config_dir = os.environ.get('KAGGLE_CONFIG_DIR')
+
+    if not config_dir:
+        config_dir = os.path.join(expanduser('~'), '.kaggle')
+        # Use ~/.kaggle if it already exists for backwards compatibility,
+        # otherwise follow XDG base directory specification
+        if sys.platform.startswith('linux') and not os.path.exists(config_dir):
+            config_dir = os.path.join(
+                (os.environ.get('XDG_CONFIG_HOME')
+                 or os.path.join(expanduser('~'), '.config')), 'kaggle')
+
     if not os.path.exists(config_dir):
         os.makedirs(config_dir)
 

--- a/src/kaggle/test/test_authenticate.py
+++ b/src/kaggle/test/test_authenticate.py
@@ -35,7 +35,7 @@ class TestAuthenticate(unittest.TestCase):
     def test_config_actions(self):
         api = KaggleApi()
 
-        self.assertTrue(api.config_dir.endswith('.kaggle'))
+        self.assertTrue(api.config_dir.endswith('kaggle'))
         self.assertEqual(api.get_config_value('doesntexist'), None)
 
 


### PR DESCRIPTION
When I was working on the last release I had got myself into a mixed-up state with too many unexpectedly-changed files. It was easiest to restore files rather than edit them and I lost the changes in this PR. These were from an external contributor in PR #540.