### PR TITLE
Convert competitions to use kagglesdk

### DIFF
--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright 2024 Kaggle Inc
+# Copyright 2019 Kaggle Inc
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -45,6 +45,9 @@ import tarfile
 import time
 import zipfile
 import tempfile
+
+from kagglesdk.datasets.types.dataset_api_service import ApiListDatasetsRequest
+from kagglesdk.datasets.types.dataset_enums import DatasetSelectionGroup, DatasetSortBy
 from ..api_client import ApiClient
 from kaggle.configuration import Configuration
 from .kaggle_api import KaggleApi
@@ -91,6 +94,9 @@ from slugify import slugify
 from tqdm import tqdm
 import bleach
 import time
+
+from kagglesdk import KaggleClient, KaggleEnv
+from kagglesdk.competitions.types.competition_api_service import *
 
 try:
     unicode  # Python 2
@@ -205,8 +211,8 @@ class ResumableFileUpload(object):
 
     def _is_previous_valid(self, previous):
         return previous.path == self.path and \
-               previous.start_blob_upload_request == self.start_blob_upload_request and \
-               previous.timestamp > time.time() - ResumableFileUpload.RESUMABLE_UPLOAD_EXPIRY_SECONDS
+            previous.start_blob_upload_request == self.start_blob_upload_request and \
+            previous.timestamp > time.time() - ResumableFileUpload.RESUMABLE_UPLOAD_EXPIRY_SECONDS
 
     def upload_initiated(self, start_blob_upload_response):
         if self.context.no_resume:
@@ -239,16 +245,16 @@ class ResumableFileUpload(object):
     def to_dict(self):
         return {
             'path':
-            self.path,
+                self.path,
             'start_blob_upload_request':
-            self.start_blob_upload_request.to_dict(),
+                self.start_blob_upload_request.to_dict(),
             'timestamp':
-            self.timestamp,
+                self.timestamp,
             'start_blob_upload_response':
-            self.start_blob_upload_response.to_dict()
-            if self.start_blob_upload_response is not None else None,
+                self.start_blob_upload_response.to_dict()
+                if self.start_blob_upload_response is not None else None,
             'upload_complete':
-            self.upload_complete,
+                self.upload_complete,
         }
 
     def from_dict(other, context):
@@ -308,6 +314,7 @@ class KaggleApi(KaggleApi):
     config = os.path.join(config_dir, config_file)
     config_values = {}
     already_printed_version_warning = False
+    args = {}
 
     # Kernels valid types
     valid_push_kernel_types = ['script', 'notebook']
@@ -416,7 +423,7 @@ class KaggleApi(KaggleApi):
                 config_data = self.read_config_file(config_data)
             elif self._is_help_or_version_command(api_command) or (len(
                     sys.argv) > 2 and api_command.startswith(
-                        self.command_prefixes_allowing_anonymous_access)):
+                self.command_prefixes_allowing_anonymous_access)):
                 # Some API commands should be allowed without authentication.
                 return
             else:
@@ -424,7 +431,7 @@ class KaggleApi(KaggleApi):
                               ' {}. Or use the environment method. See setup'
                               ' instructions at'
                               ' https://github.com/Kaggle/kaggle-api/'.format(
-                                  self.config_file, self.config_dir))
+                    self.config_file, self.config_dir))
 
         # Step 3: load into configuration!
         self._load_config(config_data)
@@ -684,6 +691,21 @@ class KaggleApi(KaggleApi):
         self.print_config_value(self.CONFIG_NAME_PROXY, prefix=prefix)
         self.print_config_value(self.CONFIG_NAME_COMPETITION, prefix=prefix)
 
+    def build_kaggle_client(self):
+        env = KaggleEnv.STAGING if '--staging' in self.args \
+            else KaggleEnv.ADMIN if '--admin' in self.args \
+            else KaggleEnv.LOCAL
+        verbose = '--verbose' in self.args or '-v' in self.args
+        return KaggleClient(env=env, verbose=verbose)
+
+    def camel_to_snake(self, name):
+        """
+        :param name: field in camel case
+        :return: field in snake case
+        """
+        name = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
+        return re.sub('([a-z0-9])([A-Z])', r'\1_\2', name).lower()
+
     ## Competitions
 
     def competitions_list(self,
@@ -692,8 +714,8 @@ class KaggleApi(KaggleApi):
                           sort_by=None,
                           page=1,
                           search=None):
-        """ make call to list competitions, format the response, and return
-            a list of Competition instances
+        """ Make a call to list competitions, format the response, and return
+            a list of ApiCompetition instances
 
             Parameters
             ==========
@@ -716,13 +738,16 @@ class KaggleApi(KaggleApi):
             raise ValueError('Invalid sort_by specified. Valid options are ' +
                              str(self.valid_competition_sort_by))
 
-        competitions_list_result = self.process_response(
-            self.competitions_list_with_http_info(group=group or '',
-                                                  category=category or '',
-                                                  sort_by=sort_by or '',
-                                                  page=page,
-                                                  search=search or ''))
-        return [Competition(c) for c in competitions_list_result]
+        with self.build_kaggle_client() as kaggle:
+            request = ApiListCompetitionsRequest()
+            request.group = group
+            request.page = page
+            request.category = category
+            request.search = search
+            request.sort_by = sort_by
+            response = kaggle.competitions.competition_api_client.list_competitions(
+                request)
+            return response.competitions
 
     def competitions_list_cli(self,
                               group=None,
@@ -731,7 +756,7 @@ class KaggleApi(KaggleApi):
                               page=1,
                               search=None,
                               csv_display=False):
-        """ a wrapper for competitions_list for the client.
+        """ A wrapper for competitions_list for the client.
 
             Parameters
             ==========
@@ -760,13 +785,13 @@ class KaggleApi(KaggleApi):
             print('No competitions found')
 
     def competition_submit(self, file_name, message, competition, quiet=False):
-        """ submit a competition!
+        """ Submit a competition.
 
             Parameters
             ==========
             file_name: the competition metadata file
             message: the submission description
-            competition: the competition name
+            competition: the competition name; if not given use the 'competition' config value
             quiet: suppress verbose output (default is False)
         """
         if competition is None:
@@ -777,44 +802,30 @@ class KaggleApi(KaggleApi):
         if competition is None:
             raise ValueError('No competition specified')
         else:
-            url_result = self.process_response(
-                self.competitions_submissions_url_with_http_info(
-                    id=competition,
-                    file_name=os.path.basename(file_name),
-                    content_length=os.path.getsize(file_name),
-                    last_modified_date_utc=int(os.path.getmtime(file_name))))
-
-            # Temporary while new worker is gradually turned on.  'isComplete'
-            # exists on the old DTO but not the new, so this is an hacky but
-            # easy solution to figure out which submission logic to use
-            if 'isComplete' in url_result:
-                # Old submissions path
-                url_result_list = url_result['createUrl'].split('/')
-                upload_result = self.process_response(
-                    self.competitions_submissions_upload_with_http_info(
-                        file=file_name,
-                        guid=url_result_list[-3],
-                        content_length=url_result_list[-2],
-                        last_modified_date_utc=url_result_list[-1]))
-                upload_result_token = upload_result['token']
-            else:
-                # New submissions path!
+            with self.build_kaggle_client() as kaggle:
+                request = ApiStartSubmissionUploadRequest()
+                request.competition_name = competition
+                request.file_name = os.path.basename(file_name)
+                request.content_length = os.path.getsize(file_name)
+                request.last_modified_epoch_seconds = int(
+                    os.path.getmtime(file_name))
+                response = kaggle.competitions.competition_api_client.start_submission_upload(
+                    request)
                 upload_status = self.upload_complete(file_name,
-                                                     url_result['createUrl'],
+                                                     response.create_url,
                                                      quiet)
                 if upload_status != ResumableUploadResult.COMPLETE:
                     # Actual error is printed during upload_complete. Not
                     # ideal but changing would not be backwards compatible
                     return "Could not submit to competition"
 
-                upload_result_token = url_result['token']
-
-            submit_result = self.process_response(
-                self.competitions_submissions_submit_with_http_info(
-                    id=competition,
-                    blob_file_tokens=upload_result_token,
-                    submission_description=message))
-            return SubmitResult(submit_result)
+                submit_request = ApiCreateSubmissionRequest()
+                submit_request.competition_name = competition
+                submit_request.blob_file_tokens = response.token
+                submit_request.submission_description = message
+                submit_response = kaggle.competitions.competition_api_client.create_submission(
+                    submit_request)
+                return submit_response
 
     def competition_submit_cli(self,
                                file_name,
@@ -822,10 +833,15 @@ class KaggleApi(KaggleApi):
                                competition,
                                competition_opt=None,
                                quiet=False):
-        """ submit a competition using the client. Arguments are same as for
+        """ Submit a competition using the client. Arguments are same as for
             competition_submit, except for extra arguments provided here.
-             Parameters
+            
+            Parameters
             ==========
+            file_name: the competition metadata file
+            message: the submission description
+            competition: the competition name; if not given use the 'competition' config value
+            quiet: suppress verbose output (default is False)
             competition_opt: an alternative competition option provided by cli
         """
         competition = competition or competition_opt
@@ -844,19 +860,28 @@ class KaggleApi(KaggleApi):
 
     def competition_submissions(self,
                                 competition,
+                                group=None,
+                                sort=None, # SubmissionSortBy.SUBMISSION_SORT_BY_NAME,
                                 page_token=None,
                                 page_size=20):
-        """ get the list of Submission for a particular competition
+        """ Get the list of Submission for a particular competition.
 
             Parameters
             ==========
             competition: the name of the competition
+            group: the submission group
+            sort: the sort-by option
             page_token: token for pagination
             page_size: the number of items per page
         """
-        submissions_result = self.process_response(
-            self.competitions_submissions_list_with_http_info(id=competition))
-        return [Submission(s) for s in submissions_result]
+        with self.build_kaggle_client() as kaggle:
+            request = ApiListSubmissionsRequest()
+            request.competition_name = competition
+            request.page = page_token
+            request.group = group
+            request.sort_by = sort
+            response = kaggle.competitions.competition_api_client.list_submissions(request)
+            return response.submissions
 
     def competition_submissions_cli(self,
                                     competition=None,
@@ -865,7 +890,7 @@ class KaggleApi(KaggleApi):
                                     page_token=None,
                                     page_size=20,
                                     quiet=False):
-        """ wrapper to competition_submission, will return either json or csv
+        """ A wrapper to competition_submission, will return either json or csv
             to the user. Additional parameters are listed below, see
             competition_submissions for rest.
 
@@ -887,8 +912,8 @@ class KaggleApi(KaggleApi):
         if competition is None:
             raise ValueError('No competition specified')
         else:
-            submissions = self.competition_submissions(competition, page_token,
-                                                       page_size)
+            submissions = self.competition_submissions(competition, page_token=page_token,
+                                                       page_size=page_size)
             fields = [
                 'fileName', 'date', 'description', 'status', 'publicScore',
                 'privateScore'
@@ -905,17 +930,20 @@ class KaggleApi(KaggleApi):
                                competition,
                                page_token=None,
                                page_size=20):
-        """ list files for competition
+        """ List files for a competition.
              Parameters
             ==========
             competition: the name of the competition
             page_token: the page token for pagination
             page_size: the number of items per page
         """
-        competition_list_files_result = self.process_response(
-            self.competitions_data_list_files_with_http_info(
-                id=competition, page_token=page_token, page_size=page_size))
-        return FileList(competition_list_files_result)
+        with self.build_kaggle_client() as kaggle:
+            request = ApiListDataFilesRequest()
+            request.competition_name = competition
+            request.page_token = page_token
+            request.page_size = page_size
+            response = kaggle.competitions.competition_api_client.list_data_files(request)
+            return response
 
     def competition_list_files_cli(self,
                                    competition,
@@ -924,7 +952,7 @@ class KaggleApi(KaggleApi):
                                    page_token=None,
                                    page_size=20,
                                    quiet=False):
-        """ List files for a competition, if it exists
+        """ List files for a competition, if it exists.
 
             Parameters
             ==========
@@ -946,15 +974,16 @@ class KaggleApi(KaggleApi):
         else:
             result = self.competition_list_files(competition, page_token,
                                                  page_size)
-            next_page_token = result.nextPageToken
+            next_page_token = result.next_page_token
             if next_page_token:
                 print('Next Page Token = {}'.format(next_page_token))
-            fields = ['name', 'size', 'creationDate']
+            fields = ['name', 'totalBytes', 'creationDate']
+            labels = ['name', 'size', 'creationDate']
             if result:
                 if csv_display:
-                    self.print_csv(result.files, fields)
+                    self.print_csv(result.files, fields, labels)
                 else:
-                    self.print_table(result.files, fields)
+                    self.print_table(result.files, fields, labels)
             else:
                 print('No files found')
 
@@ -964,8 +993,8 @@ class KaggleApi(KaggleApi):
                                   path=None,
                                   force=False,
                                   quiet=False):
-        """ download a competition file to a designated location, or use
-            a default location
+        """ Download a competition file to a designated location, or use
+            a default location.
 
             Parameters
             =========
@@ -981,11 +1010,13 @@ class KaggleApi(KaggleApi):
         else:
             effective_path = path
 
-        response = self.process_response(
-            self.competitions_data_download_file_with_http_info(
-                id=competition, file_name=file_name, _preload_content=False))
-        url = response.retries.history[0].redirect_location.split('?')[0]
-        outfile = os.path.join(effective_path, url.split('/')[-1])
+        with self.build_kaggle_client() as kaggle:
+            request = ApiDownloadDataFileRequest()
+            request.competition_name = competition
+            request.file_name = file_name
+            response = kaggle.competitions.competition_api_client.download_data_file(request)
+        url = response.history[0].url
+        outfile = os.path.join(effective_path, url.split('?')[0].split('/')[-1])
 
         if force or self.download_needed(response, outfile, quiet):
             self.download_file(response, outfile, quiet, not force)
@@ -995,7 +1026,7 @@ class KaggleApi(KaggleApi):
                                    path=None,
                                    force=False,
                                    quiet=True):
-        """ downloads all competition files.
+        """ Download all competition files.
 
             Parameters
             =========
@@ -1010,10 +1041,11 @@ class KaggleApi(KaggleApi):
         else:
             effective_path = path
 
-        response = self.process_response(
-            self.competitions_data_download_files_with_http_info(
-                id=competition, _preload_content=False))
-        url = response.retries.history[0].redirect_location.split('?')[0]
+        with self.build_kaggle_client() as kaggle:
+            request = ApiDownloadDataFilesRequest()
+            request.competition_name = competition
+            response = kaggle.competitions.competition_api_client.download_data_files(request)
+        url = response.url.split('?')[0]
         outfile = os.path.join(effective_path,
                                competition + '.' + url.split('.')[-1])
 
@@ -1027,7 +1059,7 @@ class KaggleApi(KaggleApi):
                                  path=None,
                                  force=False,
                                  quiet=False):
