### PR TITLE
Use specific version of yapf to avoid format diffs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ install-autogen = """curl -fsSL --output /tmp/autogen.zip "https://github.com/mb
   mv /tmp/autogen/autogen-*/* /tmp/autogen && rm -rf /tmp/autogen/autogen-* && 
   sudo chmod a+rx /tmp/autogen/autogen.sh"""
 # TODO: install in Mac/Windows
-install-yapf = """sudo apt-get install -y yapf3 python3-yapf || echo 'yapf could not be installed'"""
+install-yapf = """pip3 install yapf==0.40.2 --break-system-packages || echo 'yapf could not be installed'"""
 install-deps = "hatch run install-autogen && hatch run install-yapf"
 
 integration-test = "pytest {args:integration_tests}"

--- a/tools/GeneratePythonLibrary.sh
+++ b/tools/GeneratePythonLibrary.sh
@@ -90,7 +90,7 @@ function reset {
 
   echo "yapf3 -ir src/"
   if [ -x "$(command -v yapf3)" ]; then
-    yapf3 -ir src/
+    yapf3 -ir --style='{based_on_style: yapf, indent_width: 4}' src/
   else
     echo "yapf3 is not installed on your system"
   fi

--- a/tools/GeneratePythonLibrary.sh
+++ b/tools/GeneratePythonLibrary.sh
@@ -90,7 +90,7 @@ function reset {
 
   echo "yapf3 -ir src/"
   if [ -x "$(command -v yapf3)" ]; then
-    yapf3 -ir --style='{based_on_style: yapf, indent_width: 4}' src/
+    yapf3 -ir --style yapf src/
   else
     echo "yapf3 is not installed on your system"
   fi


### PR DESCRIPTION
Switch to Google's open-source project formatting conventions, `yapf`, except preserve our 4-space indentation.

See #635 for results. If we need to change things even more, now is a good time for feedback.