### PR TITLE
Add -vertex param to "kaggle models list"

### DIFF
--- a/docs/KaggleApi.md
+++ b/docs/KaggleApi.md
@@ -2173,7 +2173,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **models_list**
-> Result models_list(search=search, sort_by=sort_by, owner=owner, page_size=page_size, page_token=page_token)
+> Result models_list(search=search, sort_by=sort_by, owner=owner, page_size=page_size, page_token=page_token, only_vertex_models=only_vertex_models)
 
 Lists models
 
@@ -2197,10 +2197,11 @@ sort_by = 'hotness' # str | Sort the results (optional) (default to hotness)
 owner = 'owner_example' # str | Display models by a specific user or organization (optional)
 page_size = 20 # int | Number of items per page (default 20) (optional) (default to 20)
 page_token = 'page_token_example' # str | Page token for pagination (optional)
+only_vertex_models = false # bool | Only return models that have a Vertex link (optional) (default to false)
 
 try:
     # Lists models
-    api_response = api_instance.models_list(search=search, sort_by=sort_by, owner=owner, page_size=page_size, page_token=page_token)
+    api_response = api_instance.models_list(search=search, sort_by=sort_by, owner=owner, page_size=page_size, page_token=page_token, only_vertex_models=only_vertex_models)
     pprint(api_response)
 except ApiException as e:
     print("Exception when calling KaggleApi->models_list: %s\n" % e)
@@ -2215,6 +2216,7 @@ Name | Type | Description  | Notes
  **owner** | **str**| Display models by a specific user or organization | [optional] 
  **page_size** | **int**| Number of items per page (default 20) | [optional] [default to 20]
  **page_token** | **str**| Page token for pagination | [optional] 
+ **only_vertex_models** | **bool**| Only return models that have a Vertex link | [optional] [default to false]
 
 ### Return type
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -612,6 +612,7 @@ optional arguments:
                         Page token for pagination
   --page-size PAGE_SIZE Number of items to show on a page. Default size is 20, max is 50
   -v, --csv             Print results in CSV format (if not set then print in table format)