-        """ a wrapper to competition_download_files, but first will parse input
+        """ A wrapper to competition_download_files, but first will parse input
             from API client. Additional parameters are listed here, see
             competition_download for remaining.
 
@@ -1057,7 +1089,7 @@ class KaggleApi(KaggleApi):
                                                force, quiet)
 
     def competition_leaderboard_download(self, competition, path, quiet=True):
-        """ Download competition leaderboards
+        """ Download a competition leaderboard.
 
             Parameters
             =========
@@ -1065,10 +1097,10 @@ class KaggleApi(KaggleApi):
             path: a path to download the file to
             quiet: suppress verbose output (default is True)
         """
-        response = self.process_response(
-            self.competition_download_leaderboard_with_http_info(
-                competition, _preload_content=False))
-
+        with self.build_kaggle_client() as kaggle:
+            request = ApiDownloadLeaderboardRequest()
+            request.competition_name = competition
+            response = kaggle.competitions.competition_api_client.download_leaderboard(request)
         if path is None:
             effective_path = self.get_default_download_dir(
                 'competitions', competition)
@@ -1080,15 +1112,17 @@ class KaggleApi(KaggleApi):
         self.download_file(response, outfile, quiet)
 
     def competition_leaderboard_view(self, competition):
-        """ view a leaderboard based on a competition name
+        """ View a leaderboard based on a competition name.
 
             Parameters
             ==========
             competition: the competition name to view leadboard for
         """
-        result = self.process_response(
-            self.competition_view_leaderboard_with_http_info(competition))
-        return [LeaderboardEntry(e) for e in result['submissions']]
+        with self.build_kaggle_client() as kaggle:
+            request = ApiGetLeaderboardRequest()
+            request.competition_name = competition
+            response = kaggle.competitions.competition_api_client.get_leaderboard(request)
+        return response.submissions
 
     def competition_leaderboard_cli(self,
                                     competition,
@@ -1098,7 +1132,7 @@ class KaggleApi(KaggleApi):
                                     download=False,
                                     csv_display=False,
                                     quiet=False):
-        """ a wrapper for competition_leaderbord_view that will print the
+        """ A wrapper for competition_leaderbord_view that will print the
             results as a table or comma separated values
 
             Parameters
@@ -1149,7 +1183,7 @@ class KaggleApi(KaggleApi):
                      page=1,
                      max_size=None,
                      min_size=None):
-        """ return a list of datasets!
+        """ Return a list of datasets.
 
             Parameters
             ==========
@@ -1165,9 +1199,12 @@ class KaggleApi(KaggleApi):
             max_size: the maximum size of the dataset to return (bytes)
             min_size: the minimum size of the dataset to return (bytes)
         """
-        if sort_by and sort_by not in self.valid_dataset_sort_bys:
-            raise ValueError('Invalid sort by specified. Valid options are ' +
-                             str(self.valid_dataset_sort_bys))
+        if sort_by:
+            if sort_by not in self.valid_dataset_sort_bys:
+                raise ValueError('Invalid sort by specified. Valid options are ' +
+                                 str(self.valid_dataset_sort_bys))
+            else:
+                sort_by = DatasetSortBy[f"DATASET_SORT_BY_{sort_by.upper()}"]
 
         if size:
             raise ValueError(
@@ -1195,27 +1232,46 @@ class KaggleApi(KaggleApi):
         elif (min_size and int(min_size) < 0):
             raise ValueError('Min Size must be >= 0')
 
-        group = 'public'
+        group = DatasetSelectionGroup.DATASET_SELECTION_GROUP_PUBLIC
         if mine:
-            group = 'my'
+            group = DatasetSelectionGroup.DATASET_SELECTION_GROUP_MY
             if user:
                 raise ValueError('Cannot specify both mine and a user')
         if user:
-            group = 'user'
+            group = DatasetSelectionGroup.DATASET_SELECTION_GROUP_USER
 
-        datasets_list_result = self.process_response(
-            self.datasets_list_with_http_info(group=group,
-                                              sort_by=sort_by or 'hottest',
-                                              size=size,
-                                              filetype=file_type or 'all',
-                                              license=license_name or 'all',
-                                              tagids=tag_ids or '',
-                                              search=search or '',
-                                              user=user or '',
-                                              page=page,
-                                              max_size=max_size,
-                                              min_size=min_size))
-        return [Dataset(d) for d in datasets_list_result]
+        # datasets_list_result = self.process_response(
+        #     self.datasets_list_with_http_info(group=group,
+        #                                       sort_by=sort_by or 'hottest',
+        #                                       size=size,
+        #                                       filetype=file_type or 'all',
+        #                                       license=license_name or 'all',
+        #                                       tagids=tag_ids or '',
+        #                                       search=search or '',
+        #                                       user=user or '',
+        #                                       page=page,
+        #                                       max_size=max_size,
+        #                                       min_size=min_size))
+        # return [Dataset(d) for d in datasets_list_result]
+        with self.build_kaggle_client() as kaggle:
+            request = ApiListDatasetsRequest()
+            request.group = group
+            request.sort_by = sort_by
+            request.file_type = file_type
+            request.license = license_name
+            request.tag_ids = tag_ids
+            request.search = search
+            request.user = user
+            request.page = page
+            request.max_size = max_size
+            request.min_size = min_size
+            response = kaggle.datasets.dataset_api_client.list_datasets(request)
+            return response.datasets
+
+
+    @staticmethod
+    def method():
+        return 'POST'
 
     def dataset_list_cli(self,
                          sort_by=None,
@@ -1230,7 +1286,7 @@ class KaggleApi(KaggleApi):
                          csv_display=False,
                          max_size=None,
                          min_size=None):
-        """ a wrapper to dataset_list for the client. Additional parameters
+        """ A wrapper to dataset_list for the client. Additional parameters
             are described here, see dataset_list for others.
 
             Parameters
@@ -1341,7 +1397,7 @@ class KaggleApi(KaggleApi):
             print('Downloaded metadata to ' + meta_file)
 
     def dataset_list_files(self, dataset, page_token=None, page_size=20):
-        """ list files for a dataset
+        """ List files for a dataset.
              Parameters
             ==========
             dataset: the string identified of the dataset
@@ -1369,8 +1425,8 @@ class KaggleApi(KaggleApi):
                                csv_display=False,
                                page_token=None,
                                page_size=20):
-        """ a wrapper to dataset_list_files for the client
-            (list files for a dataset)
+        """ A wrapper to dataset_list_files for the client
+            (list files for a dataset).
              Parameters
             ==========
             dataset: the string identified of the dataset
@@ -1399,10 +1455,10 @@ class KaggleApi(KaggleApi):
             print('No files found')
 
     def dataset_status(self, dataset):
-        """ call to get the status of a dataset from the API
+        """ Call to get the status of a dataset from the API.
              Parameters
             ==========
-            dataset: the string identified of the dataset
+            dataset: the string identifier of the dataset
                      should be in format [owner]/[dataset-name]
         """
         if dataset is None:
@@ -1421,8 +1477,8 @@ class KaggleApi(KaggleApi):
         return dataset_status_result
 
     def dataset_status_cli(self, dataset, dataset_opt=None):
-        """ wrapper for client for dataset_status, with additional
-            dataset_opt to get the status of a dataset from the API
+        """ A wrapper for client for dataset_status, with additional
+            dataset_opt to get the status of a dataset from the API.
              Parameters
             ==========
             dataset_opt: an alternative to dataset
@@ -1437,7 +1493,7 @@ class KaggleApi(KaggleApi):
                               force=False,
                               quiet=True,
                               licenses=[]):
-        """ download a single file for a dataset
+        """ Download a single file for a dataset.
 
             Parameters
             ==========
@@ -1489,7 +1545,7 @@ class KaggleApi(KaggleApi):
                                quiet=True,
                                unzip=False,
                                licenses=[]):
-        """ download all files for a dataset
+        """ Download all files for a dataset.
 
             Parameters
             ==========
@@ -1732,10 +1788,10 @@ class KaggleApi(KaggleApi):
                     self.process_response(
                         self.with_retry(
                             self.datasets_create_version_by_id_with_http_info)(
-                                id_no, request)))
+                            id_no, request)))
             else:
                 if ref == self.config_values[
-                        self.CONFIG_NAME_USER] + '/INSERT_SLUG_HERE':
+                    self.CONFIG_NAME_USER] + '/INSERT_SLUG_HERE':
                     raise ValueError(
                         'Default slug detected, please change values before '
                         'uploading')
@@ -1853,7 +1909,7 @@ class KaggleApi(KaggleApi):
 
         # validations
         if ref == self.config_values[
-                self.CONFIG_NAME_USER] + '/INSERT_SLUG_HERE':
+            self.CONFIG_NAME_USER] + '/INSERT_SLUG_HERE':
             raise ValueError(
                 'Default slug detected, please change values before uploading')
         if title == 'INSERT_TITLE_HERE':
@@ -1996,16 +2052,28 @@ class KaggleApi(KaggleApi):
                   unit_divisor=1024,
                   disable=quiet) as pbar:
             with open(outfile, open_mode) as out:
-                while True:
-                    data = response.read(chunk_size)
-                    if not data:
-                        break
-                    out.write(data)
-                    os.utime(outfile,
-                             times=(remote_date_timestamp - 1,
-                                    remote_date_timestamp - 1))
-                    size_read = min(size, size_read + chunk_size)
-                    pbar.update(len(data))
+                # TODO: Delete this test after all API methods are converted.
+                if type(response).__name__ == 'HTTPResponse':
+                    while True:
+                        data = response.read(chunk_size)
+                        if not data:
+                            break
+                        out.write(data)
+                        os.utime(outfile,
+                                 times=(remote_date_timestamp - 1,
+                                        remote_date_timestamp - 1))
+                        size_read = min(size, size_read + chunk_size)
+                        pbar.update(len(data))
+                else:
+                    for data in response.iter_content(chunk_size):
+                        if not data:
+                            break
+                        out.write(data)
+                        os.utime(outfile,
+                                 times=(remote_date_timestamp - 1,
+                                        remote_date_timestamp - 1))
+                        size_read = min(size, size_read + chunk_size)
+                        pbar.update(len(data))
             if not quiet:
                 print('\n', end='')
 
@@ -2211,25 +2279,25 @@ class KaggleApi(KaggleApi):
         username = self.get_config_value(self.CONFIG_NAME_USER)
         meta_data = {
             'id':
-            username + '/INSERT_KERNEL_SLUG_HERE',
+                username + '/INSERT_KERNEL_SLUG_HERE',
             'title':
-            'INSERT_TITLE_HERE',
+                'INSERT_TITLE_HERE',
             'code_file':
-            'INSERT_CODE_FILE_PATH_HERE',
+                'INSERT_CODE_FILE_PATH_HERE',
             'language':
-            'Pick one of: {' +
-            ','.join(x for x in self.valid_push_language_types) + '}',
+                'Pick one of: {' +
+                ','.join(x for x in self.valid_push_language_types) + '}',
             'kernel_type':
-            'Pick one of: {' +
-            ','.join(x for x in self.valid_push_kernel_types) + '}',
+                'Pick one of: {' +
+                ','.join(x for x in self.valid_push_kernel_types) + '}',
             'is_private':
-            'true',
+                'true',
             'enable_gpu':
-            'false',
+                'false',
             'enable_tpu':
-            'false',
+                'false',
             'enable_internet':
-            'true',
+                'true',
             'dataset_sources': [],
             'competition_sources': [],
             'kernel_sources': [],
@@ -3471,8 +3539,8 @@ class KaggleApi(KaggleApi):
                 self.process_response(
                     self.with_retry(
                         self.models_create_instance_version_with_http_info)(
-                            owner_slug, model_slug, framework, instance_slug,
-                            request)))
+                        owner_slug, model_slug, framework, instance_slug,
+                        request)))
 
             return result
 
@@ -3785,48 +3853,54 @@ class KaggleApi(KaggleApi):
             pass
         return True
 
-    def print_table(self, items, fields):
+    def print_table(self, items, fields, labels = None):
         """ print a table of items, for a set of fields defined
 
             Parameters
             ==========
             items: a list of items to print
             fields: a list of fields to select from items
+            labels: labels for the fields, defaults to fields
         """
+        if labels is None:
+            labels = fields
         formats = []
         borders = []
         if len(items) == 0:
             return
         for f in fields:
             length = max(len(f),
-                         max([len(self.string(getattr(i, f))) for i in items]))
+                         max([len(self.string(getattr(i, self.camel_to_snake(f)))) for i in items]))
             justify = '>' if isinstance(getattr(
-                items[0], f), int) or f == 'size' or f == 'reward' else '<'
+                items[0], self.camel_to_snake(f)), int) or f == 'size' or f == 'reward' else '<'
             formats.append('{:' + justify + self.string(length + 2) + '}')
             borders.append('-' * length + '  ')
         row_format = u''.join(formats)
-        headers = [f + '  ' for f in fields]
+        headers = [f + '  ' for f in labels]
         print(row_format.format(*headers))
         print(row_format.format(*borders))
         for i in items:
-            i_fields = [self.string(getattr(i, f)) + '  ' for f in fields]
+            i_fields = [self.string(getattr(i, self.camel_to_snake(f))) + '  ' for f in fields]
             try:
                 print(row_format.format(*i_fields))
             except UnicodeEncodeError:
                 print(row_format.format(*i_fields).encode('utf-8'))
 
-    def print_csv(self, items, fields):
+    def print_csv(self, items, fields, labels = None):
         """ print a set of fields in a set of items using a csv.writer
 
             Parameters
             ==========
             items: a list of items to print
             fields: a list of fields to select from items
+            labels: labels for the fields, defaults to fields
         """
+        if labels is None:
+            labels = fields
         writer = csv.writer(sys.stdout)
-        writer.writerow(fields)
+        writer.writerow(labels)
         for i in items:
-            i_fields = [self.string(getattr(i, f)) for f in fields]
+            i_fields = [self.string(getattr(i, self.camel_to_snake(f))) for f in fields]
             writer.writerow(i_fields)
 
     def string(self, item):
