### PR TITLE
Concatenate cells.source into a single string if it's a list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,3 @@ target/
 
 #Ipython Notebook
 .ipynb_checkpoints
-
-# Rider
-.idea

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -414,8 +414,8 @@ class KaggleApi(KaggleApi):
                 or self.CONFIG_NAME_KEY not in config_data:
             if os.path.exists(self.config):
                 config_data = self.read_config_file(config_data)
-            elif self._is_help_or_version_command(api_command) or (len(
-                    sys.argv) > 2 and api_command.startswith(
+            elif self._is_help_or_version_command(api_command) or (
+                    len(sys.argv) > 2 and api_command.startswith(
                         self.command_prefixes_allowing_anonymous_access)):
                 # Some API commands should be allowed without authentication.
                 return
@@ -2334,6 +2334,10 @@ class KaggleApi(KaggleApi):
                 for cell in json_body['cells']:
                     if 'outputs' in cell and cell['cell_type'] == 'code':
                         cell['outputs'] = []
+                    # The spec allows a list of strings,
+                    # but the server expects just one
+                    if 'source' in cell and isinstance(cell['source'], list):
+                        cell['source'] = ''.join(cell['source'])
             script_body = json.dumps(json_body)
 
         kernel_push_request = KernelPushRequest(

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -398,8 +398,8 @@ class KaggleApi(KaggleApi):
                 or self.CONFIG_NAME_KEY not in config_data:
             if os.path.exists(self.config):
                 config_data = self.read_config_file(config_data)
-            elif self._is_help_or_version_command(api_command) or (len(
-                    sys.argv) > 2 and api_command.startswith(
+            elif self._is_help_or_version_command(api_command) or (
+                    len(sys.argv) > 2 and api_command.startswith(
                         self.command_prefixes_allowing_anonymous_access)):
                 # Some API commands should be allowed without authentication.
                 return
@@ -2318,6 +2318,10 @@ class KaggleApi(KaggleApi):
                 for cell in json_body['cells']:
                     if 'outputs' in cell and cell['cell_type'] == 'code':
                         cell['outputs'] = []
+                    # The spec allows a list of strings,
+                    # but the server expects just one
+                    if 'source' in cell and isinstance(cell['source'], list):
+                        cell['source'] = ''.join(cell['source'])
             script_body = json.dumps(json_body)
 
         kernel_push_request = KernelPushRequest(


### PR DESCRIPTION
Confirmed this fixes https://github.com/Kaggle/kaggle-api/issues/574 by building locally and successfully pushing a file that'd been edited in VSCode.

Note that it looks like there was a recent commit that didn't include the generation/auto-formatting that runs w/ `hatch run compile`, that seems to be responsible for the changes in .gitignore and the moving of `len` down a line--those changes appeared after running `hatch compile` even before I'd made any edits. If you'd prefer, I can drop those changes from this PR. Just let me know.