+  --vertex VERTEX_ONLY  'true' if you only want to return models with Vertex links, 'false' by default
 ```
 
 Example:

--- a/kaggle/api/kaggle_api.py
+++ b/kaggle/api/kaggle_api.py
@@ -4213,6 +4213,7 @@ class KaggleApi(object):
         :param str owner: Display models by a specific user or organization
         :param int page_size: Number of items per page (default 20)
         :param str page_token: Page token for pagination
+        :param bool only_vertex_models: Only return models that have a Vertex link
         :return: Result
                  If the method is called asynchronously,
                  returns the request thread.
@@ -4238,12 +4239,13 @@ class KaggleApi(object):
         :param str owner: Display models by a specific user or organization
         :param int page_size: Number of items per page (default 20)
         :param str page_token: Page token for pagination
+        :param bool only_vertex_models: Only return models that have a Vertex link
         :return: Result
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = ['search', 'sort_by', 'owner', 'page_size', 'page_token']  # noqa: E501
+        all_params = ['search', 'sort_by', 'owner', 'page_size', 'page_token', 'only_vertex_models']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -4274,6 +4276,8 @@ class KaggleApi(object):
             query_params.append(('pageSize', params['page_size']))  # noqa: E501
         if 'page_token' in params:
             query_params.append(('pageToken', params['page_token']))  # noqa: E501
+        if 'only_vertex_models' in params:
+            query_params.append(('only_vertex_models', params['only_vertex_models']))  # noqa: E501
 
         header_params = {}
 

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -2727,7 +2727,8 @@ class KaggleApi(KaggleApi):
                    search=None,
                    owner=None,
                    page_size=20,
-                   page_token=None):
+                   page_token=None,
+                   only_vertex_models=False):
         """ return a list of models!
 
             Parameters
@@ -2737,6 +2738,7 @@ class KaggleApi(KaggleApi):
             owner: username or organization slug to filter the search to
             page_size: the page size to return (default is 20)
             page_token: the page token for pagination
+            only_vertex_models: return vertex models only
         """
         if sort_by and sort_by not in self.valid_model_sort_bys:
             raise ValueError('Invalid sort by specified. Valid options are ' +
@@ -2746,11 +2748,13 @@ class KaggleApi(KaggleApi):
             raise ValueError('Page size must be >= 1')
 
         models_list_result = self.process_response(
-            self.models_list_with_http_info(sort_by=sort_by or 'hotness',
-                                            search=search or '',
-                                            owner=owner or '',
-                                            page_size=page_size,
-                                            page_token=page_token))
+            self.models_list_with_http_info(
+                sort_by=sort_by or 'hotness',
+                search=search or '',
+                owner=owner or '',
+                page_size=page_size,
+                page_token=page_token,
+                only_vertex_models=only_vertex_models))
 
         next_page_token = models_list_result['nextPageToken']
         if next_page_token:
@@ -2764,7 +2768,8 @@ class KaggleApi(KaggleApi):
                        owner=None,
                        page_size=20,
                        page_token=None,
-                       csv_display=False):
+                       csv_display=False,
+                       only_vertex_models=False):
         """ a wrapper to model_list for the client. Additional parameters
             are described here, see model_list for others.
 
@@ -2776,9 +2781,13 @@ class KaggleApi(KaggleApi):
             page_size: the page size to return (default is 20)
             page_token: the page token for pagination
             csv_display: if True, print comma separated values instead of table
+            only_vertex_models: return vertex models only
         """
-        models = self.model_list(sort_by, search, owner, page_size, page_token)
+        models = self.model_list(sort_by, search, owner, page_size, page_token,
+                                 only_vertex_models)
         fields = ['id', 'ref', 'title', 'subtitle', 'author']
+        if only_vertex_models:
+            fields.append('modelVersionLinks')
         if models:
             if csv_display:
                 self.print_csv(models, fields)

--- a/kaggle/cli.py
+++ b/kaggle/cli.py
@@ -976,6 +976,10 @@ def parse_models(subparsers):
                                     dest='csv_display',
                                     action='store_true',
                                     help=Help.param_csv)
+    parser_models_list.add_argument('-vertex',
+                                    dest='only_vertex_models',
+                                    action='store_true',
+                                    help=Help.param_model_vertex)
     parser_models_list._action_groups.append(parser_models_list_optional)
     parser_models_list.set_defaults(func=api.model_list_cli)
 
@@ -1663,6 +1667,7 @@ class Help(object):
         'Folder containing the special model-metadata.json file '
         '(https://github.com/Kaggle/kaggle-api/wiki/Model-Metadata). '
         'Defaults to current working directory')
+    param_model_vertex = ('Only return models that are Vertex models.')
 
     # Model Instances params
     param_model_instance = (

--- a/src/KaggleSwagger.yaml
+++ b/src/KaggleSwagger.yaml
@@ -1061,6 +1061,11 @@ paths:
           name: pageToken
           type: string
           description: Page token for pagination
+        - in: query
+          name: only_vertex_models
+          type: boolean
+          default: false
+          description: Only return models that have a Vertex link
       responses:
         200:
           description: Result

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -2703,7 +2703,8 @@ class KaggleApi(KaggleApi):
                    search=None,
                    owner=None,
                    page_size=20,
-                   page_token=None):
+                   page_token=None,
+                   only_vertex_models=False):
         """ return a list of models!
 
             Parameters
@@ -2713,6 +2714,7 @@ class KaggleApi(KaggleApi):
             owner: username or organization slug to filter the search to
             page_size: the page size to return (default is 20)
             page_token: the page token for pagination
+            only_vertex_models: return vertex models only
         """
         if sort_by and sort_by not in self.valid_model_sort_bys:
             raise ValueError('Invalid sort by specified. Valid options are ' +
@@ -2722,11 +2724,13 @@ class KaggleApi(KaggleApi):
             raise ValueError('Page size must be >= 1')
 
         models_list_result = self.process_response(
-            self.models_list_with_http_info(sort_by=sort_by or 'hotness',
-                                            search=search or '',
-                                            owner=owner or '',
-                                            page_size=page_size,
-                                            page_token=page_token))
+            self.models_list_with_http_info(
+                sort_by=sort_by or 'hotness',
+                search=search or '',
+                owner=owner or '',
+                page_size=page_size,
+                page_token=page_token,
+                only_vertex_models=only_vertex_models))
 
         next_page_token = models_list_result['nextPageToken']
         if next_page_token:
@@ -2740,7 +2744,8 @@ class KaggleApi(KaggleApi):
                        owner=None,
                        page_size=20,
                        page_token=None,
-                       csv_display=False):
+                       csv_display=False,
+                       only_vertex_models=False):
         """ a wrapper to model_list for the client. Additional parameters
             are described here, see model_list for others.
 
@@ -2752,9 +2757,13 @@ class KaggleApi(KaggleApi):
             page_size: the page size to return (default is 20)
             page_token: the page token for pagination
             csv_display: if True, print comma separated values instead of table
+            only_vertex_models: return vertex models only
         """
-        models = self.model_list(sort_by, search, owner, page_size, page_token)
+        models = self.model_list(sort_by, search, owner, page_size, page_token,
+                                 only_vertex_models)
         fields = ['id', 'ref', 'title', 'subtitle', 'author']
+        if only_vertex_models:
+            fields.append('modelVersionLinks')
         if models:
             if csv_display:
                 self.print_csv(models, fields)

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -960,6 +960,10 @@ def parse_models(subparsers):
                                     dest='csv_display',
                                     action='store_true',
                                     help=Help.param_csv)
+    parser_models_list.add_argument('-vertex',
+                                    dest='only_vertex_models',
+                                    action='store_true',
+                                    help=Help.param_model_vertex)
     parser_models_list._action_groups.append(parser_models_list_optional)
     parser_models_list.set_defaults(func=api.model_list_cli)
 
@@ -1647,6 +1651,7 @@ class Help(object):
         'Folder containing the special model-metadata.json file '
         '(https://github.com/Kaggle/kaggle-api/wiki/Model-Metadata). '
         'Defaults to current working directory')
+    param_model_vertex = ('Only return models that are Vertex models.')
 
     # Model Instances params
     param_model_instance = (


### PR DESCRIPTION
The "-vertex" param to "kaggle models list" is an additional filter parameter that only filters on models that have a Vertex URL in Kaggle.