@@ -3946,9 +4020,9 @@ class KaggleApi(KaggleApi):
         """
         for file_name in os.listdir(folder):
             if (file_name in [
-                    self.DATASET_METADATA_FILE, self.OLD_DATASET_METADATA_FILE,
-                    self.KERNEL_METADATA_FILE, self.MODEL_METADATA_FILE,
-                    self.MODEL_INSTANCE_METADATA_FILE
+                self.DATASET_METADATA_FILE, self.OLD_DATASET_METADATA_FILE,
+                self.KERNEL_METADATA_FILE, self.MODEL_METADATA_FILE,
+                self.MODEL_INSTANCE_METADATA_FILE
             ]):
                 continue
             upload_file = self._upload_file_or_folder(folder, file_name,
@@ -4093,10 +4167,10 @@ class KaggleApi(KaggleApi):
                         fp.seek(start_at)
                         session.headers.update({
                             'Content-Length':
-                            '%d' % upload_size,
+                                '%d' % upload_size,
                             'Content-Range':
-                            'bytes %d-%d/%d' %
-                            (start_at, file_size - 1, file_size)
+                                'bytes %d-%d/%d' %
+                                (start_at, file_size - 1, file_size)
                         })
                     reader = TqdmBufferedReader(fp, progress_bar)
                     retries = Retry(total=10, backoff_factor=0.5)
@@ -4278,7 +4352,7 @@ class KaggleApi(KaggleApi):
 
             split = model_instance_version.split('/')
             if not split[0] or not split[1] or not split[2] or not split[
-                    3] or not split[4]:
+                3] or not split[4]:
                 raise ValueError(
                     'Invalid model instance version specification ' +
                     model_instance_version)

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -314,7 +314,7 @@ class KaggleApi(KaggleApi):
     config = os.path.join(config_dir, config_file)
     config_values = {}
     already_printed_version_warning = False
-    args = {}  # DEBUG Add --local to use localhost
+    args = {'--local'}  # DEBUG Add --local to use localhost
 
     # Kernels valid types
     valid_push_kernel_types = ['script', 'notebook']
@@ -354,6 +354,15 @@ class KaggleApi(KaggleApi):
     # Command prefixes that are valid without authentication.
     command_prefixes_allowing_anonymous_access = ('datasets download',
                                                   'datasets files')
+
+    # Attributes
+    competition_fields = ['ref', 'deadline', 'category', 'reward', 'teamCount','userHasEntered']
+    submission_fields = ['fileName', 'date', 'description', 'status', 'publicScore', 'privateScore']
+    competition_file_fields = ['name', 'totalBytes', 'creationDate']
+    competition_file_labels = ['name', 'size', 'creationDate']
+    competition_leaderboard_fields = ['teamId', 'teamName', 'submissionDate', 'score']
+    dataset_fields = ['ref', 'title', 'totalBytes', 'lastUpdated', 'downloadCount', 'voteCount', 'usabilityRating']
+    dataset_labels = ['ref', 'title', 'size', 'lastUpdated', 'downloadCount', 'voteCount', 'usabilityRating']
 
     # Hack for https://github.com/Kaggle/kaggle-api/issues/22 / b/78194015
     if six.PY2:
@@ -697,6 +706,7 @@ class KaggleApi(KaggleApi):
             else KaggleEnv.LOCAL if '--local' in self.args \
             else KaggleEnv.PROD
         verbose = '--verbose' in self.args or '-v' in self.args
+        config = self.api_client.configuration
         return KaggleClient(env=env,
                             verbose=verbose,
                             username=config.username,
@@ -776,15 +786,11 @@ class KaggleApi(KaggleApi):
                                               sort_by=sort_by,
                                               page=page,
                                               search=search)
-        fields = [
-            'ref', 'deadline', 'category', 'reward', 'teamCount',
-            'userHasEntered'
-        ]
         if competitions:
             if csv_display:
-                self.print_csv(competitions, fields)
+                self.print_csv(competitions, self.competition_fields)
             else:
-                self.print_table(competitions, fields)
+                self.print_table(competitions, self.competition_fields)
         else:
             print('No competitions found')
 
@@ -921,15 +927,11 @@ class KaggleApi(KaggleApi):
             submissions = self.competition_submissions(competition,
                                                        page_token=page_token,
                                                        page_size=page_size)
-            fields = [
-                'fileName', 'date', 'description', 'status', 'publicScore',
-                'privateScore'
-            ]
             if submissions:
                 if csv_display:
-                    self.print_csv(submissions, fields)
+                    self.print_csv(submissions, submission_fields)
                 else:
-                    self.print_table(submissions, fields)
+                    self.print_table(submissions, submission_fields)
             else:
                 print('No submissions found')
 
@@ -985,13 +987,11 @@ class KaggleApi(KaggleApi):
             next_page_token = result.next_page_token
             if next_page_token:
                 print('Next Page Token = {}'.format(next_page_token))
-            fields = ['name', 'totalBytes', 'creationDate']
-            labels = ['name', 'size', 'creationDate']
             if result:
                 if csv_display:
-                    self.print_csv(result.files, fields, labels)
+                    self.print_csv(result.files, self.competition_file_fields, self.competition_file_labels)
                 else:
-                    self.print_table(result.files, fields, labels)
+                    self.print_table(result.files, self.competition_file_fields, self.competition_file_labels)
             else:
                 print('No files found')
 
@@ -1175,12 +1175,11 @@ class KaggleApi(KaggleApi):
 
         if view:
             results = self.competition_leaderboard_view(competition)
-            fields = ['teamId', 'teamName', 'submissionDate', 'score']
             if results:
                 if csv_display:
-                    self.print_csv(results, fields)
+                    self.print_csv(results, self.competition_leaderboard_fields)
                 else:
-                    self.print_table(results, fields)
+                    self.print_table(results, self.competition_leaderboard_fields)
             else:
                 print('No results found')
 
@@ -1304,15 +1303,11 @@ class KaggleApi(KaggleApi):
         datasets = self.dataset_list(sort_by, size, file_type, license_name,
                                      tag_ids, search, user, mine, page,
                                      max_size, min_size)
-        fields = [
-            'ref', 'title', 'size', 'lastUpdated', 'downloadCount',
-            'voteCount', 'usabilityRating'
-        ]
         if datasets:
             if csv_display:
-                self.print_csv(datasets, fields)
+                self.print_csv(datasets, self.dataset_fields, self.dataset_labels)
             else:
-                self.print_table(datasets, fields)
+                self.print_table(datasets, self.dataset_fields, self.dataset_labels)
         else:
             print('No datasets found')
 

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -314,7 +314,7 @@ class KaggleApi(KaggleApi):
     config = os.path.join(config_dir, config_file)
     config_values = {}
     already_printed_version_warning = False
-    args = {}
+    args = {} # DEBUG Add --local to use localhost
 
     # Kernels valid types
     valid_push_kernel_types = ['script', 'notebook']
@@ -694,9 +694,10 @@ class KaggleApi(KaggleApi):
     def build_kaggle_client(self):
         env = KaggleEnv.STAGING if '--staging' in self.args \
             else KaggleEnv.ADMIN if '--admin' in self.args \
-            else KaggleEnv.LOCAL
+            else KaggleEnv.LOCAL if '--local' in self.args \
+            else KaggleEnv.PROD
         verbose = '--verbose' in self.args or '-v' in self.args
-        return KaggleClient(env=env, verbose=verbose)
+        return KaggleClient(env=env, verbose=verbose, username=config.username, password=config.password)
 
     def camel_to_snake(self, name):
         """
@@ -1240,19 +1241,6 @@ class KaggleApi(KaggleApi):
         if user:
             group = DatasetSelectionGroup.DATASET_SELECTION_GROUP_USER
 
-        # datasets_list_result = self.process_response(
-        #     self.datasets_list_with_http_info(group=group,
-        #                                       sort_by=sort_by or 'hottest',
-        #                                       size=size,
-        #                                       filetype=file_type or 'all',
-        #                                       license=license_name or 'all',
-        #                                       tagids=tag_ids or '',
-        #                                       search=search or '',
-        #                                       user=user or '',
-        #                                       page=page,
-        #                                       max_size=max_size,
-        #                                       min_size=min_size))
-        # return [Dataset(d) for d in datasets_list_result]
         with self.build_kaggle_client() as kaggle:
             request = ApiListDatasetsRequest()
             request.group = group
@@ -1267,11 +1255,6 @@ class KaggleApi(KaggleApi):
             request.min_size = min_size
             response = kaggle.datasets.dataset_api_client.list_datasets(request)
             return response.datasets
-
-
-    @staticmethod
-    def method():
-        return 'POST'
 
     def dataset_list_cli(self,
                          sort_by=None,

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -314,7 +314,7 @@ class KaggleApi(KaggleApi):
     config = os.path.join(config_dir, config_file)
     config_values = {}
     already_printed_version_warning = False
-    args = {'--local'}  # DEBUG Add --local to use localhost
+    args = {}  # DEBUG Add --local to use localhost
 
     # Kernels valid types
     valid_push_kernel_types = ['script', 'notebook']

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright 2019 Kaggle Inc
+# Copyright 2024 Kaggle Inc
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -211,8 +211,8 @@ class ResumableFileUpload(object):
 
     def _is_previous_valid(self, previous):
         return previous.path == self.path and \
-            previous.start_blob_upload_request == self.start_blob_upload_request and \
-            previous.timestamp > time.time() - ResumableFileUpload.RESUMABLE_UPLOAD_EXPIRY_SECONDS
+               previous.start_blob_upload_request == self.start_blob_upload_request and \
+               previous.timestamp > time.time() - ResumableFileUpload.RESUMABLE_UPLOAD_EXPIRY_SECONDS
 
     def upload_initiated(self, start_blob_upload_response):
         if self.context.no_resume:
@@ -245,16 +245,16 @@ class ResumableFileUpload(object):
     def to_dict(self):
         return {
             'path':
-                self.path,
+            self.path,
             'start_blob_upload_request':
-                self.start_blob_upload_request.to_dict(),
+            self.start_blob_upload_request.to_dict(),
             'timestamp':
-                self.timestamp,
+            self.timestamp,
             'start_blob_upload_response':
-                self.start_blob_upload_response.to_dict()
-                if self.start_blob_upload_response is not None else None,
+            self.start_blob_upload_response.to_dict()
+            if self.start_blob_upload_response is not None else None,
             'upload_complete':
-                self.upload_complete,
+            self.upload_complete,
         }
 
     def from_dict(other, context):
@@ -314,7 +314,7 @@ class KaggleApi(KaggleApi):
     config = os.path.join(config_dir, config_file)
     config_values = {}
     already_printed_version_warning = False
-    args = {} # DEBUG Add --local to use localhost
+    args = {}  # DEBUG Add --local to use localhost
 
     # Kernels valid types
     valid_push_kernel_types = ['script', 'notebook']
@@ -421,9 +421,9 @@ class KaggleApi(KaggleApi):
                 or self.CONFIG_NAME_KEY not in config_data:
             if os.path.exists(self.config):
                 config_data = self.read_config_file(config_data)
-            elif self._is_help_or_version_command(api_command) or (len(
-                    sys.argv) > 2 and api_command.startswith(
-                self.command_prefixes_allowing_anonymous_access)):
+            elif self._is_help_or_version_command(api_command) or (
+                    len(sys.argv) > 2 and api_command.startswith(
+                        self.command_prefixes_allowing_anonymous_access)):
                 # Some API commands should be allowed without authentication.
                 return
             else:
@@ -431,7 +431,7 @@ class KaggleApi(KaggleApi):
                               ' {}. Or use the environment method. See setup'
                               ' instructions at'
                               ' https://github.com/Kaggle/kaggle-api/'.format(
-                    self.config_file, self.config_dir))
+                                  self.config_file, self.config_dir))
 
         # Step 3: load into configuration!
         self._load_config(config_data)
@@ -697,7 +697,10 @@ class KaggleApi(KaggleApi):
             else KaggleEnv.LOCAL if '--local' in self.args \
             else KaggleEnv.PROD
         verbose = '--verbose' in self.args or '-v' in self.args
-        return KaggleClient(env=env, verbose=verbose, username=config.username, password=config.password)
+        return KaggleClient(env=env,
+                            verbose=verbose,
+                            username=config.username,
+                            password=config.password)
 
     def camel_to_snake(self, name):
         """
@@ -859,12 +862,13 @@ class KaggleApi(KaggleApi):
                 raise e
         return submit_result
 
-    def competition_submissions(self,
-                                competition,
-                                group=None,
-                                sort=None, # SubmissionSortBy.SUBMISSION_SORT_BY_NAME,
-                                page_token=None,
-                                page_size=20):
+    def competition_submissions(
+            self,
+            competition,
+            group=None,
+            sort=None,  # SubmissionSortBy.SUBMISSION_SORT_BY_NAME,
+            page_token=None,
+            page_size=20):
         """ Get the list of Submission for a particular competition.
 
             Parameters
@@ -881,7 +885,8 @@ class KaggleApi(KaggleApi):
             request.page = page_token
             request.group = group
             request.sort_by = sort
