### PR TITLE
Remove KaggleAPI.authenticate() from __init__.py

### DIFF
--- a/kaggle/__init__.py
+++ b/kaggle/__init__.py
@@ -18,6 +18,3 @@
 from __future__ import absolute_import
 from kaggle.api.kaggle_api_extended import KaggleApi
 from kaggle.api_client import ApiClient
-
-api = KaggleApi(ApiClient())
-api.authenticate()


### PR DESCRIPTION
In the kaggle-api package init.py there is code that creates an instance of the KaggleAPI and tries to authenticate.

This makes it impossible to do things like download public data sets from Kaggle that don't require authentication. Removing these lines make this possible.

Downloading public data sets (without authentication) are possible via the CLI, so it makes sense to enable this capability for developers that would like to call the Python API's directly. Creating the api instances and invoking authenticate() is offering a very small convenience for developers importing the package, I think it's okay to expect developers to do this themselves.

Kaggle should be consistent, either allow public dataset download without authentication in BOTH the CLI and direct python API, or remove this functionality from both. The ability to download without authentication on CLI led me down a path to automate this via the python API only to be blocked by this a few hours later.

Thanks,
Abhay