### PR TITLE
Remove kaggle API authentication from __init__.py

### DIFF
--- a/kaggle/__init__.py
+++ b/kaggle/__init__.py
@@ -18,6 +18,3 @@
 from __future__ import absolute_import
 from kaggle.api.kaggle_api_extended import KaggleApi
 from kaggle.api_client import ApiClient
-
-api = KaggleApi(ApiClient())
-api.authenticate()


### PR DESCRIPTION
The kaggle-api module init.py creates an instance of the KaggleAPI and authenticates. If the user has not added a Kaggle API token in their local environment, this code causes a Kaggle.json not found exception to be thrown immediately on package import.

This assertion prevents the user from being able to use the kaggle python API for feature that don't need authentication, like the downloading of public data sets. I verified we can download public data sets without authentication using the CLI commands and this feature was already publicly announced here: https://www.kaggle.com/discussions/product-feedback/485439

The existing code doesn't seem to add much value, it seems reasonable to give the developer (importer of the package), the responsibility to simply create an instance of KaggleAPI and authenticate as needed. By removing this code, both the CLI API and the python API can now download public data sets without authentication keeping the behavior consistent. I think it's pretty confusing to allow user's to call the CLI api without authenticating, but force them to authenticate when using the Python API directly. If anything the CLI API should be more restrictive