-            response = kaggle.competitions.competition_api_client.list_submissions(request)
+            response = kaggle.competitions.competition_api_client.list_submissions(
+                request)
             return response.submissions
 
     def competition_submissions_cli(self,
@@ -913,7 +918,8 @@ class KaggleApi(KaggleApi):
         if competition is None:
             raise ValueError('No competition specified')
         else:
-            submissions = self.competition_submissions(competition, page_token=page_token,
+            submissions = self.competition_submissions(competition,
+                                                       page_token=page_token,
                                                        page_size=page_size)
             fields = [
                 'fileName', 'date', 'description', 'status', 'publicScore',
@@ -943,7 +949,8 @@ class KaggleApi(KaggleApi):
             request.competition_name = competition
             request.page_token = page_token
             request.page_size = page_size
-            response = kaggle.competitions.competition_api_client.list_data_files(request)
+            response = kaggle.competitions.competition_api_client.list_data_files(
+                request)
             return response
 
     def competition_list_files_cli(self,
@@ -1015,9 +1022,11 @@ class KaggleApi(KaggleApi):
             request = ApiDownloadDataFileRequest()
             request.competition_name = competition
             request.file_name = file_name
-            response = kaggle.competitions.competition_api_client.download_data_file(request)
+            response = kaggle.competitions.competition_api_client.download_data_file(
+                request)
         url = response.history[0].url
-        outfile = os.path.join(effective_path, url.split('?')[0].split('/')[-1])
+        outfile = os.path.join(effective_path,
+                               url.split('?')[0].split('/')[-1])
 
         if force or self.download_needed(response, outfile, quiet):
             self.download_file(response, outfile, quiet, not force)
@@ -1045,7 +1054,8 @@ class KaggleApi(KaggleApi):
         with self.build_kaggle_client() as kaggle:
             request = ApiDownloadDataFilesRequest()
             request.competition_name = competition
-            response = kaggle.competitions.competition_api_client.download_data_files(request)
+            response = kaggle.competitions.competition_api_client.download_data_files(
+                request)
         url = response.url.split('?')[0]
         outfile = os.path.join(effective_path,
                                competition + '.' + url.split('.')[-1])
@@ -1101,7 +1111,8 @@ class KaggleApi(KaggleApi):
         with self.build_kaggle_client() as kaggle:
             request = ApiDownloadLeaderboardRequest()
             request.competition_name = competition
-            response = kaggle.competitions.competition_api_client.download_leaderboard(request)
+            response = kaggle.competitions.competition_api_client.download_leaderboard(
+                request)
         if path is None:
             effective_path = self.get_default_download_dir(
                 'competitions', competition)
@@ -1122,7 +1133,8 @@ class KaggleApi(KaggleApi):
         with self.build_kaggle_client() as kaggle:
             request = ApiGetLeaderboardRequest()
             request.competition_name = competition
-            response = kaggle.competitions.competition_api_client.get_leaderboard(request)
+            response = kaggle.competitions.competition_api_client.get_leaderboard(
+                request)
         return response.submissions
 
     def competition_leaderboard_cli(self,
@@ -1202,8 +1214,9 @@ class KaggleApi(KaggleApi):
         """
         if sort_by:
             if sort_by not in self.valid_dataset_sort_bys:
-                raise ValueError('Invalid sort by specified. Valid options are ' +
-                                 str(self.valid_dataset_sort_bys))
+                raise ValueError(
+                    'Invalid sort by specified. Valid options are ' +
+                    str(self.valid_dataset_sort_bys))
             else:
                 sort_by = DatasetSortBy[f"DATASET_SORT_BY_{sort_by.upper()}"]
 
@@ -1253,7 +1266,8 @@ class KaggleApi(KaggleApi):
             request.page = page
             request.max_size = max_size
             request.min_size = min_size
-            response = kaggle.datasets.dataset_api_client.list_datasets(request)
+            response = kaggle.datasets.dataset_api_client.list_datasets(
+                request)
             return response.datasets
 
     def dataset_list_cli(self,
@@ -1771,10 +1785,10 @@ class KaggleApi(KaggleApi):
                     self.process_response(
                         self.with_retry(
                             self.datasets_create_version_by_id_with_http_info)(
-                            id_no, request)))
+                                id_no, request)))
             else:
                 if ref == self.config_values[
-                    self.CONFIG_NAME_USER] + '/INSERT_SLUG_HERE':
+                        self.CONFIG_NAME_USER] + '/INSERT_SLUG_HERE':
                     raise ValueError(
                         'Default slug detected, please change values before '
                         'uploading')
@@ -1892,7 +1906,7 @@ class KaggleApi(KaggleApi):
 
         # validations
         if ref == self.config_values[
-            self.CONFIG_NAME_USER] + '/INSERT_SLUG_HERE':
+                self.CONFIG_NAME_USER] + '/INSERT_SLUG_HERE':
             raise ValueError(
                 'Default slug detected, please change values before uploading')
         if title == 'INSERT_TITLE_HERE':
@@ -2262,25 +2276,25 @@ class KaggleApi(KaggleApi):
         username = self.get_config_value(self.CONFIG_NAME_USER)
         meta_data = {
             'id':
-                username + '/INSERT_KERNEL_SLUG_HERE',
+            username + '/INSERT_KERNEL_SLUG_HERE',
             'title':
-                'INSERT_TITLE_HERE',
+            'INSERT_TITLE_HERE',
             'code_file':
-                'INSERT_CODE_FILE_PATH_HERE',
+            'INSERT_CODE_FILE_PATH_HERE',
             'language':
-                'Pick one of: {' +
-                ','.join(x for x in self.valid_push_language_types) + '}',
+            'Pick one of: {' +
+            ','.join(x for x in self.valid_push_language_types) + '}',
             'kernel_type':
-                'Pick one of: {' +
-                ','.join(x for x in self.valid_push_kernel_types) + '}',
+            'Pick one of: {' +
+            ','.join(x for x in self.valid_push_kernel_types) + '}',
             'is_private':
-                'true',
+            'true',
             'enable_gpu':
-                'false',
+            'false',
             'enable_tpu':
-                'false',
+            'false',
             'enable_internet':
-                'true',
+            'true',
             'dataset_sources': [],
             'competition_sources': [],
             'kernel_sources': [],
@@ -3522,8 +3536,8 @@ class KaggleApi(KaggleApi):
                 self.process_response(
                     self.with_retry(
                         self.models_create_instance_version_with_http_info)(
-                        owner_slug, model_slug, framework, instance_slug,
-                        request)))
+                            owner_slug, model_slug, framework, instance_slug,
+                            request)))
 
             return result
 
@@ -3816,8 +3830,9 @@ class KaggleApi(KaggleApi):
             if last_modified is None:
                 remote_date = datetime.now()
             else:
-                remote_date = datetime.strptime(response.headers['Last-Modified'],
-                                                '%a, %d %b %Y %H:%M:%S %Z')
+                remote_date = datetime.strptime(
+                    response.headers['Last-Modified'],
+                    '%a, %d %b %Y %H:%M:%S %Z')
             file_exists = os.path.isfile(outfile)
             if file_exists:
                 local_date = datetime.fromtimestamp(os.path.getmtime(outfile))
@@ -3836,7 +3851,7 @@ class KaggleApi(KaggleApi):
             pass
         return True
 
-    def print_table(self, items, fields, labels = None):
+    def print_table(self, items, fields, labels=None):
         """ print a table of items, for a set of fields defined
 
             Parameters
@@ -3852,10 +3867,15 @@ class KaggleApi(KaggleApi):
         if len(items) == 0:
             return
         for f in fields:
-            length = max(len(f),
-                         max([len(self.string(getattr(i, self.camel_to_snake(f)))) for i in items]))
-            justify = '>' if isinstance(getattr(
-                items[0], self.camel_to_snake(f)), int) or f == 'size' or f == 'reward' else '<'
+            length = max(
+                len(f),
+                max([
+                    len(self.string(getattr(i, self.camel_to_snake(f))))
+                    for i in items
+                ]))
+            justify = '>' if isinstance(
+                getattr(items[0], self.camel_to_snake(f)),
+                int) or f == 'size' or f == 'reward' else '<'
             formats.append('{:' + justify + self.string(length + 2) + '}')
             borders.append('-' * length + '  ')
         row_format = u''.join(formats)
@@ -3863,13 +3883,16 @@ class KaggleApi(KaggleApi):
         print(row_format.format(*headers))
         print(row_format.format(*borders))
         for i in items:
-            i_fields = [self.string(getattr(i, self.camel_to_snake(f))) + '  ' for f in fields]
+            i_fields = [
+                self.string(getattr(i, self.camel_to_snake(f))) + '  '
+                for f in fields
+            ]
             try:
                 print(row_format.format(*i_fields))
             except UnicodeEncodeError:
                 print(row_format.format(*i_fields).encode('utf-8'))
 
-    def print_csv(self, items, fields, labels = None):
+    def print_csv(self, items, fields, labels=None):
         """ print a set of fields in a set of items using a csv.writer
 
             Parameters
@@ -3883,7 +3906,9 @@ class KaggleApi(KaggleApi):
         writer = csv.writer(sys.stdout)
         writer.writerow(labels)
         for i in items:
-            i_fields = [self.string(getattr(i, self.camel_to_snake(f))) for f in fields]
+            i_fields = [
+                self.string(getattr(i, self.camel_to_snake(f))) for f in fields
+            ]
             writer.writerow(i_fields)
 
     def string(self, item):
@@ -4003,9 +4028,9 @@ class KaggleApi(KaggleApi):
         """
         for file_name in os.listdir(folder):
             if (file_name in [
-                self.DATASET_METADATA_FILE, self.OLD_DATASET_METADATA_FILE,
-                self.KERNEL_METADATA_FILE, self.MODEL_METADATA_FILE,
-                self.MODEL_INSTANCE_METADATA_FILE
+                    self.DATASET_METADATA_FILE, self.OLD_DATASET_METADATA_FILE,
+                    self.KERNEL_METADATA_FILE, self.MODEL_METADATA_FILE,
+                    self.MODEL_INSTANCE_METADATA_FILE
             ]):
                 continue
             upload_file = self._upload_file_or_folder(folder, file_name,
@@ -4150,10 +4175,10 @@ class KaggleApi(KaggleApi):
                         fp.seek(start_at)
                         session.headers.update({
                             'Content-Length':
-                                '%d' % upload_size,
+                            '%d' % upload_size,
                             'Content-Range':
-                                'bytes %d-%d/%d' %
-                                (start_at, file_size - 1, file_size)
+                            'bytes %d-%d/%d' %
+                            (start_at, file_size - 1, file_size)
                         })
                     reader = TqdmBufferedReader(fp, progress_bar)
                     retries = Retry(total=10, backoff_factor=0.5)
@@ -4335,7 +4360,7 @@ class KaggleApi(KaggleApi):
 
             split = model_instance_version.split('/')
             if not split[0] or not split[1] or not split[2] or not split[
-                3] or not split[4]:
+                    3] or not split[4]:
                 raise ValueError(
                     'Invalid model instance version specification ' +
                     model_instance_version)

--- a/kaggle/models/kaggle_models_extended.py
+++ b/kaggle/models/kaggle_models_extended.py
@@ -136,7 +136,7 @@ class File(object):
         self.size = File.get_size(self.totalBytes)
 
     def __repr__(self):
-        return self.ref
+        return self.name
 
     @staticmethod
     def get_size(size, precision=0):

--- a/kagglesdk/common/types/file_download.py
+++ b/kagglesdk/common/types/file_download.py
@@ -89,6 +89,10 @@ class FileDownload(KaggleObject):
     self._content_length = content_length
 
 
+  @classmethod
+  def prepare_from(cls, http_response):
+    return http_response
+
 FileDownload._fields = [
   FieldMetadata("contentType", "content_type", "_content_type", str, "", PredefinedSerializer()),
   FieldMetadata("fileName", "file_name", "_file_name", str, "", PredefinedSerializer()),

--- a/kagglesdk/kaggle_client.py
+++ b/kagglesdk/kaggle_client.py
@@ -25,12 +25,14 @@ class KaggleClient(object):
     def __init__(self, http_client: KaggleHttpClient):
       self.dataset_api_client = DatasetApiClient(http_client)
 
-  def __init__(self, env: KaggleEnv = None, verbose: bool = False):
-    self._http_client = http_client = KaggleHttpClient(env, verbose, self._renew_iap_token)
+  def __init__(self, env: KaggleEnv = None, verbose: bool = False, username: str = None, password: str = None):
+    self._http_client = http_client = KaggleHttpClient(env, verbose, self._renew_iap_token, username=username, password=password)
     self.kernels = KaggleClient.Kernels(http_client)
     self.models = KaggleClient.Models(http_client)
     self.competitions = KaggleClient.Competitions(http_client)
     self.datasets = KaggleClient.Datasets(http_client)
+    self.username = username
+    self.password = password
 
   def _renew_iap_token(self):
     return self.admin.admin_client.renew_iap_token()

--- a/kagglesdk/kaggle_env.py
+++ b/kagglesdk/kaggle_env.py
@@ -7,6 +7,8 @@ class KaggleEnv(Enum):
   STAGING = 1  # staging.kaggle.com
   ADMIN = 2  # admin.kaggle.com
   QA = 3 # qa.kaggle.com
+  # Direct prod access is not allowed to have IAP protection during testing.
+  # PROD = 3  # www.kaggle.com
 
 
 _env_to_endpoint = {
@@ -14,6 +16,8 @@ _env_to_endpoint = {
   KaggleEnv.STAGING: 'https://staging.kaggle.com',
   KaggleEnv.ADMIN: 'https://admin.kaggle.com',
   KaggleEnv.QA: 'https://qa.kaggle.com',
+  # See the comment above in KaggleEnv enum.
+  # KaggleEnv.PROD: "http://www.kaggle.com",
 }
 
 

--- a/kagglesdk/kaggle_env.py
+++ b/kagglesdk/kaggle_env.py
@@ -7,8 +7,8 @@ class KaggleEnv(Enum):
   STAGING = 1  # staging.kaggle.com
   ADMIN = 2  # admin.kaggle.com
   QA = 3 # qa.kaggle.com
-  # Direct prod access is not allowed to have IAP protection during testing.
-  # PROD = 3  # www.kaggle.com
+  # Direct prod access is not allowed to have IAP protection during testing, but we support basic auth.
+  PROD = 4  # www.kaggle.com
 
 
 _env_to_endpoint = {
@@ -17,7 +17,7 @@ _env_to_endpoint = {
   KaggleEnv.ADMIN: 'https://admin.kaggle.com',
   KaggleEnv.QA: 'https://qa.kaggle.com',
   # See the comment above in KaggleEnv enum.
-  # KaggleEnv.PROD: "http://www.kaggle.com",
+  KaggleEnv.PROD: "https://www.kaggle.com",
 }
 
 
@@ -37,4 +37,6 @@ def get_env():
     return KaggleEnv.STAGING
   if env == 'QA':
     return KaggleEnv.QA
+  if env == 'PROD':
+    return KaggleEnv.PROD
   raise Exception(f'Unrecognized value in KAGGLE_API_ENVIRONMENT: "{env}"')

--- a/kagglesdk/kaggle_http_client.py
+++ b/kagglesdk/kaggle_http_client.py
@@ -1,5 +1,7 @@
 import os
 import json
+import urllib.parse
+
 import requests
 from kagglesdk.kaggle_env import get_endpoint, get_env, KaggleEnv
 from kagglesdk.kaggle_object import KaggleObject
@@ -61,10 +63,9 @@ class KaggleHttpClient(object):
   def _prepare_request(self, service_name: str, request_name: str, request: KaggleObject):
     request_url = self._get_request_url(request)
     method = request.method()
-    if method == 'POST':
-      data = request.__class__.to_dict(request)
-    else:
-      data = []
+    data = request.__class__.to_dict(request)
+    if method == 'GET':
+      request_url = f'{request_url}?{urllib.parse.urlencode(data)}'
     http_request = requests.Request(
       method=method,
       url=request_url,

--- a/kagglesdk/kaggle_http_client.py
+++ b/kagglesdk/kaggle_http_client.py
@@ -44,12 +44,16 @@ class KaggleHttpClient(object):
   def __init__(self,
                env: KaggleEnv = None,
                verbose: bool = False,
-               renew_iap_token = None):
+               renew_iap_token = None,
+               username = None,
+               password = None):
     self._env = env or get_env()
     self._signed_in = None
     self._endpoint = get_endpoint(self._env)
     self._verbose = verbose
     self._session = None
+    self._username = username
+    self._password = password
 
   def call(self, service_name: str, request_name: str, request: KaggleObject, response_type: Type[KaggleObject]):
     self._init_session()
@@ -66,6 +70,11 @@ class KaggleHttpClient(object):
     data = request.__class__.to_dict(request)
     if method == 'GET':
       request_url = f'{request_url}?{urllib.parse.urlencode(data)}'
+      data = ''
+      self._session.headers.update({
+        'Accept': 'application/json',
+        'Content-Type': 'text/plain',
+      })
     http_request = requests.Request(
       method=method,
       url=request_url,
@@ -87,6 +96,10 @@ class KaggleHttpClient(object):
   def _prepare_response(self, response_type, http_response):
     self._print_response(http_response)
     http_response.raise_for_status()
+    if 'application/json' in http_response.headers['Content-Type']:
+      resp = http_response.json()
+      if 'code' in resp and resp['code'] >= 400:
+        raise requests.exceptions.HTTPError(resp['message'], response=http_response)
     if response_type is None:  # Method doesn't have a return type
       return None
     return response_type.prepare_from(http_response)
@@ -185,7 +198,10 @@ class KaggleHttpClient(object):
       self._signed_in = True
       return
 
-    apikey_creds = _get_apikey_creds()
+    if self._username and self._password:
+      apikey_creds = self._username, self._password
+    else:
+      apikey_creds = _get_apikey_creds()
     if apikey_creds is not None:
       self._session.auth = apikey_creds
       self._signed_in = True

--- a/kagglesdk/kaggle_object.py
+++ b/kagglesdk/kaggle_object.py
@@ -65,7 +65,15 @@ class EnumSerializer(ObjectSerializer):
     #   return enum_items[v[ix_start:]]
     # 
     # return enum_items[f'{enum_prefix}_{v}']
-    return cls[v]
+    try:
+      return cls[v]
+    except KeyError:
+      dct = vars(cls)
+      n = v.lower()
+      for key in dct.keys():
+        if key.lower() == n:
+          return dct[key]
+      raise
 
 
 class ListSerializer(ObjectSerializer):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,8 @@ dependencies = [
   "text-unidecode",
   "tqdm",
   "urllib3>=1.15.1",
-  "webencodings"
+  "webencodings", 
+  "protobuf"
 ]
 
 [project.scripts]

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         'python-slugify',
         'urllib3',
         'bleach',
+        'protobuf'
     ],
     packages=find_packages(exclude=("src.*", "src")),
     license='Apache 2.0')

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -76,6 +76,9 @@ from tqdm import tqdm
 import bleach
 import time
 
+from kagglesdk import KaggleClient, KaggleEnv
+from kagglesdk.competitions.types.competition_api_service import *
+
 try:
     unicode  # Python 2
 except NameError:
@@ -189,8 +192,8 @@ class ResumableFileUpload(object):
 
     def _is_previous_valid(self, previous):
         return previous.path == self.path and \
-               previous.start_blob_upload_request == self.start_blob_upload_request and \
-               previous.timestamp > time.time() - ResumableFileUpload.RESUMABLE_UPLOAD_EXPIRY_SECONDS
+            previous.start_blob_upload_request == self.start_blob_upload_request and \
+            previous.timestamp > time.time() - ResumableFileUpload.RESUMABLE_UPLOAD_EXPIRY_SECONDS
 
     def upload_initiated(self, start_blob_upload_response):
         if self.context.no_resume:
@@ -223,16 +226,16 @@ class ResumableFileUpload(object):
     def to_dict(self):
         return {
             'path':
-            self.path,
+                self.path,
             'start_blob_upload_request':
-            self.start_blob_upload_request.to_dict(),
+                self.start_blob_upload_request.to_dict(),
             'timestamp':
-            self.timestamp,
+                self.timestamp,
             'start_blob_upload_response':
-            self.start_blob_upload_response.to_dict()
-            if self.start_blob_upload_response is not None else None,
+                self.start_blob_upload_response.to_dict()
+                if self.start_blob_upload_response is not None else None,
             'upload_complete':
-            self.upload_complete,
+                self.upload_complete,
         }
 
     def from_dict(other, context):
@@ -292,6 +295,7 @@ class KaggleApi(KaggleApi):
     config = os.path.join(config_dir, config_file)
     config_values = {}
     already_printed_version_warning = False
+    args = {}
 
     # Kernels valid types
     valid_push_kernel_types = ['script', 'notebook']
@@ -400,7 +404,7 @@ class KaggleApi(KaggleApi):
                 config_data = self.read_config_file(config_data)
             elif self._is_help_or_version_command(api_command) or (len(
                     sys.argv) > 2 and api_command.startswith(
-                        self.command_prefixes_allowing_anonymous_access)):
+                self.command_prefixes_allowing_anonymous_access)):
                 # Some API commands should be allowed without authentication.
                 return
             else:
@@ -408,7 +412,7 @@ class KaggleApi(KaggleApi):
                               ' {}. Or use the environment method. See setup'
                               ' instructions at'
                               ' https://github.com/Kaggle/kaggle-api/'.format(
-                                  self.config_file, self.config_dir))
+                    self.config_file, self.config_dir))
 
         # Step 3: load into configuration!
         self._load_config(config_data)
@@ -668,6 +672,21 @@ class KaggleApi(KaggleApi):
         self.print_config_value(self.CONFIG_NAME_PROXY, prefix=prefix)
         self.print_config_value(self.CONFIG_NAME_COMPETITION, prefix=prefix)
 
+    def build_kaggle_client(self):
+        env = KaggleEnv.STAGING if '--staging' in self.args \
+            else KaggleEnv.ADMIN if '--admin' in self.args \
+            else KaggleEnv.LOCAL
+        verbose = '--verbose' in self.args or '-v' in self.args
+        return KaggleClient(env=env, verbose=verbose)
+
+    def camel_to_snake(self, name):
+        """
+        :param name: field in camel case
+        :return: field in snake case
+        """
+        name = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
+        return re.sub('([a-z0-9])([A-Z])', r'\1_\2', name).lower()
+
     ## Competitions
 
     def competitions_list(self,
@@ -676,8 +695,8 @@ class KaggleApi(KaggleApi):
                           sort_by=None,
                           page=1,
                           search=None):
-        """ make call to list competitions, format the response, and return
-            a list of Competition instances
+        """ Make a call to list competitions, format the response, and return
+            a list of ApiCompetition instances
 
             Parameters
             ==========
@@ -700,13 +719,16 @@ class KaggleApi(KaggleApi):
             raise ValueError('Invalid sort_by specified. Valid options are ' +
                              str(self.valid_competition_sort_by))
 
-        competitions_list_result = self.process_response(
-            self.competitions_list_with_http_info(group=group or '',
-                                                  category=category or '',
-                                                  sort_by=sort_by or '',
-                                                  page=page,
-                                                  search=search or ''))
-        return [Competition(c) for c in competitions_list_result]
+        with self.build_kaggle_client() as kaggle:
+            request = ApiListCompetitionsRequest()
+            request.group = group
+            request.page = page
+            request.category = category
+            request.search = search
+            request.sort_by = sort_by
+            response = kaggle.competitions.competition_api_client.list_competitions(
+                request)
+            return response.competitions
 
     def competitions_list_cli(self,
                               group=None,
@@ -715,7 +737,7 @@ class KaggleApi(KaggleApi):
                               page=1,
                               search=None,
                               csv_display=False):
-        """ a wrapper for competitions_list for the client.
+        """ A wrapper for competitions_list for the client.
 
             Parameters
             ==========
@@ -744,13 +766,13 @@ class KaggleApi(KaggleApi):
             print('No competitions found')
 
     def competition_submit(self, file_name, message, competition, quiet=False):
-        """ submit a competition!
+        """ Submit a competition.
 
             Parameters
             ==========
             file_name: the competition metadata file
             message: the submission description
-            competition: the competition name
+            competition: the competition name; if not given use the 'competition' config value
             quiet: suppress verbose output (default is False)
         """
         if competition is None:
@@ -761,44 +783,30 @@ class KaggleApi(KaggleApi):
         if competition is None:
             raise ValueError('No competition specified')
         else:
-            url_result = self.process_response(
-                self.competitions_submissions_url_with_http_info(
-                    id=competition,
-                    file_name=os.path.basename(file_name),
-                    content_length=os.path.getsize(file_name),
-                    last_modified_date_utc=int(os.path.getmtime(file_name))))
-
-            # Temporary while new worker is gradually turned on.  'isComplete'
-            # exists on the old DTO but not the new, so this is an hacky but
-            # easy solution to figure out which submission logic to use
-            if 'isComplete' in url_result:
-                # Old submissions path
-                url_result_list = url_result['createUrl'].split('/')
-                upload_result = self.process_response(
-                    self.competitions_submissions_upload_with_http_info(
-                        file=file_name,
-                        guid=url_result_list[-3],
-                        content_length=url_result_list[-2],
-                        last_modified_date_utc=url_result_list[-1]))
-                upload_result_token = upload_result['token']
-            else:
-                # New submissions path!
+            with self.build_kaggle_client() as kaggle:
+                request = ApiStartSubmissionUploadRequest()
+                request.competition_name = competition
+                request.file_name = os.path.basename(file_name)
+                request.content_length = os.path.getsize(file_name)
+                request.last_modified_epoch_seconds = int(
+                    os.path.getmtime(file_name))
+                response = kaggle.competitions.competition_api_client.start_submission_upload(
+                    request)
                 upload_status = self.upload_complete(file_name,
-                                                     url_result['createUrl'],
+                                                     response.create_url,
                                                      quiet)
                 if upload_status != ResumableUploadResult.COMPLETE:
                     # Actual error is printed during upload_complete. Not
                     # ideal but changing would not be backwards compatible
                     return "Could not submit to competition"
 
-                upload_result_token = url_result['token']
-
-            submit_result = self.process_response(
-                self.competitions_submissions_submit_with_http_info(
-                    id=competition,
-                    blob_file_tokens=upload_result_token,
-                    submission_description=message))
-            return SubmitResult(submit_result)
+                submit_request = ApiCreateSubmissionRequest()
+                submit_request.competition_name = competition
+                submit_request.blob_file_tokens = response.token
+                submit_request.submission_description = message
+                submit_response = kaggle.competitions.competition_api_client.create_submission(
+                    submit_request)
+                return submit_response
 
     def competition_submit_cli(self,
                                file_name,
@@ -806,10 +814,15 @@ class KaggleApi(KaggleApi):
                                competition,
                                competition_opt=None,
                                quiet=False):
-        """ submit a competition using the client. Arguments are same as for
+        """ Submit a competition using the client. Arguments are same as for
             competition_submit, except for extra arguments provided here.
-             Parameters
+            
+            Parameters
             ==========
+            file_name: the competition metadata file
+            message: the submission description
+            competition: the competition name; if not given use the 'competition' config value
+            quiet: suppress verbose output (default is False)
             competition_opt: an alternative competition option provided by cli
         """
         competition = competition or competition_opt
@@ -828,19 +841,28 @@ class KaggleApi(KaggleApi):
 
     def competition_submissions(self,
                                 competition,
+                                group=None,
+                                sort=None, # SubmissionSortBy.SUBMISSION_SORT_BY_NAME,
                                 page_token=None,
                                 page_size=20):
-        """ get the list of Submission for a particular competition
+        """ Get the list of Submission for a particular competition.
 
             Parameters
             ==========
             competition: the name of the competition
+            group: the submission group
+            sort: the sort-by option
             page_token: token for pagination
             page_size: the number of items per page
         """
-        submissions_result = self.process_response(
-            self.competitions_submissions_list_with_http_info(id=competition))
-        return [Submission(s) for s in submissions_result]
+        with self.build_kaggle_client() as kaggle:
+            request = ApiListSubmissionsRequest()
+            request.competition_name = competition
+            request.page = page_token
+            request.group = group
+            request.sort_by = sort
+            response = kaggle.competitions.competition_api_client.list_submissions(request)
+            return response.submissions
 
     def competition_submissions_cli(self,
                                     competition=None,
@@ -849,7 +871,7 @@ class KaggleApi(KaggleApi):
                                     page_token=None,
                                     page_size=20,
                                     quiet=False):
-        """ wrapper to competition_submission, will return either json or csv
+        """ A wrapper to competition_submission, will return either json or csv
             to the user. Additional parameters are listed below, see
             competition_submissions for rest.
 
@@ -871,8 +893,8 @@ class KaggleApi(KaggleApi):
         if competition is None:
             raise ValueError('No competition specified')
         else:
-            submissions = self.competition_submissions(competition, page_token,
-                                                       page_size)
+            submissions = self.competition_submissions(competition, page_token=page_token,
+                                                       page_size=page_size)
             fields = [
                 'fileName', 'date', 'description', 'status', 'publicScore',
                 'privateScore'
@@ -889,17 +911,20 @@ class KaggleApi(KaggleApi):
                                competition,
                                page_token=None,
                                page_size=20):
-        """ list files for competition
+        """ List files for a competition.
              Parameters
             ==========
             competition: the name of the competition
             page_token: the page token for pagination
             page_size: the number of items per page
         """
-        competition_list_files_result = self.process_response(
-            self.competitions_data_list_files_with_http_info(
-                id=competition, page_token=page_token, page_size=page_size))
-        return FileList(competition_list_files_result)
+        with self.build_kaggle_client() as kaggle:
+            request = ApiListDataFilesRequest()
+            request.competition_name = competition
+            request.page_token = page_token
+            request.page_size = page_size
+            response = kaggle.competitions.competition_api_client.list_data_files(request)
+            return response
 
     def competition_list_files_cli(self,
                                    competition,
@@ -908,7 +933,7 @@ class KaggleApi(KaggleApi):
                                    page_token=None,
                                    page_size=20,
                                    quiet=False):
-        """ List files for a competition, if it exists
+        """ List files for a competition, if it exists.
 
             Parameters
             ==========
@@ -930,15 +955,16 @@ class KaggleApi(KaggleApi):
         else:
             result = self.competition_list_files(competition, page_token,
                                                  page_size)
-            next_page_token = result.nextPageToken
+            next_page_token = result.next_page_token
             if next_page_token:
                 print('Next Page Token = {}'.format(next_page_token))
-            fields = ['name', 'size', 'creationDate']
+            fields = ['name', 'totalBytes', 'creationDate']
+            labels = ['name', 'size', 'creationDate']
             if result:
                 if csv_display:
-                    self.print_csv(result.files, fields)
+                    self.print_csv(result.files, fields, labels)
                 else:
-                    self.print_table(result.files, fields)
+                    self.print_table(result.files, fields, labels)
             else:
                 print('No files found')
 
@@ -948,8 +974,8 @@ class KaggleApi(KaggleApi):
                                   path=None,
                                   force=False,
                                   quiet=False):
-        """ download a competition file to a designated location, or use
-            a default location
+        """ Download a competition file to a designated location, or use
+            a default location.
 
             Parameters
             =========
@@ -965,10 +991,12 @@ class KaggleApi(KaggleApi):
         else:
             effective_path = path
 
-        response = self.process_response(
-            self.competitions_data_download_file_with_http_info(
-                id=competition, file_name=file_name, _preload_content=False))
-        url = response.retries.history[0].redirect_location.split('?')[0]
+        with self.build_kaggle_client() as kaggle:
+            request = ApiDownloadDataFileRequest()
+            request.competition_name = competition
+            request.file_name = file_name
+            response = kaggle.competitions.competition_api_client.download_data_file(request)
+        url = response.history[0].url
         outfile = os.path.join(effective_path, url.split('/')[-1])
 
         if force or self.download_needed(response, outfile, quiet):
@@ -979,7 +1007,7 @@ class KaggleApi(KaggleApi):
                                    path=None,
                                    force=False,
                                    quiet=True):
