### PR TITLE
[bugfix] download_needed param error in kernels_output

### DIFF
--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -2612,8 +2612,8 @@ class KaggleApi(KaggleApi):
         for item in response['files']:
             outfile = os.path.join(target_dir, item['fileName'])
             outfiles.append(outfile)
-            download_response = requests.get(item['url'])
-            if force or self.download_needed(item, outfile, quiet):
+            download_response = requests.get(item['url'], stream=True)
+            if force or self.download_needed(download_response, outfile, quiet):
                 os.makedirs(os.path.split(outfile)[0], exist_ok=True)
                 with open(outfile, 'wb') as out:
                     out.write(download_response.content)

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -2585,8 +2585,8 @@ class KaggleApi(KaggleApi):
         for item in response['files']:
             outfile = os.path.join(target_dir, item['fileName'])
             outfiles.append(outfile)
-            download_response = requests.get(item['url'])
-            if force or self.download_needed(item, outfile, quiet):
+            download_response = requests.get(item['url'], stream=True)
+            if force or self.download_needed(download_response, outfile, quiet):
                 os.makedirs(os.path.split(outfile)[0], exist_ok=True)
                 with open(outfile, 'wb') as out:
                     out.write(download_response.content)


### PR DESCRIPTION
When I use the "kaggle kernel output" to download files, it always re-downloads files that already exist. Additionally, I found some issues in the kernels_output method.

1) When calling download_needed, the first parameter is url, but it expects a response object instead.

2) After fixing issue 1, the method does skip existing files. However, it’s still slow, and system monitoring tools show high network usage, indicating that the files are actually being downloaded again. The download_needed method only requires response.headers, but requests.get downloads the entire file by default. This can be fixed by setting the stream=True parameter to change the download behavior.