### PR TITLE
Allow last-modified to be absent from header

### DIFF
--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -1956,8 +1956,12 @@ class KaggleApi(KaggleApi):
         size = int(response.headers['Content-Length'])
         size_read = 0
         open_mode = 'wb'
-        remote_date = datetime.strptime(response.headers['Last-Modified'],
-                                        '%a, %d %b %Y %H:%M:%S %Z')
+        last_modified = response.headers.get('Last-Modified')
+        if last_modified is None:
+            remote_date = datetime.now()
+        else:
+            remote_date = datetime.strptime(response.headers['Last-Modified'],
+                                            '%a, %d %b %Y %H:%M:%S %Z')
         remote_date_timestamp = time.mktime(remote_date.timetuple())
 
         if not quiet:
@@ -3757,8 +3761,12 @@ class KaggleApi(KaggleApi):
             quiet: suppress verbose output (default is True)
         """
         try:
-            remote_date = datetime.strptime(response.headers['Last-Modified'],
-                                            '%a, %d %b %Y %H:%M:%S %Z')
+            last_modified = response.headers.get('Last-Modified')
+            if last_modified is None:
+                remote_date = datetime.now()
+            else:
+                remote_date = datetime.strptime(response.headers['Last-Modified'],
+                                                '%a, %d %b %Y %H:%M:%S %Z')
             file_exists = os.path.isfile(outfile)
             if file_exists:
                 local_date = datetime.fromtimestamp(os.path.getmtime(outfile))

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -1929,8 +1929,11 @@ class KaggleApi(KaggleApi):
         size = int(response.headers['Content-Length'])
         size_read = 0
         open_mode = 'wb'
-        remote_date = datetime.strptime(response.headers['Last-Modified'],
-                                        '%a, %d %b %Y %H:%M:%S %Z')
+        try:
+            remote_date = datetime.strptime(response.headers['Last-Modified'],
+                                            '%a, %d %b %Y %H:%M:%S %Z')
+        except KeyError:
+            remote_date = datetime.now()
         remote_date_timestamp = time.mktime(remote_date.timetuple())
 
         if not quiet:


### PR DESCRIPTION
Some time in the last year the server stopped adding "Last-Modified" to some HTTP response headers. That broke the download file handler.

Fixes #622