-        """ downloads all competition files.
+        """ Download all competition files.
 
             Parameters
             =========
@@ -994,10 +1022,11 @@ class KaggleApi(KaggleApi):
         else:
             effective_path = path
 
-        response = self.process_response(
-            self.competitions_data_download_files_with_http_info(
-                id=competition, _preload_content=False))
-        url = response.retries.history[0].redirect_location.split('?')[0]
+        with self.build_kaggle_client() as kaggle:
+            request = ApiDownloadDataFilesRequest()
+            request.competition_name = competition
+            response = kaggle.competitions.competition_api_client.download_data_files(request)
+        url = response.url.split('?')[0]
         outfile = os.path.join(effective_path,
                                competition + '.' + url.split('.')[-1])
 
@@ -1011,7 +1040,7 @@ class KaggleApi(KaggleApi):
                                  path=None,
                                  force=False,
                                  quiet=False):
-        """ a wrapper to competition_download_files, but first will parse input
+        """ A wrapper to competition_download_files, but first will parse input
             from API client. Additional parameters are listed here, see
             competition_download for remaining.
 
@@ -1041,7 +1070,7 @@ class KaggleApi(KaggleApi):
                                                force, quiet)
 
     def competition_leaderboard_download(self, competition, path, quiet=True):
-        """ Download competition leaderboards
+        """ Download a competition leaderboard.
 
             Parameters
             =========
