### PR TITLE
Add missing model licenses.

### DIFF
--- a/src/KaggleSwagger.yaml
+++ b/src/KaggleSwagger.yaml
@@ -2046,7 +2046,6 @@ definitions:
           - CC0 1.0
           - CC0: Public Domain
           - CC BY-NC-SA 4.0
-          - Other
           - Unknown
           - CC BY-SA 4.0
           - GPL 2
@@ -2150,7 +2149,6 @@ definitions:
           - CC0 1.0
           - CC0: Public Domain
           - CC BY-NC-SA 4.0
-          - Other
           - Unknown
           - CC BY-SA 4.0
           - GPL 2

--- a/src/KaggleSwagger.yaml
+++ b/src/KaggleSwagger.yaml
@@ -2041,30 +2041,67 @@ definitions:
         type: string
         description: The license that should be associated with the model instance
         default: Apache 2.0
+        # Use go/kaggle-models-license-values-swagger to get the accepted values (both abbreviation & full name are accepted)
         enum:
+          - CC0 1.0
           - CC0: Public Domain
           - CC BY-NC-SA 4.0
+          - Other
+          - Unknown
           - CC BY-SA 4.0
           - GPL 2
           - CC BY-SA 3.0
+          - Other
+          - Other (specified in description)
+          - CC BY 4.0
           - Attribution 4.0 International (CC BY 4.0)
+          - CC BY-NC 4.0
           - Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)
+          - PDDL
           - ODC Public Domain Dedication and Licence (PDDL)
+          - CC BY 3.0
           - Attribution 3.0 Unported (CC BY 3.0)
+          - CC BY 3.0 IGO
           - Attribution 3.0 IGO (CC BY 3.0 IGO)
+          - CC BY-NC-SA 3.0 IGO
           - Attribution-NonCommercial-ShareAlike 3.0 IGO (CC BY-NC-SA 3.0 IGO)
+          - CDLA Permissive 1.0
           - Community Data License Agreement - Permissive - Version 1.0
+          - CDLA Sharing 1.0
           - Community Data License Agreement - Sharing - Version 1.0
+          - CC BY-ND 4.0
           - Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)
+          - CC BY-NC-ND 4.0
           - Attribution-NonCommercial-NoDerivatives 4.0 International (CC BY-NC-ND 4.0)
+          - ODC-BY 1.0
           - ODC Attribution License (ODC-By)
+          - LGPL 3.0
           - GNU Lesser General Public License 3.0
+          - AGPL 3.0
           - GNU Affero General Public License 3.0
+          - FDL 1.3
           - GNU Free Documentation License 1.3
+          - apache-2.0
           - Apache 2.0
+          - mit
           - MIT
+          - bsd-3-clause
           - BSD-3-Clause
+          - Llama 2
+          - Llama 2 Community License
+          - Gemma
+          - gpl-3
           - GPL 3
+          - RAIL-M
+          - AI Pubs Open RAIL-M License
+          - AIPubs Research-Use RAIL-M
+          - AI Pubs Research-Use RAIL-M License
+          - BigScience OpenRAIL-M
+          - BigScience Open RAIL-M License
+          - RAIL
+          - RAIL (specified in description)
+          - Llama 3
+          - Llama 3 Community License
       fineTunable:
         type: boolean
         description: Whether the model instance is fine tunable
@@ -2108,30 +2145,67 @@ definitions:
         type: string
         description: The license that should be associated with the model instance
         default: Apache 2.0
+        # Use go/kaggle-models-license-values-swagger to get the accepted values (both abbreviation & full name are accepted)
         enum:
+          - CC0 1.0
           - CC0: Public Domain
           - CC BY-NC-SA 4.0
+          - Other
+          - Unknown
           - CC BY-SA 4.0
           - GPL 2
           - CC BY-SA 3.0
+          - Other
+          - Other (specified in description)
+          - CC BY 4.0
           - Attribution 4.0 International (CC BY 4.0)
+          - CC BY-NC 4.0
           - Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)
+          - PDDL
           - ODC Public Domain Dedication and Licence (PDDL)
+          - CC BY 3.0
           - Attribution 3.0 Unported (CC BY 3.0)
+          - CC BY 3.0 IGO
           - Attribution 3.0 IGO (CC BY 3.0 IGO)
+          - CC BY-NC-SA 3.0 IGO
           - Attribution-NonCommercial-ShareAlike 3.0 IGO (CC BY-NC-SA 3.0 IGO)
+          - CDLA Permissive 1.0
           - Community Data License Agreement - Permissive - Version 1.0
+          - CDLA Sharing 1.0
           - Community Data License Agreement - Sharing - Version 1.0
+          - CC BY-ND 4.0
           - Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)
+          - CC BY-NC-ND 4.0
           - Attribution-NonCommercial-NoDerivatives 4.0 International (CC BY-NC-ND 4.0)
+          - ODC-BY 1.0
           - ODC Attribution License (ODC-By)
+          - LGPL 3.0
           - GNU Lesser General Public License 3.0
+          - AGPL 3.0
           - GNU Affero General Public License 3.0
+          - FDL 1.3
           - GNU Free Documentation License 1.3
+          - apache-2.0
           - Apache 2.0
+          - mit
           - MIT
+          - bsd-3-clause
           - BSD-3-Clause
+          - Llama 2
+          - Llama 2 Community License
+          - Gemma
+          - gpl-3
           - GPL 3
+          - RAIL-M
+          - AI Pubs Open RAIL-M License
+          - AIPubs Research-Use RAIL-M
+          - AI Pubs Research-Use RAIL-M License
+          - BigScience OpenRAIL-M
+          - BigScience Open RAIL-M License
+          - RAIL
+          - RAIL (specified in description)
+          - Llama 3
+          - Llama 3 Community License
       fineTunable:
         type: boolean
         description: Whether the model instance is fine tunable

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -1658,11 +1658,11 @@ class Help(object):
     command_model_instances_new = 'Create a new model instance'
     param_model_instance_downfile = (
         'Folder for downloading the special model-instance-metadata.json file '
-        '(https://github.com/Kaggle/kaggle-api/wiki/ModelInstance-Metadata). ')
+        '(https://github.com/Kaggle/kaggle-api/wiki/Model-Metadata#model-instance). ')
     param_model_instance_upfile = (
         'Folder for upload, containing data files and a '
         'special model-instance-metadata.json file '
-        '(https://github.com/Kaggle/kaggle-api/wiki/ModelInstance-Metadata). '
+        '(https://github.com/Kaggle/kaggle-api/wiki/Model-Metadata#model-instance). '
         'Defaults to current working directory')
     command_model_instances_delete = 'Delete a model instance'
     command_model_instances_update = 'Update a model instance'


### PR DESCRIPTION
Also, both the abbreviation or the full is accepted by the backend: https://github.com/Kaggle/kaggleazure/blob/aa12660a3bb6321ca2134110633571485ed049fc/Kaggle.Services.Models/Handlers/ModelApiService/V1/CreateModelInstanceHandler.cs#L118

Drive-by fix for the wiki URL.