@@ -1049,10 +1078,10 @@ class KaggleApi(KaggleApi):
             path: a path to download the file to
             quiet: suppress verbose output (default is True)
         """
-        response = self.process_response(
-            self.competition_download_leaderboard_with_http_info(
-                competition, _preload_content=False))
-
+        with self.build_kaggle_client() as kaggle:
+            request = ApiDownloadLeaderboardRequest()
+            request.competition_name = competition
+            response = kaggle.competitions.competition_api_client.download_leaderboard(request)
         if path is None:
             effective_path = self.get_default_download_dir(
                 'competitions', competition)
@@ -1064,15 +1093,17 @@ class KaggleApi(KaggleApi):
         self.download_file(response, outfile, quiet)
 
     def competition_leaderboard_view(self, competition):
-        """ view a leaderboard based on a competition name
+        """ View a leaderboard based on a competition name.
 
             Parameters
             ==========
             competition: the competition name to view leadboard for
         """
-        result = self.process_response(
-            self.competition_view_leaderboard_with_http_info(competition))
-        return [LeaderboardEntry(e) for e in result['submissions']]
+        with self.build_kaggle_client() as kaggle:
+            request = ApiGetLeaderboardRequest()
+            request.competition_name = competition
+            response = kaggle.competitions.competition_api_client.get_leaderboard(request)
+        return response.submissions
 
     def competition_leaderboard_cli(self,
                                     competition,
@@ -1082,7 +1113,7 @@ class KaggleApi(KaggleApi):
                                     download=False,
                                     csv_display=False,
                                     quiet=False):
-        """ a wrapper for competition_leaderbord_view that will print the
+        """ A wrapper for competition_leaderbord_view that will print the
             results as a table or comma separated values
 
             Parameters
@@ -1133,7 +1164,7 @@ class KaggleApi(KaggleApi):
                      page=1,
                      max_size=None,
                      min_size=None):
-        """ return a list of datasets!
+        """ Return a list of datasets.
 
             Parameters
             ==========
@@ -1214,7 +1245,7 @@ class KaggleApi(KaggleApi):
                          csv_display=False,
                          max_size=None,
                          min_size=None):
-        """ a wrapper to dataset_list for the client. Additional parameters
+        """ A wrapper to dataset_list for the client. Additional parameters
             are described here, see dataset_list for others.
 
             Parameters
@@ -1325,7 +1356,7 @@ class KaggleApi(KaggleApi):
             print('Downloaded metadata to ' + meta_file)
 
     def dataset_list_files(self, dataset, page_token=None, page_size=20):
-        """ list files for a dataset
+        """ List files for a dataset.
              Parameters
             ==========
             dataset: the string identified of the dataset
@@ -1353,8 +1384,8 @@ class KaggleApi(KaggleApi):
                                csv_display=False,
                                page_token=None,
                                page_size=20):
-        """ a wrapper to dataset_list_files for the client
-            (list files for a dataset)
+        """ A wrapper to dataset_list_files for the client
+            (list files for a dataset).
              Parameters
             ==========
             dataset: the string identified of the dataset
@@ -1383,10 +1414,10 @@ class KaggleApi(KaggleApi):
             print('No files found')
 
     def dataset_status(self, dataset):
-        """ call to get the status of a dataset from the API
+        """ Call to get the status of a dataset from the API.
              Parameters
             ==========
-            dataset: the string identified of the dataset
+            dataset: the string identifier of the dataset
                      should be in format [owner]/[dataset-name]
         """
         if dataset is None:
@@ -1405,8 +1436,8 @@ class KaggleApi(KaggleApi):
         return dataset_status_result
 
     def dataset_status_cli(self, dataset, dataset_opt=None):
-        """ wrapper for client for dataset_status, with additional
-            dataset_opt to get the status of a dataset from the API
+        """ A wrapper for client for dataset_status, with additional
+            dataset_opt to get the status of a dataset from the API.
              Parameters
             ==========
             dataset_opt: an alternative to dataset
@@ -1421,7 +1452,7 @@ class KaggleApi(KaggleApi):
                               force=False,
                               quiet=True,
                               licenses=[]):
-        """ download a single file for a dataset
+        """ Download a single file for a dataset.
 
             Parameters
             ==========
@@ -1473,7 +1504,7 @@ class KaggleApi(KaggleApi):
                                quiet=True,
                                unzip=False,
                                licenses=[]):
-        """ download all files for a dataset
+        """ Download all files for a dataset.
 
             Parameters
             ==========
@@ -1716,10 +1747,10 @@ class KaggleApi(KaggleApi):
                     self.process_response(
                         self.with_retry(
                             self.datasets_create_version_by_id_with_http_info)(
-                                id_no, request)))
+                            id_no, request)))
             else:
                 if ref == self.config_values[
-                        self.CONFIG_NAME_USER] + '/INSERT_SLUG_HERE':
+                    self.CONFIG_NAME_USER] + '/INSERT_SLUG_HERE':
                     raise ValueError(
                         'Default slug detected, please change values before '
                         'uploading')
@@ -1837,7 +1868,7 @@ class KaggleApi(KaggleApi):
 
         # validations
         if ref == self.config_values[
-                self.CONFIG_NAME_USER] + '/INSERT_SLUG_HERE':
+            self.CONFIG_NAME_USER] + '/INSERT_SLUG_HERE':
             raise ValueError(
                 'Default slug detected, please change values before uploading')
         if title == 'INSERT_TITLE_HERE':
@@ -1980,16 +2011,28 @@ class KaggleApi(KaggleApi):
                   unit_divisor=1024,
                   disable=quiet) as pbar:
             with open(outfile, open_mode) as out:
-                while True:
-                    data = response.read(chunk_size)
-                    if not data:
-                        break
-                    out.write(data)
-                    os.utime(outfile,
-                             times=(remote_date_timestamp - 1,
-                                    remote_date_timestamp - 1))
-                    size_read = min(size, size_read + chunk_size)
-                    pbar.update(len(data))
+                # TODO: Delete this test after all API methods are converted.
+                if type(response).__name__ == 'HTTPResponse':
+                    while True:
+                        data = response.read(chunk_size)
+                        if not data:
+                            break
+                        out.write(data)
+                        os.utime(outfile,
+                                 times=(remote_date_timestamp - 1,
+                                        remote_date_timestamp - 1))
+                        size_read = min(size, size_read + chunk_size)
+                        pbar.update(len(data))
+                else:
+                    for data in response.iter_content(chunk_size):
+                        if not data:
+                            break
+                        out.write(data)
+                        os.utime(outfile,
+                                 times=(remote_date_timestamp - 1,
+                                        remote_date_timestamp - 1))
+                        size_read = min(size, size_read + chunk_size)
+                        pbar.update(len(data))
             if not quiet:
                 print('\n', end='')
 
@@ -2195,25 +2238,25 @@ class KaggleApi(KaggleApi):
         username = self.get_config_value(self.CONFIG_NAME_USER)
         meta_data = {
             'id':
-            username + '/INSERT_KERNEL_SLUG_HERE',
+                username + '/INSERT_KERNEL_SLUG_HERE',
             'title':
-            'INSERT_TITLE_HERE',
+                'INSERT_TITLE_HERE',
             'code_file':
-            'INSERT_CODE_FILE_PATH_HERE',
+                'INSERT_CODE_FILE_PATH_HERE',
             'language':
-            'Pick one of: {' +
-            ','.join(x for x in self.valid_push_language_types) + '}',
+                'Pick one of: {' +
+                ','.join(x for x in self.valid_push_language_types) + '}',
             'kernel_type':
-            'Pick one of: {' +
-            ','.join(x for x in self.valid_push_kernel_types) + '}',
+                'Pick one of: {' +
+                ','.join(x for x in self.valid_push_kernel_types) + '}',
             'is_private':
-            'true',
+                'true',
             'enable_gpu':
-            'false',
+                'false',
             'enable_tpu':
-            'false',
+                'false',
             'enable_internet':
-            'true',
+                'true',
             'dataset_sources': [],
             'competition_sources': [],
             'kernel_sources': [],
@@ -3455,8 +3498,8 @@ class KaggleApi(KaggleApi):
                 self.process_response(
                     self.with_retry(
                         self.models_create_instance_version_with_http_info)(
-                            owner_slug, model_slug, framework, instance_slug,
-                            request)))
+                        owner_slug, model_slug, framework, instance_slug,
+                        request)))
 
             return result
 
@@ -3769,48 +3812,54 @@ class KaggleApi(KaggleApi):
             pass
         return True
 
-    def print_table(self, items, fields):
+    def print_table(self, items, fields, labels: None):
         """ print a table of items, for a set of fields defined
 
             Parameters
             ==========
             items: a list of items to print
             fields: a list of fields to select from items
+            labels: labels for the fields, defaults to fields
         """
+        if labels is None:
+            labels = fields
         formats = []
         borders = []
         if len(items) == 0:
             return
         for f in fields:
             length = max(len(f),
-                         max([len(self.string(getattr(i, f))) for i in items]))
+                         max([len(self.string(getattr(i, self.camel_to_snake(f)))) for i in items]))
             justify = '>' if isinstance(getattr(
-                items[0], f), int) or f == 'size' or f == 'reward' else '<'
+                items[0], self.camel_to_snake(f)), int) or f == 'size' or f == 'reward' else '<'
             formats.append('{:' + justify + self.string(length + 2) + '}')
             borders.append('-' * length + '  ')
         row_format = u''.join(formats)
-        headers = [f + '  ' for f in fields]
+        headers = [f + '  ' for f in labels]
         print(row_format.format(*headers))
         print(row_format.format(*borders))
         for i in items:
-            i_fields = [self.string(getattr(i, f)) + '  ' for f in fields]
+            i_fields = [self.string(getattr(i, self.camel_to_snake(f))) + '  ' for f in fields]
             try:
                 print(row_format.format(*i_fields))
             except UnicodeEncodeError:
                 print(row_format.format(*i_fields).encode('utf-8'))
 
-    def print_csv(self, items, fields):
+    def print_csv(self, items, fields, labels: None):
         """ print a set of fields in a set of items using a csv.writer
 
             Parameters
             ==========
             items: a list of items to print
             fields: a list of fields to select from items
+            labels: labels for the fields, defaults to fields
         """
+        if labels is None:
+            labels = fields
         writer = csv.writer(sys.stdout)
-        writer.writerow(fields)
+        writer.writerow(labels)
         for i in items:
-            i_fields = [self.string(getattr(i, f)) for f in fields]
+            i_fields = [self.string(getattr(i, self.camel_to_snake(f))) for f in fields]
             writer.writerow(i_fields)
 
     def string(self, item):
@@ -3930,9 +3979,9 @@ class KaggleApi(KaggleApi):
         """
         for file_name in os.listdir(folder):
             if (file_name in [
-                    self.DATASET_METADATA_FILE, self.OLD_DATASET_METADATA_FILE,
-                    self.KERNEL_METADATA_FILE, self.MODEL_METADATA_FILE,
-                    self.MODEL_INSTANCE_METADATA_FILE
+                self.DATASET_METADATA_FILE, self.OLD_DATASET_METADATA_FILE,
+                self.KERNEL_METADATA_FILE, self.MODEL_METADATA_FILE,
+                self.MODEL_INSTANCE_METADATA_FILE
             ]):
                 continue
             upload_file = self._upload_file_or_folder(folder, file_name,
@@ -4077,10 +4126,10 @@ class KaggleApi(KaggleApi):
                         fp.seek(start_at)
                         session.headers.update({
                             'Content-Length':
-                            '%d' % upload_size,
+                                '%d' % upload_size,
                             'Content-Range':
-                            'bytes %d-%d/%d' %
-                            (start_at, file_size - 1, file_size)
+                                'bytes %d-%d/%d' %
+                                (start_at, file_size - 1, file_size)
                         })
                     reader = TqdmBufferedReader(fp, progress_bar)
                     retries = Retry(total=10, backoff_factor=0.5)
@@ -4262,7 +4311,7 @@ class KaggleApi(KaggleApi):
 
             split = model_instance_version.split('/')
             if not split[0] or not split[1] or not split[2] or not split[
-                    3] or not split[4]:
+                3] or not split[4]:
                 raise ValueError(
                     'Invalid model instance version specification ' +
                     model_instance_version)

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -195,8 +195,8 @@ class ResumableFileUpload(object):
 
     def _is_previous_valid(self, previous):
         return previous.path == self.path and \
-               previous.start_blob_upload_request == self.start_blob_upload_request and \
-               previous.timestamp > time.time() - ResumableFileUpload.RESUMABLE_UPLOAD_EXPIRY_SECONDS
+            previous.start_blob_upload_request == self.start_blob_upload_request and \
+            previous.timestamp > time.time() - ResumableFileUpload.RESUMABLE_UPLOAD_EXPIRY_SECONDS
 
     def upload_initiated(self, start_blob_upload_response):
         if self.context.no_resume:
@@ -229,16 +229,16 @@ class ResumableFileUpload(object):
     def to_dict(self):
         return {
             'path':
-            self.path,
+                self.path,
             'start_blob_upload_request':
-            self.start_blob_upload_request.to_dict(),
+                self.start_blob_upload_request.to_dict(),
             'timestamp':
-            self.timestamp,
+                self.timestamp,
             'start_blob_upload_response':
-            self.start_blob_upload_response.to_dict()
-            if self.start_blob_upload_response is not None else None,
+                self.start_blob_upload_response.to_dict()
+                if self.start_blob_upload_response is not None else None,
             'upload_complete':
-            self.upload_complete,
+                self.upload_complete,
         }
 
     def from_dict(other, context):
@@ -339,6 +339,15 @@ class KaggleApi(KaggleApi):
     command_prefixes_allowing_anonymous_access = ('datasets download',
                                                   'datasets files')
 
+    # Attributes
+    competition_fields = ['ref', 'deadline', 'category', 'reward', 'teamCount','userHasEntered']
+    submission_fields = ['fileName', 'date', 'description', 'status', 'publicScore', 'privateScore']
+    competition_file_fields = ['name', 'totalBytes', 'creationDate']
+    competition_file_labels = ['name', 'size', 'creationDate']
+    competition_leaderboard_fields = ['teamId', 'teamName', 'submissionDate', 'score']
+    dataset_fields = ['ref', 'title', 'totalBytes', 'lastUpdated', 'downloadCount', 'voteCount', 'usabilityRating']
+    dataset_labels = ['ref', 'title', 'size', 'lastUpdated', 'downloadCount', 'voteCount', 'usabilityRating']
+
     # Hack for https://github.com/Kaggle/kaggle-api/issues/22 / b/78194015
     if six.PY2:
         reload(sys)
@@ -407,7 +416,7 @@ class KaggleApi(KaggleApi):
                 config_data = self.read_config_file(config_data)
             elif self._is_help_or_version_command(api_command) or (
                     len(sys.argv) > 2 and api_command.startswith(
-                        self.command_prefixes_allowing_anonymous_access)):
+                self.command_prefixes_allowing_anonymous_access)):
                 # Some API commands should be allowed without authentication.
                 return
             else:
@@ -415,7 +424,7 @@ class KaggleApi(KaggleApi):
                               ' {}. Or use the environment method. See setup'
                               ' instructions at'
                               ' https://github.com/Kaggle/kaggle-api/'.format(
-                                  self.config_file, self.config_dir))
+                    self.config_file, self.config_dir))
 
         # Step 3: load into configuration!
         self._load_config(config_data)
@@ -681,6 +690,7 @@ class KaggleApi(KaggleApi):
             else KaggleEnv.LOCAL if '--local' in self.args \
             else KaggleEnv.PROD
         verbose = '--verbose' in self.args or '-v' in self.args
+        config = self.api_client.configuration
         return KaggleClient(env=env,
                             verbose=verbose,
                             username=config.username,
@@ -760,15 +770,11 @@ class KaggleApi(KaggleApi):
                                               sort_by=sort_by,
                                               page=page,
                                               search=search)
-        fields = [
-            'ref', 'deadline', 'category', 'reward', 'teamCount',
-            'userHasEntered'
-        ]
         if competitions:
             if csv_display:
-                self.print_csv(competitions, fields)
+                self.print_csv(competitions, self.competition_fields)
             else:
-                self.print_table(competitions, fields)
+                self.print_table(competitions, self.competition_fields)
         else:
             print('No competitions found')
 
@@ -905,15 +911,11 @@ class KaggleApi(KaggleApi):
             submissions = self.competition_submissions(competition,
                                                        page_token=page_token,
                                                        page_size=page_size)
-            fields = [
-                'fileName', 'date', 'description', 'status', 'publicScore',
-                'privateScore'
-            ]
             if submissions:
                 if csv_display:
-                    self.print_csv(submissions, fields)
+                    self.print_csv(submissions, submission_fields)
                 else:
-                    self.print_table(submissions, fields)
+                    self.print_table(submissions, submission_fields)
             else:
                 print('No submissions found')
 
@@ -969,13 +971,11 @@ class KaggleApi(KaggleApi):
             next_page_token = result.next_page_token
             if next_page_token:
                 print('Next Page Token = {}'.format(next_page_token))
-            fields = ['name', 'totalBytes', 'creationDate']
-            labels = ['name', 'size', 'creationDate']
             if result:
                 if csv_display:
-                    self.print_csv(result.files, fields, labels)
+                    self.print_csv(result.files, self.competition_file_fields, self.competition_file_labels)
                 else:
-                    self.print_table(result.files, fields, labels)
+                    self.print_table(result.files, self.competition_file_fields, self.competition_file_labels)
             else:
                 print('No files found')
 
@@ -1159,12 +1159,11 @@ class KaggleApi(KaggleApi):
 
         if view:
             results = self.competition_leaderboard_view(competition)
-            fields = ['teamId', 'teamName', 'submissionDate', 'score']
             if results:
                 if csv_display:
-                    self.print_csv(results, fields)
+                    self.print_csv(results, self.competition_leaderboard_fields)
                 else:
-                    self.print_table(results, fields)
+                    self.print_table(results, self.competition_leaderboard_fields)
             else:
                 print('No results found')
 
@@ -1288,15 +1287,11 @@ class KaggleApi(KaggleApi):
         datasets = self.dataset_list(sort_by, size, file_type, license_name,
                                      tag_ids, search, user, mine, page,
                                      max_size, min_size)
-        fields = [
-            'ref', 'title', 'size', 'lastUpdated', 'downloadCount',
-            'voteCount', 'usabilityRating'
-        ]
         if datasets:
             if csv_display:
-                self.print_csv(datasets, fields)
+                self.print_csv(datasets, self.dataset_fields, self.dataset_labels)
             else:
-                self.print_table(datasets, fields)
+                self.print_table(datasets, self.dataset_fields, self.dataset_labels)
         else:
             print('No datasets found')
 
@@ -1769,10 +1764,10 @@ class KaggleApi(KaggleApi):
                     self.process_response(
                         self.with_retry(
                             self.datasets_create_version_by_id_with_http_info)(
-                                id_no, request)))
+                            id_no, request)))
             else:
                 if ref == self.config_values[
-                        self.CONFIG_NAME_USER] + '/INSERT_SLUG_HERE':
+                    self.CONFIG_NAME_USER] + '/INSERT_SLUG_HERE':
                     raise ValueError(
                         'Default slug detected, please change values before '
                         'uploading')
@@ -1890,7 +1885,7 @@ class KaggleApi(KaggleApi):
 
         # validations
         if ref == self.config_values[
-                self.CONFIG_NAME_USER] + '/INSERT_SLUG_HERE':
+            self.CONFIG_NAME_USER] + '/INSERT_SLUG_HERE':
             raise ValueError(
                 'Default slug detected, please change values before uploading')
         if title == 'INSERT_TITLE_HERE':
@@ -2260,25 +2255,25 @@ class KaggleApi(KaggleApi):
         username = self.get_config_value(self.CONFIG_NAME_USER)
         meta_data = {
             'id':
-            username + '/INSERT_KERNEL_SLUG_HERE',
+                username + '/INSERT_KERNEL_SLUG_HERE',
             'title':
-            'INSERT_TITLE_HERE',
+                'INSERT_TITLE_HERE',
             'code_file':
-            'INSERT_CODE_FILE_PATH_HERE',
+                'INSERT_CODE_FILE_PATH_HERE',
             'language':
-            'Pick one of: {' +
-            ','.join(x for x in self.valid_push_language_types) + '}',
+                'Pick one of: {' +
+                ','.join(x for x in self.valid_push_language_types) + '}',
             'kernel_type':
-            'Pick one of: {' +
-            ','.join(x for x in self.valid_push_kernel_types) + '}',
+                'Pick one of: {' +
+                ','.join(x for x in self.valid_push_kernel_types) + '}',
             'is_private':
-            'true',
+                'true',
             'enable_gpu':
-            'false',
+                'false',
             'enable_tpu':
-            'false',
+                'false',
             'enable_internet':
-            'true',
+                'true',
             'dataset_sources': [],
             'competition_sources': [],
             'kernel_sources': [],
@@ -3520,8 +3515,8 @@ class KaggleApi(KaggleApi):
                 self.process_response(
                     self.with_retry(
                         self.models_create_instance_version_with_http_info)(
-                            owner_slug, model_slug, framework, instance_slug,
-                            request)))
+                        owner_slug, model_slug, framework, instance_slug,
+                        request)))
 
             return result
 
@@ -4012,9 +4007,9 @@ class KaggleApi(KaggleApi):
         """
         for file_name in os.listdir(folder):
             if (file_name in [
-                    self.DATASET_METADATA_FILE, self.OLD_DATASET_METADATA_FILE,
-                    self.KERNEL_METADATA_FILE, self.MODEL_METADATA_FILE,
-                    self.MODEL_INSTANCE_METADATA_FILE
+                self.DATASET_METADATA_FILE, self.OLD_DATASET_METADATA_FILE,
+                self.KERNEL_METADATA_FILE, self.MODEL_METADATA_FILE,
+                self.MODEL_INSTANCE_METADATA_FILE
             ]):
                 continue
             upload_file = self._upload_file_or_folder(folder, file_name,
@@ -4159,10 +4154,10 @@ class KaggleApi(KaggleApi):
                         fp.seek(start_at)
                         session.headers.update({
                             'Content-Length':
-                            '%d' % upload_size,
+                                '%d' % upload_size,
                             'Content-Range':
-                            'bytes %d-%d/%d' %
-                            (start_at, file_size - 1, file_size)
+                                'bytes %d-%d/%d' %
+                                (start_at, file_size - 1, file_size)
                         })
                     reader = TqdmBufferedReader(fp, progress_bar)
                     retries = Retry(total=10, backoff_factor=0.5)
@@ -4344,7 +4339,7 @@ class KaggleApi(KaggleApi):
 
             split = model_instance_version.split('/')
             if not split[0] or not split[1] or not split[2] or not split[
-                    3] or not split[4]:
+                3] or not split[4]:
                 raise ValueError(
                     'Invalid model instance version specification ' +
                     model_instance_version)

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -195,8 +195,8 @@ class ResumableFileUpload(object):
 
     def _is_previous_valid(self, previous):
         return previous.path == self.path and \
-            previous.start_blob_upload_request == self.start_blob_upload_request and \
-            previous.timestamp > time.time() - ResumableFileUpload.RESUMABLE_UPLOAD_EXPIRY_SECONDS
+               previous.start_blob_upload_request == self.start_blob_upload_request and \
+               previous.timestamp > time.time() - ResumableFileUpload.RESUMABLE_UPLOAD_EXPIRY_SECONDS
 
     def upload_initiated(self, start_blob_upload_response):
         if self.context.no_resume:
@@ -229,16 +229,16 @@ class ResumableFileUpload(object):
     def to_dict(self):
         return {
             'path':
-                self.path,
+            self.path,
             'start_blob_upload_request':
-                self.start_blob_upload_request.to_dict(),
+            self.start_blob_upload_request.to_dict(),
             'timestamp':
-                self.timestamp,
+            self.timestamp,
             'start_blob_upload_response':
-                self.start_blob_upload_response.to_dict()
-                if self.start_blob_upload_response is not None else None,
+            self.start_blob_upload_response.to_dict()
+            if self.start_blob_upload_response is not None else None,
             'upload_complete':
-                self.upload_complete,
+            self.upload_complete,
         }
 
     def from_dict(other, context):
@@ -298,7 +298,7 @@ class KaggleApi(KaggleApi):
     config = os.path.join(config_dir, config_file)
     config_values = {}
     already_printed_version_warning = False
-    args = {} # DEBUG Add --local to use localhost
+    args = {}  # DEBUG Add --local to use localhost
 
     # Kernels valid types
     valid_push_kernel_types = ['script', 'notebook']
@@ -405,9 +405,9 @@ class KaggleApi(KaggleApi):
                 or self.CONFIG_NAME_KEY not in config_data:
             if os.path.exists(self.config):
                 config_data = self.read_config_file(config_data)
-            elif self._is_help_or_version_command(api_command) or (len(
-                    sys.argv) > 2 and api_command.startswith(
-                self.command_prefixes_allowing_anonymous_access)):
+            elif self._is_help_or_version_command(api_command) or (
+                    len(sys.argv) > 2 and api_command.startswith(
+                        self.command_prefixes_allowing_anonymous_access)):
                 # Some API commands should be allowed without authentication.
                 return
             else:
@@ -415,7 +415,7 @@ class KaggleApi(KaggleApi):
                               ' {}. Or use the environment method. See setup'
                               ' instructions at'
                               ' https://github.com/Kaggle/kaggle-api/'.format(
-                    self.config_file, self.config_dir))
+                                  self.config_file, self.config_dir))
 
         # Step 3: load into configuration!
         self._load_config(config_data)
@@ -681,7 +681,10 @@ class KaggleApi(KaggleApi):
             else KaggleEnv.LOCAL if '--local' in self.args \
             else KaggleEnv.PROD
         verbose = '--verbose' in self.args or '-v' in self.args
-        return KaggleClient(env=env, verbose=verbose, username=config.username, password=config.password)
+        return KaggleClient(env=env,
+                            verbose=verbose,
+                            username=config.username,
+                            password=config.password)
 
     def camel_to_snake(self, name):
         """
@@ -843,12 +846,13 @@ class KaggleApi(KaggleApi):
                 raise e
         return submit_result
 
-    def competition_submissions(self,
-                                competition,
-                                group=None,
-                                sort=None, # SubmissionSortBy.SUBMISSION_SORT_BY_NAME,
-                                page_token=None,
-                                page_size=20):
+    def competition_submissions(
+            self,
+            competition,
+            group=None,
+            sort=None,  # SubmissionSortBy.SUBMISSION_SORT_BY_NAME,
+            page_token=None,
+            page_size=20):
         """ Get the list of Submission for a particular competition.
 
             Parameters
@@ -865,7 +869,8 @@ class KaggleApi(KaggleApi):
             request.page = page_token
             request.group = group
             request.sort_by = sort
-            response = kaggle.competitions.competition_api_client.list_submissions(request)
+            response = kaggle.competitions.competition_api_client.list_submissions(
+                request)
             return response.submissions
 
     def competition_submissions_cli(self,
@@ -897,7 +902,8 @@ class KaggleApi(KaggleApi):
         if competition is None:
             raise ValueError('No competition specified')
         else:
-            submissions = self.competition_submissions(competition, page_token=page_token,
+            submissions = self.competition_submissions(competition,
+                                                       page_token=page_token,
                                                        page_size=page_size)
             fields = [
                 'fileName', 'date', 'description', 'status', 'publicScore',
@@ -927,7 +933,8 @@ class KaggleApi(KaggleApi):
             request.competition_name = competition
             request.page_token = page_token
             request.page_size = page_size
-            response = kaggle.competitions.competition_api_client.list_data_files(request)
+            response = kaggle.competitions.competition_api_client.list_data_files(
+                request)
             return response
 
     def competition_list_files_cli(self,
@@ -999,9 +1006,11 @@ class KaggleApi(KaggleApi):
             request = ApiDownloadDataFileRequest()
             request.competition_name = competition
             request.file_name = file_name
-            response = kaggle.competitions.competition_api_client.download_data_file(request)
+            response = kaggle.competitions.competition_api_client.download_data_file(
+                request)
         url = response.history[0].url
-        outfile = os.path.join(effective_path, url.split('?')[0].split('/')[-1])
+        outfile = os.path.join(effective_path,
+                               url.split('?')[0].split('/')[-1])
 
         if force or self.download_needed(response, outfile, quiet):
             self.download_file(response, outfile, quiet, not force)
@@ -1029,7 +1038,8 @@ class KaggleApi(KaggleApi):
         with self.build_kaggle_client() as kaggle:
             request = ApiDownloadDataFilesRequest()
             request.competition_name = competition
-            response = kaggle.competitions.competition_api_client.download_data_files(request)
+            response = kaggle.competitions.competition_api_client.download_data_files(
+                request)
         url = response.url.split('?')[0]
         outfile = os.path.join(effective_path,
                                competition + '.' + url.split('.')[-1])
@@ -1085,7 +1095,8 @@ class KaggleApi(KaggleApi):
         with self.build_kaggle_client() as kaggle:
             request = ApiDownloadLeaderboardRequest()
             request.competition_name = competition
-            response = kaggle.competitions.competition_api_client.download_leaderboard(request)
+            response = kaggle.competitions.competition_api_client.download_leaderboard(
+                request)
         if path is None:
             effective_path = self.get_default_download_dir(
                 'competitions', competition)
@@ -1106,7 +1117,8 @@ class KaggleApi(KaggleApi):
         with self.build_kaggle_client() as kaggle:
             request = ApiGetLeaderboardRequest()
             request.competition_name = competition
-            response = kaggle.competitions.competition_api_client.get_leaderboard(request)
+            response = kaggle.competitions.competition_api_client.get_leaderboard(
+                request)
         return response.submissions
 
     def competition_leaderboard_cli(self,
@@ -1186,8 +1198,9 @@ class KaggleApi(KaggleApi):
         """
         if sort_by:
             if sort_by not in self.valid_dataset_sort_bys:
-                raise ValueError('Invalid sort by specified. Valid options are ' +
-                                 str(self.valid_dataset_sort_bys))
+                raise ValueError(
+                    'Invalid sort by specified. Valid options are ' +
+                    str(self.valid_dataset_sort_bys))
             else:
                 sort_by = DatasetSortBy[f"DATASET_SORT_BY_{sort_by.upper()}"]
 
@@ -1237,7 +1250,8 @@ class KaggleApi(KaggleApi):
             request.page = page
             request.max_size = max_size
             request.min_size = min_size
-            response = kaggle.datasets.dataset_api_client.list_datasets(request)
+            response = kaggle.datasets.dataset_api_client.list_datasets(
+                request)
             return response.datasets
 
     def dataset_list_cli(self,
@@ -1755,10 +1769,10 @@ class KaggleApi(KaggleApi):
                     self.process_response(
                         self.with_retry(
                             self.datasets_create_version_by_id_with_http_info)(
-                            id_no, request)))
+                                id_no, request)))
             else:
                 if ref == self.config_values[
-                    self.CONFIG_NAME_USER] + '/INSERT_SLUG_HERE':
+                        self.CONFIG_NAME_USER] + '/INSERT_SLUG_HERE':
                     raise ValueError(
                         'Default slug detected, please change values before '
                         'uploading')
@@ -1876,7 +1890,7 @@ class KaggleApi(KaggleApi):
 
         # validations
         if ref == self.config_values[
-            self.CONFIG_NAME_USER] + '/INSERT_SLUG_HERE':
+                self.CONFIG_NAME_USER] + '/INSERT_SLUG_HERE':
             raise ValueError(
                 'Default slug detected, please change values before uploading')
         if title == 'INSERT_TITLE_HERE':
@@ -2246,25 +2260,25 @@ class KaggleApi(KaggleApi):
         username = self.get_config_value(self.CONFIG_NAME_USER)
         meta_data = {
             'id':
-                username + '/INSERT_KERNEL_SLUG_HERE',
+            username + '/INSERT_KERNEL_SLUG_HERE',
             'title':
-                'INSERT_TITLE_HERE',
+            'INSERT_TITLE_HERE',
             'code_file':
-                'INSERT_CODE_FILE_PATH_HERE',
+            'INSERT_CODE_FILE_PATH_HERE',
             'language':
-                'Pick one of: {' +
-                ','.join(x for x in self.valid_push_language_types) + '}',
+            'Pick one of: {' +
+            ','.join(x for x in self.valid_push_language_types) + '}',
             'kernel_type':
-                'Pick one of: {' +
-                ','.join(x for x in self.valid_push_kernel_types) + '}',
+            'Pick one of: {' +
+            ','.join(x for x in self.valid_push_kernel_types) + '}',
             'is_private':
-                'true',
+            'true',
             'enable_gpu':
-                'false',
+            'false',
             'enable_tpu':
-                'false',
+            'false',
             'enable_internet':
-                'true',
+            'true',
             'dataset_sources': [],
             'competition_sources': [],
             'kernel_sources': [],
@@ -3506,8 +3520,8 @@ class KaggleApi(KaggleApi):
                 self.process_response(
                     self.with_retry(
                         self.models_create_instance_version_with_http_info)(
-                        owner_slug, model_slug, framework, instance_slug,
-                        request)))
+                            owner_slug, model_slug, framework, instance_slug,
+                            request)))
 
             return result
 
@@ -3800,8 +3814,9 @@ class KaggleApi(KaggleApi):
             if last_modified is None:
                 remote_date = datetime.now()
             else:
-                remote_date = datetime.strptime(response.headers['Last-Modified'],
-                                                '%a, %d %b %Y %H:%M:%S %Z')
+                remote_date = datetime.strptime(
+                    response.headers['Last-Modified'],
+                    '%a, %d %b %Y %H:%M:%S %Z')
             file_exists = os.path.isfile(outfile)
             if file_exists:
                 local_date = datetime.fromtimestamp(os.path.getmtime(outfile))
@@ -3820,7 +3835,7 @@ class KaggleApi(KaggleApi):
             pass
         return True
 
-    def print_table(self, items, fields, labels = None):
+    def print_table(self, items, fields, labels=None):
         """ print a table of items, for a set of fields defined
 
             Parameters
@@ -3836,10 +3851,15 @@ class KaggleApi(KaggleApi):
         if len(items) == 0:
             return
         for f in fields:
-            length = max(len(f),
-                         max([len(self.string(getattr(i, self.camel_to_snake(f)))) for i in items]))
-            justify = '>' if isinstance(getattr(
-                items[0], self.camel_to_snake(f)), int) or f == 'size' or f == 'reward' else '<'
+            length = max(
+                len(f),
+                max([
+                    len(self.string(getattr(i, self.camel_to_snake(f))))
+                    for i in items
+                ]))
+            justify = '>' if isinstance(
+                getattr(items[0], self.camel_to_snake(f)),
+                int) or f == 'size' or f == 'reward' else '<'
             formats.append('{:' + justify + self.string(length + 2) + '}')
             borders.append('-' * length + '  ')
         row_format = u''.join(formats)
@@ -3847,13 +3867,16 @@ class KaggleApi(KaggleApi):
         print(row_format.format(*headers))
         print(row_format.format(*borders))
         for i in items:
-            i_fields = [self.string(getattr(i, self.camel_to_snake(f))) + '  ' for f in fields]
+            i_fields = [
+                self.string(getattr(i, self.camel_to_snake(f))) + '  '
+                for f in fields
+            ]
             try:
                 print(row_format.format(*i_fields))
             except UnicodeEncodeError:
                 print(row_format.format(*i_fields).encode('utf-8'))
 
-    def print_csv(self, items, fields, labels = None):
+    def print_csv(self, items, fields, labels=None):
         """ print a set of fields in a set of items using a csv.writer
 
             Parameters
@@ -3867,7 +3890,9 @@ class KaggleApi(KaggleApi):
         writer = csv.writer(sys.stdout)
         writer.writerow(labels)
         for i in items:
-            i_fields = [self.string(getattr(i, self.camel_to_snake(f))) for f in fields]
+            i_fields = [
+                self.string(getattr(i, self.camel_to_snake(f))) for f in fields
+            ]
             writer.writerow(i_fields)
 
     def string(self, item):
@@ -3987,9 +4012,9 @@ class KaggleApi(KaggleApi):
         """
         for file_name in os.listdir(folder):
             if (file_name in [
-                self.DATASET_METADATA_FILE, self.OLD_DATASET_METADATA_FILE,
-                self.KERNEL_METADATA_FILE, self.MODEL_METADATA_FILE,
-                self.MODEL_INSTANCE_METADATA_FILE
+                    self.DATASET_METADATA_FILE, self.OLD_DATASET_METADATA_FILE,
+                    self.KERNEL_METADATA_FILE, self.MODEL_METADATA_FILE,
+                    self.MODEL_INSTANCE_METADATA_FILE
             ]):
                 continue
             upload_file = self._upload_file_or_folder(folder, file_name,
@@ -4134,10 +4159,10 @@ class KaggleApi(KaggleApi):
                         fp.seek(start_at)
                         session.headers.update({
                             'Content-Length':
-                                '%d' % upload_size,
+                            '%d' % upload_size,
                             'Content-Range':
-                                'bytes %d-%d/%d' %
-                                (start_at, file_size - 1, file_size)
+                            'bytes %d-%d/%d' %
+                            (start_at, file_size - 1, file_size)
                         })
                     reader = TqdmBufferedReader(fp, progress_bar)
                     retries = Retry(total=10, backoff_factor=0.5)
@@ -4319,7 +4344,7 @@ class KaggleApi(KaggleApi):
 
             split = model_instance_version.split('/')
             if not split[0] or not split[1] or not split[2] or not split[
-                3] or not split[4]:
+                    3] or not split[4]:
                 raise ValueError(
                     'Invalid model instance version specification ' +
                     model_instance_version)

--- a/src/kaggle/models/kaggle_models_extended.py
+++ b/src/kaggle/models/kaggle_models_extended.py
@@ -120,7 +120,7 @@ class File(object):
         self.size = File.get_size(self.totalBytes)
 
     def __repr__(self):
-        return self.ref
+        return self.name
 
     @staticmethod
     def get_size(size, precision=0):

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -182,6 +182,10 @@ def update_model_instance_metadata(metadata_file, owner, model_slug, instance_sl
         json.dump(meta_data, f, indent=2)
     return meta_data
 
+def print_fields(instance,fields): # For debugging.
+    for f in fields:
+        if not hasattr(instance, api.camel_to_snake(f)):
+            print(f"Missing field: {f} named: {api.camel_to_snake(f)}")
 
 class TestKaggleApi(unittest.TestCase):
 
@@ -292,7 +296,7 @@ class TestKaggleApi(unittest.TestCase):
         try:
             competitions = api.competitions_list()
             self.assertGreater(len(competitions), 0)  # Assuming there should be some competitions
-            api.competitions_list_cli()
+            [self.assertTrue(hasattr(competitions[0], api.camel_to_snake(f))) for f in api.competition_fields]
         except ApiException as e:
             self.fail(f"competitions_list failed: {e}")
 
@@ -311,7 +315,7 @@ class TestKaggleApi(unittest.TestCase):
             submissions = api.competition_submissions(competition)
             self.assertIsInstance(submissions, list)  # Assuming it returns a list of submissions
             self.assertGreater(len(submissions), 0)
-            api.competition_submissions_cli(competition)
+            [self.assertTrue(hasattr(submissions[0], api.camel_to_snake(f))) for f in api.submission_fields]
         except ApiException as e:
             self.fail(f"competition_submissions failed: {e}")
 
@@ -321,7 +325,7 @@ class TestKaggleApi(unittest.TestCase):
             self.assertIsInstance(competition_files, list)
             self.assertGreater(len(competition_files), 0)
             self.competition_file = competition_files[0]
-            api.competition_list_files_cli(competition)
+            [self.assertTrue(hasattr(competition_files[0], api.camel_to_snake(f))) for f in api.competition_file_fields]
         except ApiException as e:
             self.fail(f"competition_list_files failed: {e}")
 
@@ -353,7 +357,7 @@ class TestKaggleApi(unittest.TestCase):
             result = api.competition_leaderboard_view(competition)
             self.assertIsInstance(result, list)
             self.assertGreater(len(result), 0)
-            api.competition_leaderboard_cli(competition, view=True)
+            [self.assertTrue(hasattr(result[0], api.camel_to_snake(f))) for f in api.competition_leaderboard_fields]
         except ApiException as e:
             self.fail(f"competition_leaderboard_view failed: {e}")
 
@@ -376,7 +380,7 @@ class TestKaggleApi(unittest.TestCase):
             datasets = api.dataset_list(sort_by='votes')
             self.assertGreater(len(datasets), 0)  # Assuming there should be some datasets
             self.dataset = str(datasets[0].ref)
-            api.dataset_list_cli()
+            [self.assertTrue(hasattr(datasets[0], api.camel_to_snake(f))) for f in api.dataset_fields]
         except ApiException as e:
             self.fail(f"dataset_list failed: {e}")
 

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -292,6 +292,7 @@ class TestKaggleApi(unittest.TestCase):
         try:
             competitions = api.competitions_list()
             self.assertGreater(len(competitions), 0)  # Assuming there should be some competitions
+            api.competitions_list_cli()
         except ApiException as e:
             self.fail(f"competitions_list failed: {e}")
 
@@ -310,6 +311,7 @@ class TestKaggleApi(unittest.TestCase):
             submissions = api.competition_submissions(competition)
             self.assertIsInstance(submissions, list)  # Assuming it returns a list of submissions
             self.assertGreater(len(submissions), 0)
+            api.competition_submissions_cli(competition)
         except ApiException as e:
             self.fail(f"competition_submissions failed: {e}")
 
@@ -319,6 +321,7 @@ class TestKaggleApi(unittest.TestCase):
             self.assertIsInstance(competition_files, list)
             self.assertGreater(len(competition_files), 0)
             self.competition_file = competition_files[0]
+            api.competition_list_files_cli(competition)
         except ApiException as e:
             self.fail(f"competition_list_files failed: {e}")
 
@@ -350,6 +353,7 @@ class TestKaggleApi(unittest.TestCase):
             result = api.competition_leaderboard_view(competition)
             self.assertIsInstance(result, list)
             self.assertGreater(len(result), 0)
+            api.competition_leaderboard_cli(competition, view=True)
         except ApiException as e:
             self.fail(f"competition_leaderboard_view failed: {e}")
 
@@ -371,7 +375,8 @@ class TestKaggleApi(unittest.TestCase):
         try:
             datasets = api.dataset_list(sort_by='votes')
             self.assertGreater(len(datasets), 0)  # Assuming there should be some datasets
-            self.dataset = str(datasets[0])
+            self.dataset = str(datasets[0].ref)
+            api.dataset_list_cli()
         except ApiException as e:
             self.fail(f"dataset_list failed: {e}")
 


### PR DESCRIPTION
The competitions portion of the API now uses `kagglesdk`.

The HTTP client has ben updated to use prod, if needed.
