### PR TITLE
Restore models used by kaggle_api.py

### DIFF
--- a/kaggle/models/dataset_new_request.py
+++ b/kaggle/models/dataset_new_request.py
@@ -1,0 +1,385 @@
+#!/usr/bin/python
+#
+# Copyright 2024 Kaggle Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# coding: utf-8
+
+import pprint
+import re  # noqa: F401
+
+import six
+
+from kaggle.models.upload_file import UploadFile  # noqa: F401,E501
+
+
+class DatasetNewRequest(object):
+    """
+    Attributes:
+      project_types (dict): The key is attribute name
+                            and the value is attribute type.
+      attribute_map (dict): The key is attribute name
+                            and the value is json key in definition.
+    """
+    project_types = {
+        'title': 'str',
+        'slug': 'str',
+        'owner_slug': 'str',
+        'license_name': 'str',
+        'subtitle': 'str',
+        'description': 'str',
+        'files': 'list[UploadFile]',
+        'is_private': 'bool',
+        'convert_to_csv': 'bool',
+        'category_ids': 'list[str]'
+    }
+
+    attribute_map = {
+        'title': 'title',
+        'slug': 'slug',
+        'owner_slug': 'ownerSlug',
+        'license_name': 'licenseName',
+        'subtitle': 'subtitle',
+        'description': 'description',
+        'files': 'files',
+        'is_private': 'isPrivate',
+        'convert_to_csv': 'convertToCsv',
+        'category_ids': 'categoryIds'
+    }
+
+    def __init__(self, title=None, slug=None, owner_slug=None, license_name='unknown', subtitle=None, description='', files=None, is_private=True, convert_to_csv=True, category_ids=None):  # noqa: E501
+
+        self._title = None
+        self._slug = None
+        self._owner_slug = None
+        self._license_name = None
+        self._subtitle = None
+        self._description = None
+        self._files = None
+        self._is_private = None
+        self._convert_to_csv = None
+        self._category_ids = None
+        self.discriminator = None
+
+        self.title = title
+        if slug is not None:
+            self.slug = slug
+        if owner_slug is not None:
+            self.owner_slug = owner_slug
+        if license_name is not None:
+            self.license_name = license_name
+        if subtitle is not None:
+            self.subtitle = subtitle
+        if description is not None:
+            self.description = description
+        self.files = files
+        if is_private is not None:
+            self.is_private = is_private
+        if convert_to_csv is not None:
+            self.convert_to_csv = convert_to_csv
+        if category_ids is not None:
+            self.category_ids = category_ids
+
+    @property
+    def title(self):
+        """Gets the title of this DatasetNewRequest.  # noqa: E501
+
+        The title of the new dataset  # noqa: E501
+
+        :return: The title of this DatasetNewRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._title
+
+    @title.setter
+    def title(self, title):
+        """Sets the title of this DatasetNewRequest.
+
+        The title of the new dataset  # noqa: E501
+
+        :param title: The title of this DatasetNewRequest.  # noqa: E501
+        :type: str
+        """
+        if title is None:
+            raise ValueError("Invalid value for `title`, must not be `None`")  # noqa: E501
+
+        self._title = title
+
+    @property
+    def slug(self):
+        """Gets the slug of this DatasetNewRequest.  # noqa: E501
+
+        The slug that the dataset should be created with  # noqa: E501
+
+        :return: The slug of this DatasetNewRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._slug
+
+    @slug.setter
+    def slug(self, slug):
+        """Sets the slug of this DatasetNewRequest.
+
+        The slug that the dataset should be created with  # noqa: E501
+
+        :param slug: The slug of this DatasetNewRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._slug = slug
+
+    @property
+    def owner_slug(self):
+        """Gets the owner_slug of this DatasetNewRequest.  # noqa: E501
+
+        The owner's username  # noqa: E501
+
+        :return: The owner_slug of this DatasetNewRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._owner_slug
+
+    @owner_slug.setter
+    def owner_slug(self, owner_slug):
+        """Sets the owner_slug of this DatasetNewRequest.
+
+        The owner's username  # noqa: E501
+
+        :param owner_slug: The owner_slug of this DatasetNewRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._owner_slug = owner_slug
+
+    @property
+    def license_name(self):
+        """Gets the license_name of this DatasetNewRequest.  # noqa: E501
+
+        The license that should be associated with the dataset  # noqa: E501
+
+        :return: The license_name of this DatasetNewRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._license_name
+
+    @license_name.setter
+    def license_name(self, license_name):
+        """Sets the license_name of this DatasetNewRequest.
+
+        The license that should be associated with the dataset  # noqa: E501
+
+        :param license_name: The license_name of this DatasetNewRequest.  # noqa: E501
+        :type: str
+        """
+        allowed_values = ["CC0-1.0", "CC-BY-SA-4.0", "GPL-2.0", "ODbL-1.0", "CC-BY-NC-SA-4.0", "unknown", "DbCL-1.0", "CC-BY-SA-3.0", "copyright-authors", "other", "reddit-api", "world-bank", "CC-BY-4.0", "CC-BY-NC-4.0", "PDDL", "CC-BY-3.0", "CC-BY-3.0-IGO", "US-Government-Works", "CC-BY-NC-SA-3.0-IGO", "CDLA-Permissive-1.0", "CDLA-Sharing-1.0", "CC-BY-ND-4.0", "CC-BY-NC-ND-4.0", "ODC-BY-1.0", "LGPL-3.0", "AGPL-3.0", "FDL-1.3", "EU-ODP-Legal-Notice", "apache-2.0", "GPL-3.0"]  # noqa: E501
+        if license_name not in allowed_values:
+            raise ValueError(
+                "Invalid value for `license_name` ({0}), must be one of {1}"  # noqa: E501
+                .format(license_name, allowed_values)
+            )
+        else:
+            license_name = license_name.lower()
+            if license_name[0-1] == 'cc':
+                license_name = 'cc'
+            elif license_name[0-3] == 'gpl':
+                license_name = 'gpl'
+            elif license_name[0-3] == 'odb':
+                license_name = 'odb'
+            else:
+                license_name = 'other'
+        self._license_name = license_name
+
+    @property
+    def subtitle(self):
+        """Gets the subtitle of this DatasetNewRequest.  # noqa: E501
+
+        The subtitle to be set on the dataset  # noqa: E501
+
+        :return: The subtitle of this DatasetNewRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._subtitle
+
+    @subtitle.setter
+    def subtitle(self, subtitle):
+        """Sets the subtitle of this DatasetNewRequest.
+
+        The subtitle to be set on the dataset  # noqa: E501
+
+        :param subtitle: The subtitle of this DatasetNewRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._subtitle = subtitle
+
+    @property
+    def description(self):
+        """Gets the description of this DatasetNewRequest.  # noqa: E501
+
+        The description to be set on the dataset  # noqa: E501
+
+        :return: The description of this DatasetNewRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """Sets the description of this DatasetNewRequest.
+
+        The description to be set on the dataset  # noqa: E501
+
+        :param description: The description of this DatasetNewRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._description = description
+
+    @property
+    def files(self):
+        """Gets the files of this DatasetNewRequest.  # noqa: E501
+
+        A list of files that should be associated with the dataset  # noqa: E501
+
+        :return: The files of this DatasetNewRequest.  # noqa: E501
+        :rtype: list[UploadFile]
+        """
+        return self._files
+
+    @files.setter
+    def files(self, files):
+        """Sets the files of this DatasetNewRequest.
+
+        A list of files that should be associated with the dataset  # noqa: E501
+
+        :param files: The files of this DatasetNewRequest.  # noqa: E501
+        :type: list[UploadFile]
+        """
+        if files is None:
+            raise ValueError("Invalid value for `files`, must not be `None`")  # noqa: E501
+
+        self._files = files
+
+    @property
+    def is_private(self):
+        """Gets the is_private of this DatasetNewRequest.  # noqa: E501
+
+        Whether or not the dataset should be private  # noqa: E501
+
+        :return: The is_private of this DatasetNewRequest.  # noqa: E501
+        :rtype: bool
+        """
+        return self._is_private
+
+    @is_private.setter
+    def is_private(self, is_private):
+        """Sets the is_private of this DatasetNewRequest.
+
+        Whether or not the dataset should be private  # noqa: E501
+
+        :param is_private: The is_private of this DatasetNewRequest.  # noqa: E501
+        :type: bool
+        """
+
+        self._is_private = is_private
+
+    @property
+    def convert_to_csv(self):
+        """Gets the convert_to_csv of this DatasetNewRequest.  # noqa: E501
+
+        Whether or not a tabular dataset should be converted to csv  # noqa: E501
+
+        :return: The convert_to_csv of this DatasetNewRequest.  # noqa: E501
+        :rtype: bool
+        """
+        return self._convert_to_csv
+
+    @convert_to_csv.setter
+    def convert_to_csv(self, convert_to_csv):
+        """Sets the convert_to_csv of this DatasetNewRequest.
+
+        Whether or not a tabular dataset should be converted to csv  # noqa: E501
+
+        :param convert_to_csv: The convert_to_csv of this DatasetNewRequest.  # noqa: E501
+        :type: bool
+        """
+
+        self._convert_to_csv = convert_to_csv
+
+    @property
+    def category_ids(self):
+        """Gets the category_ids of this DatasetNewRequest.  # noqa: E501
+
+        A list of tag IDs to associated with the dataset  # noqa: E501
+
+        :return: The category_ids of this DatasetNewRequest.  # noqa: E501
+        :rtype: list[str]
+        """
+        return self._category_ids
+
+    @category_ids.setter
+    def category_ids(self, category_ids):
+        """Sets the category_ids of this DatasetNewRequest.
+
+        A list of tag IDs to associated with the dataset  # noqa: E501
+
+        :param category_ids: The category_ids of this DatasetNewRequest.  # noqa: E501
+        :type: list[str]
+        """
+
+        self._category_ids = category_ids
+
+    def to_dict(self):
+        """Returns the model properties as a dict"""
+        result = {}
+
+        for attr, _ in six.iteritems(self.project_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
+                    lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
+                    value
+                ))
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
+            elif isinstance(value, dict):
+                result[attr] = dict(map(
+                    lambda item: (item[0], item[1].to_dict())
+                    if hasattr(item[1], "to_dict") else item,
+                    value.items()
+                ))
+            else:
+                result[attr] = value
+
+        return result
+
+    def to_str(self):
+        """Returns the string representation of the model"""
+        return pprint.pformat(self.to_dict())
+
+    def __repr__(self):
+        """For `print` and `pprint`"""
+        return self.to_str()
+
+    def __eq__(self, other):
+        """Returns true if both objects are equal"""
+        if not isinstance(other, DatasetNewRequest):
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        """Returns true if both objects are not equal"""
+        return not self == other
+

--- a/kaggle/models/dataset_new_version_request.py
+++ b/kaggle/models/dataset_new_version_request.py
@@ -1,0 +1,287 @@
+#!/usr/bin/python
+#
+# Copyright 2024 Kaggle Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# coding: utf-8
+
+
+import pprint
+import re  # noqa: F401
+
+import six
+
+from kaggle.models.upload_file import UploadFile  # noqa: F401,E501
+
+
+class DatasetNewVersionRequest(object):
+    """
+    Attributes:
+      project_types (dict): The key is attribute name
+                            and the value is attribute type.
+      attribute_map (dict): The key is attribute name
+                            and the value is json key in definition.
+    """
+    project_types = {
+        'version_notes': 'str',
+        'subtitle': 'str',
+        'description': 'str',
+        'files': 'list[UploadFile]',
+        'convert_to_csv': 'bool',
+        'category_ids': 'list[str]',
+        'delete_old_versions': 'bool'
+    }
+
+    attribute_map = {
+        'version_notes': 'versionNotes',
+        'subtitle': 'subtitle',
+        'description': 'description',
+        'files': 'files',
+        'convert_to_csv': 'convertToCsv',
+        'category_ids': 'categoryIds',
+        'delete_old_versions': 'deleteOldVersions'
+    }
+
+    def __init__(self, version_notes=None, subtitle=None, description=None, files=None, convert_to_csv=True, category_ids=None, delete_old_versions=False):  # noqa: E501
+
+        self._version_notes = None
+        self._subtitle = None
+        self._description = None
+        self._files = None
+        self._convert_to_csv = None
+        self._category_ids = None
+        self._delete_old_versions = None
+        self.discriminator = None
+
+        self.version_notes = version_notes
+        if subtitle is not None:
+            self.subtitle = subtitle
+        if description is not None:
+            self.description = description
+        self.files = files
+        if convert_to_csv is not None:
+            self.convert_to_csv = convert_to_csv
+        if category_ids is not None:
+            self.category_ids = category_ids
+        if delete_old_versions is not None:
+            self.delete_old_versions = delete_old_versions
+
+    @property
+    def version_notes(self):
+        """Gets the version_notes of this DatasetNewVersionRequest.  # noqa: E501
+
+        The version notes for the new dataset version  # noqa: E501
+
+        :return: The version_notes of this DatasetNewVersionRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._version_notes
+
+    @version_notes.setter
+    def version_notes(self, version_notes):
+        """Sets the version_notes of this DatasetNewVersionRequest.
+
+        The version notes for the new dataset version  # noqa: E501
+
+        :param version_notes: The version_notes of this DatasetNewVersionRequest.  # noqa: E501
+        :type: str
+        """
+        if version_notes is None:
+            raise ValueError("Invalid value for `version_notes`, must not be `None`")  # noqa: E501
+
+        self._version_notes = version_notes
+
+    @property
+    def subtitle(self):
+        """Gets the subtitle of this DatasetNewVersionRequest.  # noqa: E501
+
+        The subtitle to set on the dataset  # noqa: E501
+
+        :return: The subtitle of this DatasetNewVersionRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._subtitle
+
+    @subtitle.setter
+    def subtitle(self, subtitle):
+        """Sets the subtitle of this DatasetNewVersionRequest.
+
+        The subtitle to set on the dataset  # noqa: E501
+
+        :param subtitle: The subtitle of this DatasetNewVersionRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._subtitle = subtitle
+
+    @property
+    def description(self):
+        """Gets the description of this DatasetNewVersionRequest.  # noqa: E501
+
+        The description to set on the dataset  # noqa: E501
+
+        :return: The description of this DatasetNewVersionRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """Sets the description of this DatasetNewVersionRequest.
+
+        The description to set on the dataset  # noqa: E501
+
+        :param description: The description of this DatasetNewVersionRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._description = description
+
+    @property
+    def files(self):
+        """Gets the files of this DatasetNewVersionRequest.  # noqa: E501
+
+        A list of files that should be associated with the dataset  # noqa: E501
+
+        :return: The files of this DatasetNewVersionRequest.  # noqa: E501
+        :rtype: list[UploadFile]
+        """
+        return self._files
+
+    @files.setter
+    def files(self, files):
+        """Sets the files of this DatasetNewVersionRequest.
+
+        A list of files that should be associated with the dataset  # noqa: E501
+
+        :param files: The files of this DatasetNewVersionRequest.  # noqa: E501
+        :type: list[UploadFile]
+        """
+        if files is None:
+            raise ValueError("Invalid value for `files`, must not be `None`")  # noqa: E501
+
+        self._files = files
+
+    @property
+    def convert_to_csv(self):
+        """Gets the convert_to_csv of this DatasetNewVersionRequest.  # noqa: E501
+
+        Whether or not a tabular dataset should be converted to csv  # noqa: E501
+
+        :return: The convert_to_csv of this DatasetNewVersionRequest.  # noqa: E501
+        :rtype: bool
+        """
+        return self._convert_to_csv
+
+    @convert_to_csv.setter
+    def convert_to_csv(self, convert_to_csv):
+        """Sets the convert_to_csv of this DatasetNewVersionRequest.
+
+        Whether or not a tabular dataset should be converted to csv  # noqa: E501
+
+        :param convert_to_csv: The convert_to_csv of this DatasetNewVersionRequest.  # noqa: E501
+        :type: bool
+        """
+
+        self._convert_to_csv = convert_to_csv
+
+    @property
+    def category_ids(self):
+        """Gets the category_ids of this DatasetNewVersionRequest.  # noqa: E501
+
+        A list of tag IDs to associated with the dataset  # noqa: E501
+
+        :return: The category_ids of this DatasetNewVersionRequest.  # noqa: E501
+        :rtype: list[str]
+        """
+        return self._category_ids
+
+    @category_ids.setter
+    def category_ids(self, category_ids):
+        """Sets the category_ids of this DatasetNewVersionRequest.
+
+        A list of tag IDs to associated with the dataset  # noqa: E501
+
+        :param category_ids: The category_ids of this DatasetNewVersionRequest.  # noqa: E501
+        :type: list[str]
+        """
+
+        self._category_ids = category_ids
+
+    @property
+    def delete_old_versions(self):
+        """Gets the delete_old_versions of this DatasetNewVersionRequest.  # noqa: E501
+
+        Whether or not all previous versions of the dataset should be deleted upon creating the new version  # noqa: E501
+
+        :return: The delete_old_versions of this DatasetNewVersionRequest.  # noqa: E501
+        :rtype: bool
+        """
+        return self._delete_old_versions
+
+    @delete_old_versions.setter
+    def delete_old_versions(self, delete_old_versions):
+        """Sets the delete_old_versions of this DatasetNewVersionRequest.
+
+        Whether or not all previous versions of the dataset should be deleted upon creating the new version  # noqa: E501
+
+        :param delete_old_versions: The delete_old_versions of this DatasetNewVersionRequest.  # noqa: E501
+        :type: bool
+        """
+
+        self._delete_old_versions = delete_old_versions
+
+    def to_dict(self):
+        """Returns the model properties as a dict"""
+        result = {}
+
+        for attr, _ in six.iteritems(self.project_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
+                    lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
+                    value
+                ))
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
+            elif isinstance(value, dict):
+                result[attr] = dict(map(
+                    lambda item: (item[0], item[1].to_dict())
+                    if hasattr(item[1], "to_dict") else item,
+                    value.items()
+                ))
+            else:
+                result[attr] = value
+
+        return result
+
+    def to_str(self):
+        """Returns the string representation of the model"""
+        return pprint.pformat(self.to_dict())
+
+    def __repr__(self):
+        """For `print` and `pprint`"""
+        return self.to_str()
+
+    def __eq__(self, other):
+        """Returns true if both objects are equal"""
+        if not isinstance(other, DatasetNewVersionRequest):
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        """Returns true if both objects are not equal"""
+        return not self == other
+

--- a/kaggle/models/dataset_update_settings_request.py
+++ b/kaggle/models/dataset_update_settings_request.py
@@ -1,0 +1,310 @@
+#!/usr/bin/python
+#
+# Copyright 2024 Kaggle Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# coding: utf-8
+
+import pprint
+import re  # noqa: F401
+
+import six
+
+
+class DatasetUpdateSettingsRequest(object):
+    """
+    Attributes:
+      project_types (dict): The key is attribute name
+                            and the value is attribute type.
+      attribute_map (dict): The key is attribute name
+                            and the value is json key in definition.
+    """
+    project_types = {
+        'title': 'str',
+        'subtitle': 'str',
+        'description': 'str',
+        'is_private': 'bool',
+        'licenses': 'list[object]',
+        'keywords': 'list[str]',
+        'collaborators': 'list[object]',
+        'data': 'list[object]'
+    }
+
+    attribute_map = {
+        'title': 'title',
+        'subtitle': 'subtitle',
+        'description': 'description',
+        'is_private': 'isPrivate',
+        'licenses': 'licenses',
+        'keywords': 'keywords',
+        'collaborators': 'collaborators',
+        'data': 'data'
+    }
+
+    def __init__(self, title=None, subtitle=None, description=None, is_private=None, licenses=None, keywords=None, collaborators=None, data=None):  # noqa: E501
+
+        self._title = None
+        self._subtitle = None
+        self._description = None
+        self._is_private = None
+        self._licenses = None
+        self._keywords = None
+        self._collaborators = None
+        self._data = None
+        self.discriminator = None
+
+        if title is not None:
+            self.title = title
+        if subtitle is not None:
+            self.subtitle = subtitle
+        if description is not None:
+            self.description = description
+        if is_private is not None:
+            self.is_private = is_private
+        if licenses is not None:
+            self.licenses = licenses
+        if keywords is not None:
+            self.keywords = keywords
+        if collaborators is not None:
+            self.collaborators = collaborators
+        if data is not None:
+            self.data = data
+
+    @property
+    def title(self):
+        """Gets the title of this DatasetUpdateSettingsRequest.  # noqa: E501
+
+        Title of the dataset  # noqa: E501
+
+        :return: The title of this DatasetUpdateSettingsRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._title
+
+    @title.setter
+    def title(self, title):
+        """Sets the title of this DatasetUpdateSettingsRequest.
+
+        Title of the dataset  # noqa: E501
+
+        :param title: The title of this DatasetUpdateSettingsRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._title = title
+
+    @property
+    def subtitle(self):
+        """Gets the subtitle of this DatasetUpdateSettingsRequest.  # noqa: E501
+
+        Subtitle of the dataset  # noqa: E501
+
+        :return: The subtitle of this DatasetUpdateSettingsRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._subtitle
+
+    @subtitle.setter
+    def subtitle(self, subtitle):
+        """Sets the subtitle of this DatasetUpdateSettingsRequest.
+
+        Subtitle of the dataset  # noqa: E501
+
+        :param subtitle: The subtitle of this DatasetUpdateSettingsRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._subtitle = subtitle
+
+    @property
+    def description(self):
+        """Gets the description of this DatasetUpdateSettingsRequest.  # noqa: E501
+
+        Decription of the dataset  # noqa: E501
+
+        :return: The description of this DatasetUpdateSettingsRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """Sets the description of this DatasetUpdateSettingsRequest.
+
+        Decription of the dataset  # noqa: E501
+
+        :param description: The description of this DatasetUpdateSettingsRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._description = description
+
+    @property
+    def is_private(self):
+        """Gets the is_private of this DatasetUpdateSettingsRequest.  # noqa: E501
+
+        Whether or not the dataset should be private  # noqa: E501
+
+        :return: The is_private of this DatasetUpdateSettingsRequest.  # noqa: E501
+        :rtype: bool
+        """
+        return self._is_private
+
+    @is_private.setter
+    def is_private(self, is_private):
+        """Sets the is_private of this DatasetUpdateSettingsRequest.
+
+        Whether or not the dataset should be private  # noqa: E501
+
+        :param is_private: The is_private of this DatasetUpdateSettingsRequest.  # noqa: E501
+        :type: bool
+        """
+
+        self._is_private = is_private
+
+    @property
+    def licenses(self):
+        """Gets the licenses of this DatasetUpdateSettingsRequest.  # noqa: E501
+
+        A list of licenses that apply to this dataset  # noqa: E501
+
+        :return: The licenses of this DatasetUpdateSettingsRequest.  # noqa: E501
+        :rtype: list[object]
+        """
+        return self._licenses
+
+    @licenses.setter
+    def licenses(self, licenses):
+        """Sets the licenses of this DatasetUpdateSettingsRequest.
+
+        A list of licenses that apply to this dataset  # noqa: E501
+
+        :param licenses: The licenses of this DatasetUpdateSettingsRequest.  # noqa: E501
+        :type: list[object]
+        """
+
+        self._licenses = licenses
+
+    @property
+    def keywords(self):
+        """Gets the keywords of this DatasetUpdateSettingsRequest.  # noqa: E501
+
+        A list of keywords that apply to this dataset  # noqa: E501
+
+        :return: The keywords of this DatasetUpdateSettingsRequest.  # noqa: E501
+        :rtype: list[str]
+        """
+        return self._keywords
+
+    @keywords.setter
+    def keywords(self, keywords):
+        """Sets the keywords of this DatasetUpdateSettingsRequest.
+
+        A list of keywords that apply to this dataset  # noqa: E501
+
+        :param keywords: The keywords of this DatasetUpdateSettingsRequest.  # noqa: E501
+        :type: list[str]
+        """
+
+        self._keywords = keywords
+
+    @property
+    def collaborators(self):
+        """Gets the collaborators of this DatasetUpdateSettingsRequest.  # noqa: E501
+
+        A list of collaborators that may read or edit this dataset  # noqa: E501
+
+        :return: The collaborators of this DatasetUpdateSettingsRequest.  # noqa: E501
+        :rtype: list[object]
+        """
+        return self._collaborators
+
+    @collaborators.setter
+    def collaborators(self, collaborators):
+        """Sets the collaborators of this DatasetUpdateSettingsRequest.
+
+        A list of collaborators that may read or edit this dataset  # noqa: E501
+
+        :param collaborators: The collaborators of this DatasetUpdateSettingsRequest.  # noqa: E501
+        :type: list[object]
+        """
+
+        self._collaborators = collaborators
+
+    @property
+    def data(self):
+        """Gets the data of this DatasetUpdateSettingsRequest.  # noqa: E501
+
+        A list containing metadata for each file in the dataset  # noqa: E501
+
+        :return: The data of this DatasetUpdateSettingsRequest.  # noqa: E501
+        :rtype: list[object]
+        """
+        return self._data
+
+    @data.setter
+    def data(self, data):
+        """Sets the data of this DatasetUpdateSettingsRequest.
+
+        A list containing metadata for each file in the dataset  # noqa: E501
+
+        :param data: The data of this DatasetUpdateSettingsRequest.  # noqa: E501
+        :type: list[object]
+        """
+
+        self._data = data
+
+    def to_dict(self):
+        """Returns the model properties as a dict"""
+        result = {}
+
+        for attr, _ in six.iteritems(self.project_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
+                    lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
+                    value
+                ))
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
+            elif isinstance(value, dict):
+                result[attr] = dict(map(
+                    lambda item: (item[0], item[1].to_dict())
+                    if hasattr(item[1], "to_dict") else item,
+                    value.items()
+                ))
+            else:
+                result[attr] = value
+
+        return result
+
+    def to_str(self):
+        """Returns the string representation of the model"""
+        return pprint.pformat(self.to_dict())
+
+    def __repr__(self):
+        """For `print` and `pprint`"""
+        return self.to_str()
+
+    def __eq__(self, other):
+        """Returns true if both objects are equal"""
+        if not isinstance(other, DatasetUpdateSettingsRequest):
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        """Returns true if both objects are not equal"""
+        return not self == other
+

--- a/kaggle/models/kernel_push_request.py
+++ b/kaggle/models/kernel_push_request.py
@@ -1,0 +1,556 @@
+#!/usr/bin/python
+#
+# Copyright 2024 Kaggle Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# coding: utf-8
+
+
+import pprint
+import re  # noqa: F401
+
+import six
+
+
+class KernelPushRequest(object):
+    """
+    Attributes:
+      project_types (dict): The key is attribute name
+                            and the value is attribute type.
+      attribute_map (dict): The key is attribute name
+                            and the value is json key in definition.
+    """
+    project_types = {
+        'id': 'int',
+        'slug': 'str',
+        'new_title': 'str',
+        'text': 'str',
+        'language': 'str',
+        'kernel_type': 'str',
+        'is_private': 'bool',
+        'enable_gpu': 'bool',
+        'enable_tpu': 'bool',
+        'enable_internet': 'bool',
+        'dataset_data_sources': 'list[str]',
+        'competition_data_sources': 'list[str]',
+        'kernel_data_sources': 'list[str]',
+        'model_data_sources': 'list[str]',
+        'category_ids': 'list[str]',
+        'docker_image_pinning_type': 'str'
+    }
+
+    attribute_map = {
+        'id': 'id',
+        'slug': 'slug',
+        'new_title': 'newTitle',
+        'text': 'text',
+        'language': 'language',
+        'kernel_type': 'kernelType',
+        'is_private': 'isPrivate',
+        'enable_gpu': 'enableGpu',
+        'enable_tpu': 'enableTpu',
+        'enable_internet': 'enableInternet',
+        'dataset_data_sources': 'datasetDataSources',
+        'competition_data_sources': 'competitionDataSources',
+        'kernel_data_sources': 'kernelDataSources',
+        'model_data_sources': 'modelDataSources',
+        'category_ids': 'categoryIds',
+        'docker_image_pinning_type': 'dockerImagePinningType'
+    }
+
+    def __init__(self, id=None, slug=None, new_title=None, text=None, language=None, kernel_type=None, is_private=None, enable_gpu=None, enable_tpu=None, enable_internet=None, dataset_data_sources=None, competition_data_sources=None, kernel_data_sources=None, model_data_sources=None, category_ids=None, docker_image_pinning_type=None):  # noqa: E501
+
+        self._id = None
+        self._slug = None
+        self._new_title = None
+        self._text = None
+        self._language = None
+        self._kernel_type = None
+        self._is_private = None
+        self._enable_gpu = None
+        self._enable_tpu = None
+        self._enable_internet = None
+        self._dataset_data_sources = None
+        self._competition_data_sources = None
+        self._kernel_data_sources = None
+        self._model_data_sources = None
+        self._category_ids = None
+        self._docker_image_pinning_type = None
+        self.discriminator = None
+
+        if id is not None:
+            self.id = id
+        if slug is not None:
+            self.slug = slug
+        if new_title is not None:
+            self.new_title = new_title
+        self.text = text
+        self.language = language
+        self.kernel_type = kernel_type
+        if is_private is not None:
+            self.is_private = is_private
+        if enable_gpu is not None:
+            self.enable_gpu = enable_gpu
+        if enable_tpu is not None:
+            self.enable_tpu = enable_tpu
+        if enable_internet is not None:
+            self.enable_internet = enable_internet
+        if dataset_data_sources is not None:
+            self.dataset_data_sources = dataset_data_sources
+        if competition_data_sources is not None:
+            self.competition_data_sources = competition_data_sources
+        if kernel_data_sources is not None:
+            self.kernel_data_sources = kernel_data_sources
+        if model_data_sources is not None:
+            self.model_data_sources = model_data_sources
+        if category_ids is not None:
+            self.category_ids = category_ids
+        if docker_image_pinning_type is not None:
+            self.docker_image_pinning_type = docker_image_pinning_type
+
+    @property
+    def id(self):
+        """Gets the id of this KernelPushRequest.  # noqa: E501
+
+        The kernel's ID number. One of `id` and `slug` are required. If both are specified, `id` will be preferred  # noqa: E501
+
+        :return: The id of this KernelPushRequest.  # noqa: E501
+        :rtype: int
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """Sets the id of this KernelPushRequest.
+
+        The kernel's ID number. One of `id` and `slug` are required. If both are specified, `id` will be preferred  # noqa: E501
+
+        :param id: The id of this KernelPushRequest.  # noqa: E501
+        :type: int
+        """
+
+        self._id = id
+
+    @property
+    def slug(self):
+        """Gets the slug of this KernelPushRequest.  # noqa: E501
+
+        The full slug of the kernel to push to, in the format `USERNAME/KERNEL-SLUG`. The kernel slug must be the title lowercased with dashes (`-`) replacing spaces. One of `id` and `slug` are required. If both are specified, `id` will be preferred  # noqa: E501
+
+        :return: The slug of this KernelPushRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._slug
+
+    @slug.setter
+    def slug(self, slug):
+        """Sets the slug of this KernelPushRequest.
+
+        The full slug of the kernel to push to, in the format `USERNAME/KERNEL-SLUG`. The kernel slug must be the title lowercased with dashes (`-`) replacing spaces. One of `id` and `slug` are required. If both are specified, `id` will be preferred  # noqa: E501
+
+        :param slug: The slug of this KernelPushRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._slug = slug
+
+    @property
+    def new_title(self):
+        """Gets the new_title of this KernelPushRequest.  # noqa: E501
+
+        The title to be set on the kernel  # noqa: E501
+
+        :return: The new_title of this KernelPushRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._new_title
+
+    @new_title.setter
+    def new_title(self, new_title):
+        """Sets the new_title of this KernelPushRequest.
+
+        The title to be set on the kernel  # noqa: E501
+
+        :param new_title: The new_title of this KernelPushRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._new_title = new_title
+
+    @property
+    def text(self):
+        """Gets the text of this KernelPushRequest.  # noqa: E501
+
+        The kernel's source code  # noqa: E501
+
+        :return: The text of this KernelPushRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._text
+
+    @text.setter
+    def text(self, text):
+        """Sets the text of this KernelPushRequest.
+
+        The kernel's source code  # noqa: E501
+
+        :param text: The text of this KernelPushRequest.  # noqa: E501
+        :type: str
+        """
+        if text is None:
+            raise ValueError("Invalid value for `text`, must not be `None`")  # noqa: E501
+
+        self._text = text
+
+    @property
+    def language(self):
+        """Gets the language of this KernelPushRequest.  # noqa: E501
+
+        The language that the kernel is written in  # noqa: E501
+
+        :return: The language of this KernelPushRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._language
+
+    @language.setter
+    def language(self, language):
+        """Sets the language of this KernelPushRequest.
+
+        The language that the kernel is written in  # noqa: E501
+
+        :param language: The language of this KernelPushRequest.  # noqa: E501
+        :type: str
+        """
+        if language is None:
+            raise ValueError("Invalid value for `language`, must not be `None`")  # noqa: E501
+        allowed_values = ["python", "r", "rmarkdown"]  # noqa: E501
+        if language not in allowed_values:
+            raise ValueError(
+                "Invalid value for `language` ({0}), must be one of {1}"  # noqa: E501
+                .format(language, allowed_values)
+            )
+
+        self._language = language
+
+    @property
+    def kernel_type(self):
+        """Gets the kernel_type of this KernelPushRequest.  # noqa: E501
+
+        The type of kernel. Cannot be changed once the kernel has been created  # noqa: E501
+
+        :return: The kernel_type of this KernelPushRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._kernel_type
+
+    @kernel_type.setter
+    def kernel_type(self, kernel_type):
+        """Sets the kernel_type of this KernelPushRequest.
+
+        The type of kernel. Cannot be changed once the kernel has been created  # noqa: E501
+
+        :param kernel_type: The kernel_type of this KernelPushRequest.  # noqa: E501
+        :type: str
+        """
+        if kernel_type is None:
+            raise ValueError("Invalid value for `kernel_type`, must not be `None`")  # noqa: E501
+        allowed_values = ["script", "notebook"]  # noqa: E501
+        if kernel_type not in allowed_values:
+            raise ValueError(
+                "Invalid value for `kernel_type` ({0}), must be one of {1}"  # noqa: E501
+                .format(kernel_type, allowed_values)
+            )
+
+        self._kernel_type = kernel_type
+
+    @property
+    def is_private(self):
+        """Gets the is_private of this KernelPushRequest.  # noqa: E501
+
+        Whether or not the kernel should be private  # noqa: E501
+
+        :return: The is_private of this KernelPushRequest.  # noqa: E501
+        :rtype: bool
+        """
+        return self._is_private
+
+    @is_private.setter
+    def is_private(self, is_private):
+        """Sets the is_private of this KernelPushRequest.
+
+        Whether or not the kernel should be private  # noqa: E501
+
+        :param is_private: The is_private of this KernelPushRequest.  # noqa: E501
+        :type: bool
+        """
+
+        self._is_private = is_private
+
+    @property
+    def enable_gpu(self):
+        """Gets the enable_gpu of this KernelPushRequest.  # noqa: E501
+
+        Whether or not the kernel should run on a GPU  # noqa: E501
+
+        :return: The enable_gpu of this KernelPushRequest.  # noqa: E501
+        :rtype: bool
+        """
+        return self._enable_gpu
+
+    @enable_gpu.setter
+    def enable_gpu(self, enable_gpu):
+        """Sets the enable_gpu of this KernelPushRequest.
+
+        Whether or not the kernel should run on a GPU  # noqa: E501
+
+        :param enable_gpu: The enable_gpu of this KernelPushRequest.  # noqa: E501
+        :type: bool
+        """
+
+        self._enable_gpu = enable_gpu
+
+    @property
+    def enable_tpu(self):
+        """Gets the enable_tpu of this KernelPushRequest.  # noqa: E501
+
+        Whether or not the kernel should run on a TPU  # noqa: E501
+
+        :return: The enable_tpu of this KernelPushRequest.  # noqa: E501
+        :rtype: bool
+        """
+        return self._enable_tpu
+
+    @enable_tpu.setter
+    def enable_tpu(self, enable_tpu):
+        """Sets the enable_tpu of this KernelPushRequest.
+
+        Whether or not the kernel should run on a TPU  # noqa: E501
+
+        :param enable_tpu: The enable_tpu of this KernelPushRequest.  # noqa: E501
+        :type: bool
+        """
+
+        self._enable_tpu = enable_tpu
+
+    @property
+    def enable_internet(self):
+        """Gets the enable_internet of this KernelPushRequest.  # noqa: E501
+
+        Whether or not the kernel should be able to access the internet  # noqa: E501
+
+        :return: The enable_internet of this KernelPushRequest.  # noqa: E501
+        :rtype: bool
+        """
+        return self._enable_internet
+
+    @enable_internet.setter
+    def enable_internet(self, enable_internet):
+        """Sets the enable_internet of this KernelPushRequest.
+
+        Whether or not the kernel should be able to access the internet  # noqa: E501
+
+        :param enable_internet: The enable_internet of this KernelPushRequest.  # noqa: E501
+        :type: bool
+        """
+
+        self._enable_internet = enable_internet
+
+    @property
+    def dataset_data_sources(self):
+        """Gets the dataset_data_sources of this KernelPushRequest.  # noqa: E501
+
+        A list of dataset data sources that the kernel should use. Each dataset is specified as `USERNAME/DATASET-SLUG`  # noqa: E501
+
+        :return: The dataset_data_sources of this KernelPushRequest.  # noqa: E501
+        :rtype: list[str]
+        """
+        return self._dataset_data_sources
+
+    @dataset_data_sources.setter
+    def dataset_data_sources(self, dataset_data_sources):
+        """Sets the dataset_data_sources of this KernelPushRequest.
+
+        A list of dataset data sources that the kernel should use. Each dataset is specified as `USERNAME/DATASET-SLUG`  # noqa: E501
+
+        :param dataset_data_sources: The dataset_data_sources of this KernelPushRequest.  # noqa: E501
+        :type: list[str]
+        """
+
+        self._dataset_data_sources = dataset_data_sources
+
+    @property
+    def competition_data_sources(self):
+        """Gets the competition_data_sources of this KernelPushRequest.  # noqa: E501
+
+        A list of competition data sources that the kernel should use  # noqa: E501
+
+        :return: The competition_data_sources of this KernelPushRequest.  # noqa: E501
+        :rtype: list[str]
+        """
+        return self._competition_data_sources
+
+    @competition_data_sources.setter
+    def competition_data_sources(self, competition_data_sources):
+        """Sets the competition_data_sources of this KernelPushRequest.
+
+        A list of competition data sources that the kernel should use  # noqa: E501
+
+        :param competition_data_sources: The competition_data_sources of this KernelPushRequest.  # noqa: E501
+        :type: list[str]
+        """
+
+        self._competition_data_sources = competition_data_sources
+
+    @property
+    def kernel_data_sources(self):
+        """Gets the kernel_data_sources of this KernelPushRequest.  # noqa: E501
+
+        A list of kernel data sources that the kernel should use. Each dataset is specified as `USERNAME/KERNEL-SLUG`  # noqa: E501
+
+        :return: The kernel_data_sources of this KernelPushRequest.  # noqa: E501
+        :rtype: list[str]
+        """
+        return self._kernel_data_sources
+
+    @kernel_data_sources.setter
+    def kernel_data_sources(self, kernel_data_sources):
+        """Sets the kernel_data_sources of this KernelPushRequest.
+
+        A list of kernel data sources that the kernel should use. Each dataset is specified as `USERNAME/KERNEL-SLUG`  # noqa: E501
+
+        :param kernel_data_sources: The kernel_data_sources of this KernelPushRequest.  # noqa: E501
+        :type: list[str]
+        """
+
+        self._kernel_data_sources = kernel_data_sources
+
+    @property
+    def model_data_sources(self):
+        """Gets the model_data_sources of this KernelPushRequest.  # noqa: E501
+
+        A list of model data sources that the kernel should use. Each model is specified as `USERNAME/MODEL-SLUG/FRAMEWORK/VARIATION-SLUG/VERSION-NUMBER`  # noqa: E501
+
+        :return: The model_data_sources of this KernelPushRequest.  # noqa: E501
+        :rtype: list[str]
+        """
+        return self._model_data_sources
+
+    @model_data_sources.setter
+    def model_data_sources(self, model_data_sources):
+        """Sets the model_data_sources of this KernelPushRequest.
+
+        A list of model data sources that the kernel should use. Each model is specified as `USERNAME/MODEL-SLUG/FRAMEWORK/VARIATION-SLUG/VERSION-NUMBER`  # noqa: E501
+
+        :param model_data_sources: The model_data_sources of this KernelPushRequest.  # noqa: E501
+        :type: list[str]
+        """
+
+        self._model_data_sources = model_data_sources
+
+    @property
+    def category_ids(self):
+        """Gets the category_ids of this KernelPushRequest.  # noqa: E501
+
+        A list of tag IDs to associated with the kernel  # noqa: E501
+
+        :return: The category_ids of this KernelPushRequest.  # noqa: E501
+        :rtype: list[str]
+        """
+        return self._category_ids
+
+    @category_ids.setter
+    def category_ids(self, category_ids):
+        """Sets the category_ids of this KernelPushRequest.
+
+        A list of tag IDs to associated with the kernel  # noqa: E501
+
+        :param category_ids: The category_ids of this KernelPushRequest.  # noqa: E501
+        :type: list[str]
+        """
+
+        self._category_ids = category_ids
+
+    @property
+    def docker_image_pinning_type(self):
+        """Gets the docker_image_pinning_type of this KernelPushRequest.  # noqa: E501
+
+        Which docker image to use for executing new versions going forward.  # noqa: E501
+
+        :return: The docker_image_pinning_type of this KernelPushRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._docker_image_pinning_type
+
+    @docker_image_pinning_type.setter
+    def docker_image_pinning_type(self, docker_image_pinning_type):
+        """Sets the docker_image_pinning_type of this KernelPushRequest.
+
+        Which docker image to use for executing new versions going forward.  # noqa: E501
+
+        :param docker_image_pinning_type: The docker_image_pinning_type of this KernelPushRequest.  # noqa: E501
+        :type: str
+        """
+        allowed_values = ["original", "latest"]  # noqa: E501
+        if docker_image_pinning_type not in allowed_values:
+            raise ValueError(
+                "Invalid value for `docker_image_pinning_type` ({0}), must be one of {1}"  # noqa: E501
+                .format(docker_image_pinning_type, allowed_values)
+            )
+
+        self._docker_image_pinning_type = docker_image_pinning_type
+
+    def to_dict(self):
+        """Returns the model properties as a dict"""
+        result = {}
+
+        for attr, _ in six.iteritems(self.project_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
+                    lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
+                    value
+                ))
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
+            elif isinstance(value, dict):
+                result[attr] = dict(map(
+                    lambda item: (item[0], item[1].to_dict())
+                    if hasattr(item[1], "to_dict") else item,
+                    value.items()
+                ))
+            else:
+                result[attr] = value
+
+        return result
+
+    def to_str(self):
+        """Returns the string representation of the model"""
+        return pprint.pformat(self.to_dict())
+
+    def __repr__(self):
+        """For `print` and `pprint`"""
+        return self.to_str()
+
+    def __eq__(self, other):
+        """Returns true if both objects are equal"""
+        if not isinstance(other, KernelPushRequest):
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        """Returns true if both objects are not equal"""
+        return not self == other
+

--- a/kaggle/models/model_instance_new_version_request.py
+++ b/kaggle/models/model_instance_new_version_request.py
@@ -1,0 +1,145 @@
+#!/usr/bin/python
+#
+# Copyright 2024 Kaggle Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# coding: utf-8
+
+import pprint
+import re  # noqa: F401
+
+import six
+
+from kaggle.models.upload_file import UploadFile  # noqa: F401,E501
+
+
+class ModelInstanceNewVersionRequest(object):
+    """
+    Attributes:
+      project_types (dict): The key is attribute name
+                            and the value is attribute type.
+      attribute_map (dict): The key is attribute name
+                            and the value is json key in definition.
+    """
+    project_types = {
+        'version_notes': 'str',
+        'files': 'list[UploadFile]'
+    }
+
+    attribute_map = {
+        'version_notes': 'versionNotes',
+        'files': 'files'
+    }
+
+    def __init__(self, version_notes=None, files=None):  # noqa: E501
+
+        self._version_notes = None
+        self._files = None
+        self.discriminator = None
+
+        if version_notes is not None:
+            self.version_notes = version_notes
+        self.files = files
+
+    @property
+    def version_notes(self):
+        """Gets the version_notes of this ModelInstanceNewVersionRequest.  # noqa: E501
+
+        The version notes for the model instance version  # noqa: E501
+
+        :return: The version_notes of this ModelInstanceNewVersionRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._version_notes
+
+    @version_notes.setter
+    def version_notes(self, version_notes):
+        """Sets the version_notes of this ModelInstanceNewVersionRequest.
+
+        The version notes for the model instance version  # noqa: E501
+
+        :param version_notes: The version_notes of this ModelInstanceNewVersionRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._version_notes = version_notes
+
+    @property
+    def files(self):
+        """Gets the files of this ModelInstanceNewVersionRequest.  # noqa: E501
+
+        A list of files that should be associated with the model instance version  # noqa: E501
+
+        :return: The files of this ModelInstanceNewVersionRequest.  # noqa: E501
+        :rtype: list[UploadFile]
+        """
+        return self._files
+
+    @files.setter
+    def files(self, files):
+        """Sets the files of this ModelInstanceNewVersionRequest.
+
+        A list of files that should be associated with the model instance version  # noqa: E501
+
+        :param files: The files of this ModelInstanceNewVersionRequest.  # noqa: E501
+        :type: list[UploadFile]
+        """
+        if files is None:
+            raise ValueError("Invalid value for `files`, must not be `None`")  # noqa: E501
+
+        self._files = files
+
+    def to_dict(self):
+        """Returns the model properties as a dict"""
+        result = {}
+
+        for attr, _ in six.iteritems(self.project_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
+                    lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
+                    value
+                ))
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
+            elif isinstance(value, dict):
+                result[attr] = dict(map(
+                    lambda item: (item[0], item[1].to_dict())
+                    if hasattr(item[1], "to_dict") else item,
+                    value.items()
+                ))
+            else:
+                result[attr] = value
+
+        return result
+
+    def to_str(self):
+        """Returns the string representation of the model"""
+        return pprint.pformat(self.to_dict())
+
+    def __repr__(self):
+        """For `print` and `pprint`"""
+        return self.to_str()
+
+    def __eq__(self, other):
+        """Returns true if both objects are equal"""
+        if not isinstance(other, ModelInstanceNewVersionRequest):
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        """Returns true if both objects are not equal"""
+        return not self == other
+

--- a/kaggle/models/model_instance_update_request.py
+++ b/kaggle/models/model_instance_update_request.py
@@ -1,0 +1,351 @@
+#!/usr/bin/python
+#
+# Copyright 2024 Kaggle Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# coding: utf-8
+
+import pprint
+import re  # noqa: F401
+
+import six
+
+
+class ModelInstanceUpdateRequest(object):
+    """
+    Attributes:
+      project_types (dict): The key is attribute name
+                            and the value is attribute type.
+      attribute_map (dict): The key is attribute name
+                            and the value is json key in definition.
+    """
+    project_types = {
+        'overview': 'str',
+        'usage': 'str',
+        'license_name': 'str',
+        'fine_tunable': 'bool',
+        'training_data': 'list[str]',
+        'model_instance_type': 'str',
+        'base_model_instance': 'str',
+        'external_base_model_url': 'int',
+        'update_mask': 'str'
+    }
+
+    attribute_map = {
+        'overview': 'overview',
+        'usage': 'usage',
+        'license_name': 'licenseName',
+        'fine_tunable': 'fineTunable',
+        'training_data': 'trainingData',
+        'model_instance_type': 'modelInstanceType',
+        'base_model_instance': 'baseModelInstance',
+        'external_base_model_url': 'externalBaseModelUrl',
+        'update_mask': 'updateMask'
+    }
+
+    def __init__(self, overview=None, usage=None, license_name='Apache 2.0', fine_tunable=True, training_data=None, model_instance_type=None, base_model_instance=None, external_base_model_url=None, update_mask=None):  # noqa: E501
+
+        self._overview = None
+        self._usage = None
+        self._license_name = None
+        self._fine_tunable = None
+        self._training_data = None
+        self._model_instance_type = None
+        self._base_model_instance = None
+        self._external_base_model_url = None
+        self._update_mask = None
+        self.discriminator = None
+
+        if overview is not None:
+            self.overview = overview
+        if usage is not None:
+            self.usage = usage
+        if license_name is not None:
+            self.license_name = license_name
+        if fine_tunable is not None:
+            self.fine_tunable = fine_tunable
+        if training_data is not None:
+            self.training_data = training_data
+        if model_instance_type is not None:
+            self.model_instance_type = model_instance_type
+        if base_model_instance is not None:
+            self.base_model_instance = base_model_instance
+        if external_base_model_url is not None:
+            self.external_base_model_url = external_base_model_url
+        self.update_mask = update_mask
+
+    @property
+    def overview(self):
+        """Gets the overview of this ModelInstanceUpdateRequest.  # noqa: E501
+
+        The overview of the model instance (markdown)  # noqa: E501
+
+        :return: The overview of this ModelInstanceUpdateRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._overview
+
+    @overview.setter
+    def overview(self, overview):
+        """Sets the overview of this ModelInstanceUpdateRequest.
+
+        The overview of the model instance (markdown)  # noqa: E501
+
+        :param overview: The overview of this ModelInstanceUpdateRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._overview = overview
+
+    @property
+    def usage(self):
+        """Gets the usage of this ModelInstanceUpdateRequest.  # noqa: E501
+
+        The description of how to use the model instance (markdown)  # noqa: E501
+
+        :return: The usage of this ModelInstanceUpdateRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._usage
+
+    @usage.setter
+    def usage(self, usage):
+        """Sets the usage of this ModelInstanceUpdateRequest.
+
+        The description of how to use the model instance (markdown)  # noqa: E501
+
+        :param usage: The usage of this ModelInstanceUpdateRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._usage = usage
+
+    @property
+    def license_name(self):
+        """Gets the license_name of this ModelInstanceUpdateRequest.  # noqa: E501
+
+        The license that should be associated with the model instance  # noqa: E501
+
+        :return: The license_name of this ModelInstanceUpdateRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._license_name
+
+    @license_name.setter
+    def license_name(self, license_name):
+        """Sets the license_name of this ModelInstanceUpdateRequest.
+
+        The license that should be associated with the model instance  # noqa: E501
+
+        :param license_name: The license_name of this ModelInstanceUpdateRequest.  # noqa: E501
+        :type: str
+        """
+        allowed_values = ["CC0 1.0", "CC BY-NC-SA 4.0", "Unknown", "CC BY-SA 4.0", "GPL 2", "CC BY-SA 3.0", "Other", "Other (specified in description)", "CC BY 4.0", "Attribution 4.0 International (CC BY 4.0)", "CC BY-NC 4.0", "Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)", "PDDL", "ODC Public Domain Dedication and Licence (PDDL)", "CC BY 3.0", "Attribution 3.0 Unported (CC BY 3.0)", "CC BY 3.0 IGO", "Attribution 3.0 IGO (CC BY 3.0 IGO)", "CC BY-NC-SA 3.0 IGO", "Attribution-NonCommercial-ShareAlike 3.0 IGO (CC BY-NC-SA 3.0 IGO)", "CDLA Permissive 1.0", "Community Data License Agreement - Permissive - Version 1.0", "CDLA Sharing 1.0", "Community Data License Agreement - Sharing - Version 1.0", "CC BY-ND 4.0", "Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)", "CC BY-NC-ND 4.0", "Attribution-NonCommercial-NoDerivatives 4.0 International (CC BY-NC-ND 4.0)", "ODC-BY 1.0", "ODC Attribution License (ODC-By)", "LGPL 3.0", "GNU Lesser General Public License 3.0", "AGPL 3.0", "GNU Affero General Public License 3.0", "FDL 1.3", "GNU Free Documentation License 1.3", "apache-2.0", "Apache 2.0", "mit", "MIT", "bsd-3-clause", "BSD-3-Clause", "Llama 2", "Llama 2 Community License", "Gemma", "gpl-3", "GPL 3", "RAIL-M", "AI Pubs Open RAIL-M License", "AIPubs Research-Use RAIL-M", "AI Pubs Research-Use RAIL-M License", "BigScience OpenRAIL-M", "BigScience Open RAIL-M License", "RAIL", "RAIL (specified in description)", "Llama 3", "Llama 3 Community License"]  # noqa: E501
+        if license_name not in allowed_values:
+            raise ValueError(
+                "Invalid value for `license_name` ({0}), must be one of {1}"  # noqa: E501
+                .format(license_name, allowed_values)
+            )
+
+        self._license_name = license_name
+
+    @property
+    def fine_tunable(self):
+        """Gets the fine_tunable of this ModelInstanceUpdateRequest.  # noqa: E501
+
+        Whether the model instance is fine tunable  # noqa: E501
+
+        :return: The fine_tunable of this ModelInstanceUpdateRequest.  # noqa: E501
+        :rtype: bool
+        """
+        return self._fine_tunable
+
+    @fine_tunable.setter
+    def fine_tunable(self, fine_tunable):
+        """Sets the fine_tunable of this ModelInstanceUpdateRequest.
+
+        Whether the model instance is fine tunable  # noqa: E501
+
+        :param fine_tunable: The fine_tunable of this ModelInstanceUpdateRequest.  # noqa: E501
+        :type: bool
+        """
+
+        self._fine_tunable = fine_tunable
+
+    @property
+    def training_data(self):
+        """Gets the training_data of this ModelInstanceUpdateRequest.  # noqa: E501
+
+        A list of training data (urls or names)  # noqa: E501
+
+        :return: The training_data of this ModelInstanceUpdateRequest.  # noqa: E501
+        :rtype: list[str]
+        """
+        return self._training_data
+
+    @training_data.setter
+    def training_data(self, training_data):
+        """Sets the training_data of this ModelInstanceUpdateRequest.
+
+        A list of training data (urls or names)  # noqa: E501
+
+        :param training_data: The training_data of this ModelInstanceUpdateRequest.  # noqa: E501
+        :type: list[str]
+        """
+
+        self._training_data = training_data
+
+    @property
+    def model_instance_type(self):
+        """Gets the model_instance_type of this ModelInstanceUpdateRequest.  # noqa: E501
+
+        Whether the model instance is a base model, external variant, internal variant, or unspecified  # noqa: E501
+
+        :return: The model_instance_type of this ModelInstanceUpdateRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._model_instance_type
+
+    @model_instance_type.setter
+    def model_instance_type(self, model_instance_type):
+        """Sets the model_instance_type of this ModelInstanceUpdateRequest.
+
+        Whether the model instance is a base model, external variant, internal variant, or unspecified  # noqa: E501
+
+        :param model_instance_type: The model_instance_type of this ModelInstanceUpdateRequest.  # noqa: E501
+        :type: str
+        """
+        allowed_values = ["Unspecified", "BaseModel", "KaggleVariant", "ExternalVariant"]  # noqa: E501
+        if model_instance_type not in allowed_values:
+            raise ValueError(
+                "Invalid value for `model_instance_type` ({0}), must be one of {1}"  # noqa: E501
+                .format(model_instance_type, allowed_values)
+            )
+
+        self._model_instance_type = model_instance_type
+
+    @property
+    def base_model_instance(self):
+        """Gets the base_model_instance of this ModelInstanceUpdateRequest.  # noqa: E501
+
+        If this is an internal variant, the `{owner-slug}/{model-slug}/{framework}/{instance-slug}` of the base model instance  # noqa: E501
+
+        :return: The base_model_instance of this ModelInstanceUpdateRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._base_model_instance
+
+    @base_model_instance.setter
+    def base_model_instance(self, base_model_instance):
+        """Sets the base_model_instance of this ModelInstanceUpdateRequest.
+
+        If this is an internal variant, the `{owner-slug}/{model-slug}/{framework}/{instance-slug}` of the base model instance  # noqa: E501
+
+        :param base_model_instance: The base_model_instance of this ModelInstanceUpdateRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._base_model_instance = base_model_instance
+
+    @property
+    def external_base_model_url(self):
+        """Gets the external_base_model_url of this ModelInstanceUpdateRequest.  # noqa: E501
+
+        If this is an external variant, a URL to the base model  # noqa: E501
+
+        :return: The external_base_model_url of this ModelInstanceUpdateRequest.  # noqa: E501
+        :rtype: int
+        """
+        return self._external_base_model_url
+
+    @external_base_model_url.setter
+    def external_base_model_url(self, external_base_model_url):
+        """Sets the external_base_model_url of this ModelInstanceUpdateRequest.
+
+        If this is an external variant, a URL to the base model  # noqa: E501
+
+        :param external_base_model_url: The external_base_model_url of this ModelInstanceUpdateRequest.  # noqa: E501
+        :type: int
+        """
+
+        self._external_base_model_url = external_base_model_url
+
+    @property
+    def update_mask(self):
+        """Gets the update_mask of this ModelInstanceUpdateRequest.  # noqa: E501
+
+        Describes which fields to update  # noqa: E501
+
+        :return: The update_mask of this ModelInstanceUpdateRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._update_mask
+
+    @update_mask.setter
+    def update_mask(self, update_mask):
+        """Sets the update_mask of this ModelInstanceUpdateRequest.
+
+        Describes which fields to update  # noqa: E501
+
+        :param update_mask: The update_mask of this ModelInstanceUpdateRequest.  # noqa: E501
+        :type: str
+        """
+        if update_mask is None:
+            raise ValueError("Invalid value for `update_mask`, must not be `None`")  # noqa: E501
+
+        self._update_mask = update_mask
+
+    def to_dict(self):
+        """Returns the model properties as a dict"""
+        result = {}
+
+        for attr, _ in six.iteritems(self.project_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
+                    lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
+                    value
+                ))
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
+            elif isinstance(value, dict):
+                result[attr] = dict(map(
+                    lambda item: (item[0], item[1].to_dict())
+                    if hasattr(item[1], "to_dict") else item,
+                    value.items()
+                ))
+            else:
+                result[attr] = value
+
+        return result
+
+    def to_str(self):
+        """Returns the string representation of the model"""
+        return pprint.pformat(self.to_dict())
+
+    def __repr__(self):
+        """For `print` and `pprint`"""
+        return self.to_str()
+
+    def __eq__(self, other):
+        """Returns true if both objects are equal"""
+        if not isinstance(other, ModelInstanceUpdateRequest):
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        """Returns true if both objects are not equal"""
+        return not self == other
+

--- a/kaggle/models/model_new_instance_request.py
+++ b/kaggle/models/model_new_instance_request.py
@@ -1,0 +1,417 @@
+#!/usr/bin/python
+#
+# Copyright 2024 Kaggle Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# coding: utf-8
+
+import pprint
+import re  # noqa: F401
+
+import six
+
+from kaggle.models.upload_file import UploadFile  # noqa: F401,E501
+
+
+class ModelNewInstanceRequest(object):
+    """
+    Attributes:
+      project_types (dict): The key is attribute name
+                            and the value is attribute type.
+      attribute_map (dict): The key is attribute name
+                            and the value is json key in definition.
+    """
+    project_types = {
+        'instance_slug': 'str',
+        'framework': 'str',
+        'overview': 'str',
+        'usage': 'str',
+        'license_name': 'str',
+        'fine_tunable': 'bool',
+        'training_data': 'list[str]',
+        'model_instance_type': 'str',
+        'base_model_instance': 'str',
+        'external_base_model_url': 'int',
+        'files': 'list[UploadFile]'
+    }
+
+    attribute_map = {
+        'instance_slug': 'instanceSlug',
+        'framework': 'framework',
+        'overview': 'overview',
+        'usage': 'usage',
+        'license_name': 'licenseName',
+        'fine_tunable': 'fineTunable',
+        'training_data': 'trainingData',
+        'model_instance_type': 'modelInstanceType',
+        'base_model_instance': 'baseModelInstance',
+        'external_base_model_url': 'externalBaseModelUrl',
+        'files': 'files'
+    }
+
+    def __init__(self, instance_slug=None, framework=None, overview=None, usage=None, license_name='Apache 2.0', fine_tunable=True, training_data=None, model_instance_type=None, base_model_instance=None, external_base_model_url=None, files=None):  # noqa: E501
+
+        self._instance_slug = None
+        self._framework = None
+        self._overview = None
+        self._usage = None
+        self._license_name = None
+        self._fine_tunable = None
+        self._training_data = None
+        self._model_instance_type = None
+        self._base_model_instance = None
+        self._external_base_model_url = None
+        self._files = None
+        self.discriminator = None
+
+        self.instance_slug = instance_slug
+        self.framework = framework
+        if overview is not None:
+            self.overview = overview
+        if usage is not None:
+            self.usage = usage
+        self.license_name = license_name
+        if fine_tunable is not None:
+            self.fine_tunable = fine_tunable
+        if training_data is not None:
+            self.training_data = training_data
+        if model_instance_type is not None:
+            self.model_instance_type = model_instance_type
+        if base_model_instance is not None:
+            self.base_model_instance = base_model_instance
+        if external_base_model_url is not None:
+            self.external_base_model_url = external_base_model_url
+        if files is not None:
+            self.files = files
+
+    @property
+    def instance_slug(self):
+        """Gets the instance_slug of this ModelNewInstanceRequest.  # noqa: E501
+
+        The slug that the model instance should be created with  # noqa: E501
+
+        :return: The instance_slug of this ModelNewInstanceRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._instance_slug
+
+    @instance_slug.setter
+    def instance_slug(self, instance_slug):
+        """Sets the instance_slug of this ModelNewInstanceRequest.
+
+        The slug that the model instance should be created with  # noqa: E501
+
+        :param instance_slug: The instance_slug of this ModelNewInstanceRequest.  # noqa: E501
+        :type: str
+        """
+        if instance_slug is None:
+            raise ValueError("Invalid value for `instance_slug`, must not be `None`")  # noqa: E501
+
+        self._instance_slug = instance_slug
+
+    @property
+    def framework(self):
+        """Gets the framework of this ModelNewInstanceRequest.  # noqa: E501
+
+        The framework of the model instance  # noqa: E501
+
+        :return: The framework of this ModelNewInstanceRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._framework
+
+    @framework.setter
+    def framework(self, framework):
+        """Sets the framework of this ModelNewInstanceRequest.
+
+        The framework of the model instance  # noqa: E501
+
+        :param framework: The framework of this ModelNewInstanceRequest.  # noqa: E501
+        :type: str
+        """
+        if framework is None:
+            raise ValueError("Invalid value for `framework`, must not be `None`")  # noqa: E501
+        allowed_values = ["tensorFlow1", "tensorFlow2", "tfLite", "tfJs", "pyTorch", "jax", "flax", "pax", "maxText", "gemmaCpp", "tensorRtLlm", "ggml", "gguf", "coral", "scikitLearn", "mxnet", "onnx", "keras", "transformers", "triton", "api", "triton", "tensorRtLlm","other"]  # noqa: E501
+        if framework not in allowed_values:
+            raise ValueError(
+                "Invalid value for `framework` ({0}), must be one of {1}"  # noqa: E501
+                .format(framework, allowed_values)
+            )
+
+        self._framework = framework
+
+    @property
+    def overview(self):
+        """Gets the overview of this ModelNewInstanceRequest.  # noqa: E501
+
+        The overview of the model instance (markdown)  # noqa: E501
+
+        :return: The overview of this ModelNewInstanceRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._overview
+
+    @overview.setter
+    def overview(self, overview):
+        """Sets the overview of this ModelNewInstanceRequest.
+
+        The overview of the model instance (markdown)  # noqa: E501
+
+        :param overview: The overview of this ModelNewInstanceRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._overview = overview
+
+    @property
+    def usage(self):
+        """Gets the usage of this ModelNewInstanceRequest.  # noqa: E501
+
+        The description of how to use the model instance (markdown)  # noqa: E501
+
+        :return: The usage of this ModelNewInstanceRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._usage
+
+    @usage.setter
+    def usage(self, usage):
+        """Sets the usage of this ModelNewInstanceRequest.
+
+        The description of how to use the model instance (markdown)  # noqa: E501
+
+        :param usage: The usage of this ModelNewInstanceRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._usage = usage
+
+    @property
+    def license_name(self):
+        """Gets the license_name of this ModelNewInstanceRequest.  # noqa: E501
+
+        The license that should be associated with the model instance  # noqa: E501
+
+        :return: The license_name of this ModelNewInstanceRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._license_name
+
+    @license_name.setter
+    def license_name(self, license_name):
+        """Sets the license_name of this ModelNewInstanceRequest.
+
+        The license that should be associated with the model instance  # noqa: E501
+
+        :param license_name: The license_name of this ModelNewInstanceRequest.  # noqa: E501
+        :type: str
+        """
+        if license_name is None:
+            raise ValueError("Invalid value for `license_name`, must not be `None`")  # noqa: E501
+        allowed_values = ["CC0 1.0", "CC BY-NC-SA 4.0", "Unknown", "CC BY-SA 4.0", "GPL 2", "CC BY-SA 3.0", "Other", "Other (specified in description)", "CC BY 4.0", "Attribution 4.0 International (CC BY 4.0)", "CC BY-NC 4.0", "Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)", "PDDL", "ODC Public Domain Dedication and Licence (PDDL)", "CC BY 3.0", "Attribution 3.0 Unported (CC BY 3.0)", "CC BY 3.0 IGO", "Attribution 3.0 IGO (CC BY 3.0 IGO)", "CC BY-NC-SA 3.0 IGO", "Attribution-NonCommercial-ShareAlike 3.0 IGO (CC BY-NC-SA 3.0 IGO)", "CDLA Permissive 1.0", "Community Data License Agreement - Permissive - Version 1.0", "CDLA Sharing 1.0", "Community Data License Agreement - Sharing - Version 1.0", "CC BY-ND 4.0", "Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)", "CC BY-NC-ND 4.0", "Attribution-NonCommercial-NoDerivatives 4.0 International (CC BY-NC-ND 4.0)", "ODC-BY 1.0", "ODC Attribution License (ODC-By)", "LGPL 3.0", "GNU Lesser General Public License 3.0", "AGPL 3.0", "GNU Affero General Public License 3.0", "FDL 1.3", "GNU Free Documentation License 1.3", "apache-2.0", "Apache 2.0", "mit", "MIT", "bsd-3-clause", "BSD-3-Clause", "Llama 2", "Llama 2 Community License", "Gemma", "gpl-3", "GPL 3", "RAIL-M", "AI Pubs Open RAIL-M License", "AIPubs Research-Use RAIL-M", "AI Pubs Research-Use RAIL-M License", "BigScience OpenRAIL-M", "BigScience Open RAIL-M License", "RAIL", "RAIL (specified in description)", "Llama 3", "Llama 3 Community License"]  # noqa: E501
+        if license_name not in allowed_values:
+            raise ValueError(
+                "Invalid value for `license_name` ({0}), must be one of {1}"  # noqa: E501
+                .format(license_name, allowed_values)
+            )
+
+        self._license_name = license_name
+
+    @property
+    def fine_tunable(self):
+        """Gets the fine_tunable of this ModelNewInstanceRequest.  # noqa: E501
+
+        Whether the model instance is fine tunable  # noqa: E501
+
+        :return: The fine_tunable of this ModelNewInstanceRequest.  # noqa: E501
+        :rtype: bool
+        """
+        return self._fine_tunable
+
+    @fine_tunable.setter
+    def fine_tunable(self, fine_tunable):
+        """Sets the fine_tunable of this ModelNewInstanceRequest.
+
+        Whether the model instance is fine tunable  # noqa: E501
+
+        :param fine_tunable: The fine_tunable of this ModelNewInstanceRequest.  # noqa: E501
+        :type: bool
+        """
+
+        self._fine_tunable = fine_tunable
+
+    @property
+    def training_data(self):
+        """Gets the training_data of this ModelNewInstanceRequest.  # noqa: E501
+
+        A list of training data (urls or names)  # noqa: E501
+
+        :return: The training_data of this ModelNewInstanceRequest.  # noqa: E501
+        :rtype: list[str]
+        """
+        return self._training_data
+
+    @training_data.setter
+    def training_data(self, training_data):
+        """Sets the training_data of this ModelNewInstanceRequest.
+
+        A list of training data (urls or names)  # noqa: E501
+
+        :param training_data: The training_data of this ModelNewInstanceRequest.  # noqa: E501
+        :type: list[str]
+        """
+
+        self._training_data = training_data
+
+    @property
+    def model_instance_type(self):
+        """Gets the model_instance_type of this ModelNewInstanceRequest.  # noqa: E501
+
+        Whether the model instance is a base model, external variant, internal variant, or unspecified  # noqa: E501
+
+        :return: The model_instance_type of this ModelNewInstanceRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._model_instance_type
+
+    @model_instance_type.setter
+    def model_instance_type(self, model_instance_type):
+        """Sets the model_instance_type of this ModelNewInstanceRequest.
+
+        Whether the model instance is a base model, external variant, internal variant, or unspecified  # noqa: E501
+
+        :param model_instance_type: The model_instance_type of this ModelNewInstanceRequest.  # noqa: E501
+        :type: str
+        """
+        allowed_values = ["Unspecified", "BaseModel", "KaggleVariant", "ExternalVariant"]  # noqa: E501
+        if model_instance_type not in allowed_values:
+            raise ValueError(
+                "Invalid value for `model_instance_type` ({0}), must be one of {1}"  # noqa: E501
+                .format(model_instance_type, allowed_values)
+            )
+
+        self._model_instance_type = model_instance_type
+
+    @property
+    def base_model_instance(self):
+        """Gets the base_model_instance of this ModelNewInstanceRequest.  # noqa: E501
+
+        If this is an internal variant, the `{owner-slug}/{model-slug}/{framework}/{instance-slug}` of the base model instance  # noqa: E501
+
+        :return: The base_model_instance of this ModelNewInstanceRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._base_model_instance
+
+    @base_model_instance.setter
+    def base_model_instance(self, base_model_instance):
+        """Sets the base_model_instance of this ModelNewInstanceRequest.
+
+        If this is an internal variant, the `{owner-slug}/{model-slug}/{framework}/{instance-slug}` of the base model instance  # noqa: E501
+
+        :param base_model_instance: The base_model_instance of this ModelNewInstanceRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._base_model_instance = base_model_instance
+
+    @property
+    def external_base_model_url(self):
+        """Gets the external_base_model_url of this ModelNewInstanceRequest.  # noqa: E501
+
+        If this is an external variant, a URL to the base model  # noqa: E501
+
+        :return: The external_base_model_url of this ModelNewInstanceRequest.  # noqa: E501
+        :rtype: int
+        """
+        return self._external_base_model_url
+
+    @external_base_model_url.setter
+    def external_base_model_url(self, external_base_model_url):
+        """Sets the external_base_model_url of this ModelNewInstanceRequest.
+
+        If this is an external variant, a URL to the base model  # noqa: E501
+
+        :param external_base_model_url: The external_base_model_url of this ModelNewInstanceRequest.  # noqa: E501
+        :type: int
+        """
+
+        self._external_base_model_url = external_base_model_url
+
+    @property
+    def files(self):
+        """Gets the files of this ModelNewInstanceRequest.  # noqa: E501
+
+        A list of files that should be associated with the model instance version  # noqa: E501
+
+        :return: The files of this ModelNewInstanceRequest.  # noqa: E501
+        :rtype: list[UploadFile]
+        """
+        return self._files
+
+    @files.setter
+    def files(self, files):
+        """Sets the files of this ModelNewInstanceRequest.
+
+        A list of files that should be associated with the model instance version  # noqa: E501
+
+        :param files: The files of this ModelNewInstanceRequest.  # noqa: E501
+        :type: list[UploadFile]
+        """
+
+        self._files = files
+
+    def to_dict(self):
+        """Returns the model properties as a dict"""
+        result = {}
+
+        for attr, _ in six.iteritems(self.project_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
+                    lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
+                    value
+                ))
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
+            elif isinstance(value, dict):
+                result[attr] = dict(map(
+                    lambda item: (item[0], item[1].to_dict())
+                    if hasattr(item[1], "to_dict") else item,
+                    value.items()
+                ))
+            else:
+                result[attr] = value
+
+        return result
+
+    def to_str(self):
+        """Returns the string representation of the model"""
+        return pprint.pformat(self.to_dict())
+
+    def __repr__(self):
+        """For `print` and `pprint`"""
+        return self.to_str()
+
+    def __eq__(self, other):
+        """Returns true if both objects are equal"""
+        if not isinstance(other, ModelNewInstanceRequest):
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        """Returns true if both objects are not equal"""
+        return not self == other
+

--- a/kaggle/models/model_new_request.py
+++ b/kaggle/models/model_new_request.py
@@ -1,0 +1,314 @@
+#!/usr/bin/python
+#
+# Copyright 2024 Kaggle Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# coding: utf-8
+
+import pprint
+import re  # noqa: F401
+
+import six
+
+
+class ModelNewRequest(object):
+    """
+    Attributes:
+      project_types (dict): The key is attribute name
+                            and the value is attribute type.
+      attribute_map (dict): The key is attribute name
+                            and the value is json key in definition.
+    """
+    project_types = {
+        'owner_slug': 'str',
+        'slug': 'str',
+        'title': 'str',
+        'subtitle': 'str',
+        'is_private': 'bool',
+        'description': 'str',
+        'publish_time': 'date',
+        'provenance_sources': 'str'
+    }
+
+    attribute_map = {
+        'owner_slug': 'ownerSlug',
+        'slug': 'slug',
+        'title': 'title',
+        'subtitle': 'subtitle',
+        'is_private': 'isPrivate',
+        'description': 'description',
+        'publish_time': 'publishTime',
+        'provenance_sources': 'provenanceSources'
+    }
+
+    def __init__(self, owner_slug=None, slug=None, title=None, subtitle=None, is_private=True, description='', publish_time=None, provenance_sources=''):  # noqa: E501
+
+        self._owner_slug = None
+        self._slug = None
+        self._title = None
+        self._subtitle = None
+        self._is_private = None
+        self._description = None
+        self._publish_time = None
+        self._provenance_sources = None
+        self.discriminator = None
+
+        self.owner_slug = owner_slug
+        self.slug = slug
+        self.title = title
+        if subtitle is not None:
+            self.subtitle = subtitle
+        self.is_private = is_private
+        if description is not None:
+            self.description = description
+        if publish_time is not None:
+            self.publish_time = publish_time
+        if provenance_sources is not None:
+            self.provenance_sources = provenance_sources
+
+    @property
+    def owner_slug(self):
+        """Gets the owner_slug of this ModelNewRequest.  # noqa: E501
+
+        The owner's slug  # noqa: E501
+
+        :return: The owner_slug of this ModelNewRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._owner_slug
+
+    @owner_slug.setter
+    def owner_slug(self, owner_slug):
+        """Sets the owner_slug of this ModelNewRequest.
+
+        The owner's slug  # noqa: E501
+
+        :param owner_slug: The owner_slug of this ModelNewRequest.  # noqa: E501
+        :type: str
+        """
+        if owner_slug is None:
+            raise ValueError("Invalid value for `owner_slug`, must not be `None`")  # noqa: E501
+
+        self._owner_slug = owner_slug
+
+    @property
+    def slug(self):
+        """Gets the slug of this ModelNewRequest.  # noqa: E501
+
+        The slug that the model should be created with  # noqa: E501
+
+        :return: The slug of this ModelNewRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._slug
+
+    @slug.setter
+    def slug(self, slug):
+        """Sets the slug of this ModelNewRequest.
+
+        The slug that the model should be created with  # noqa: E501
+
+        :param slug: The slug of this ModelNewRequest.  # noqa: E501
+        :type: str
+        """
+        if slug is None:
+            raise ValueError("Invalid value for `slug`, must not be `None`")  # noqa: E501
+
+        self._slug = slug
+
+    @property
+    def title(self):
+        """Gets the title of this ModelNewRequest.  # noqa: E501
+
+        The title of the new model  # noqa: E501
+
+        :return: The title of this ModelNewRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._title
+
+    @title.setter
+    def title(self, title):
+        """Sets the title of this ModelNewRequest.
+
+        The title of the new model  # noqa: E501
+
+        :param title: The title of this ModelNewRequest.  # noqa: E501
+        :type: str
+        """
+        if title is None:
+            raise ValueError("Invalid value for `title`, must not be `None`")  # noqa: E501
+
+        self._title = title
+
+    @property
+    def subtitle(self):
+        """Gets the subtitle of this ModelNewRequest.  # noqa: E501
+
+        The subtitle of the new model  # noqa: E501
+
+        :return: The subtitle of this ModelNewRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._subtitle
+
+    @subtitle.setter
+    def subtitle(self, subtitle):
+        """Sets the subtitle of this ModelNewRequest.
+
+        The subtitle of the new model  # noqa: E501
+
+        :param subtitle: The subtitle of this ModelNewRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._subtitle = subtitle
+
+    @property
+    def is_private(self):
+        """Gets the is_private of this ModelNewRequest.  # noqa: E501
+
+        Whether or not the model should be private  # noqa: E501
+
+        :return: The is_private of this ModelNewRequest.  # noqa: E501
+        :rtype: bool
+        """
+        return self._is_private
+
+    @is_private.setter
+    def is_private(self, is_private):
+        """Sets the is_private of this ModelNewRequest.
+
+        Whether or not the model should be private  # noqa: E501
+
+        :param is_private: The is_private of this ModelNewRequest.  # noqa: E501
+        :type: bool
+        """
+        if is_private is None:
+            raise ValueError("Invalid value for `is_private`, must not be `None`")  # noqa: E501
+
+        self._is_private = is_private
+
+    @property
+    def description(self):
+        """Gets the description of this ModelNewRequest.  # noqa: E501
+
+        The description to be set on the model  # noqa: E501
+
+        :return: The description of this ModelNewRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """Sets the description of this ModelNewRequest.
+
+        The description to be set on the model  # noqa: E501
+
+        :param description: The description of this ModelNewRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._description = description
+
+    @property
+    def publish_time(self):
+        """Gets the publish_time of this ModelNewRequest.  # noqa: E501
+
+        When the model was initially published  # noqa: E501
+
+        :return: The publish_time of this ModelNewRequest.  # noqa: E501
+        :rtype: date
+        """
+        return self._publish_time
+
+    @publish_time.setter
+    def publish_time(self, publish_time):
+        """Sets the publish_time of this ModelNewRequest.
+
+        When the model was initially published  # noqa: E501
+
+        :param publish_time: The publish_time of this ModelNewRequest.  # noqa: E501
+        :type: date
+        """
+
+        self._publish_time = publish_time
+
+    @property
+    def provenance_sources(self):
+        """Gets the provenance_sources of this ModelNewRequest.  # noqa: E501
+
+        The provenance sources to be set on the model  # noqa: E501
+
+        :return: The provenance_sources of this ModelNewRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._provenance_sources
+
+    @provenance_sources.setter
+    def provenance_sources(self, provenance_sources):
+        """Sets the provenance_sources of this ModelNewRequest.
+
+        The provenance sources to be set on the model  # noqa: E501
+
+        :param provenance_sources: The provenance_sources of this ModelNewRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._provenance_sources = provenance_sources
+
+    def to_dict(self):
+        """Returns the model properties as a dict"""
+        result = {}
+
+        for attr, _ in six.iteritems(self.project_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
+                    lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
+                    value
+                ))
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
+            elif isinstance(value, dict):
+                result[attr] = dict(map(
+                    lambda item: (item[0], item[1].to_dict())
+                    if hasattr(item[1], "to_dict") else item,
+                    value.items()
+                ))
+            else:
+                result[attr] = value
+
+        return result
+
+    def to_str(self):
+        """Returns the string representation of the model"""
+        return pprint.pformat(self.to_dict())
+
+    def __repr__(self):
+        """For `print` and `pprint`"""
+        return self.to_str()
+
+    def __eq__(self, other):
+        """Returns true if both objects are equal"""
+        if not isinstance(other, ModelNewRequest):
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        """Returns true if both objects are not equal"""
+        return not self == other
+

--- a/kaggle/models/model_update_request.py
+++ b/kaggle/models/model_update_request.py
@@ -1,0 +1,282 @@
+#!/usr/bin/python
+#
+# Copyright 2024 Kaggle Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# coding: utf-8
+
+import pprint
+import re  # noqa: F401
+
+import six
+
+
+class ModelUpdateRequest(object):
+    """
+    Attributes:
+      project_types (dict): The key is attribute name
+                            and the value is attribute type.
+      attribute_map (dict): The key is attribute name
+                            and the value is json key in definition.
+    """
+    project_types = {
+        'title': 'str',
+        'subtitle': 'str',
+        'is_private': 'bool',
+        'description': 'str',
+        'publish_time': 'date',
+        'provenance_sources': 'str',
+        'update_mask': 'str'
+    }
+
+    attribute_map = {
+        'title': 'title',
+        'subtitle': 'subtitle',
+        'is_private': 'isPrivate',
+        'description': 'description',
+        'publish_time': 'publishTime',
+        'provenance_sources': 'provenanceSources',
+        'update_mask': 'updateMask'
+    }
+
+    def __init__(self, title=None, subtitle=None, is_private=True, description='', publish_time=None, provenance_sources='', update_mask=None):  # noqa: E501
+
+        self._title = None
+        self._subtitle = None
+        self._is_private = None
+        self._description = None
+        self._publish_time = None
+        self._provenance_sources = None
+        self._update_mask = None
+        self.discriminator = None
+
+        if title is not None:
+            self.title = title
+        if subtitle is not None:
+            self.subtitle = subtitle
+        if is_private is not None:
+            self.is_private = is_private
+        if description is not None:
+            self.description = description
+        if publish_time is not None:
+            self.publish_time = publish_time
+        if provenance_sources is not None:
+            self.provenance_sources = provenance_sources
+        if update_mask is not None:
+            self.update_mask = update_mask
+
+    @property
+    def title(self):
+        """Gets the title of this ModelUpdateRequest.  # noqa: E501
+
+        The title of the new model  # noqa: E501
+
+        :return: The title of this ModelUpdateRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._title
+
+    @title.setter
+    def title(self, title):
+        """Sets the title of this ModelUpdateRequest.
+
+        The title of the new model  # noqa: E501
+
+        :param title: The title of this ModelUpdateRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._title = title
+
+    @property
+    def subtitle(self):
+        """Gets the subtitle of this ModelUpdateRequest.  # noqa: E501
+
+        The subtitle of the new model  # noqa: E501
+
+        :return: The subtitle of this ModelUpdateRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._subtitle
+
+    @subtitle.setter
+    def subtitle(self, subtitle):
+        """Sets the subtitle of this ModelUpdateRequest.
+
+        The subtitle of the new model  # noqa: E501
+
+        :param subtitle: The subtitle of this ModelUpdateRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._subtitle = subtitle
+
+    @property
+    def is_private(self):
+        """Gets the is_private of this ModelUpdateRequest.  # noqa: E501
+
+        Whether or not the model should be private  # noqa: E501
+
+        :return: The is_private of this ModelUpdateRequest.  # noqa: E501
+        :rtype: bool
+        """
+        return self._is_private
+
+    @is_private.setter
+    def is_private(self, is_private):
+        """Sets the is_private of this ModelUpdateRequest.
+
+        Whether or not the model should be private  # noqa: E501
+
+        :param is_private: The is_private of this ModelUpdateRequest.  # noqa: E501
+        :type: bool
+        """
+
+        self._is_private = is_private
+
+    @property
+    def description(self):
+        """Gets the description of this ModelUpdateRequest.  # noqa: E501
+
+        The description to be set on the model  # noqa: E501
+
+        :return: The description of this ModelUpdateRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """Sets the description of this ModelUpdateRequest.
+
+        The description to be set on the model  # noqa: E501
+
+        :param description: The description of this ModelUpdateRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._description = description
+
+    @property
+    def publish_time(self):
+        """Gets the publish_time of this ModelUpdateRequest.  # noqa: E501
+
+        When the model was initially published  # noqa: E501
+
+        :return: The publish_time of this ModelUpdateRequest.  # noqa: E501
+        :rtype: date
+        """
+        return self._publish_time
+
+    @publish_time.setter
+    def publish_time(self, publish_time):
+        """Sets the publish_time of this ModelUpdateRequest.
+
+        When the model was initially published  # noqa: E501
+
+        :param publish_time: The publish_time of this ModelUpdateRequest.  # noqa: E501
+        :type: date
+        """
+
+        self._publish_time = publish_time
+
+    @property
+    def provenance_sources(self):
+        """Gets the provenance_sources of this ModelUpdateRequest.  # noqa: E501
+
+        The provenance sources to be set on the model  # noqa: E501
+
+        :return: The provenance_sources of this ModelUpdateRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._provenance_sources
+
+    @provenance_sources.setter
+    def provenance_sources(self, provenance_sources):
+        """Sets the provenance_sources of this ModelUpdateRequest.
+
+        The provenance sources to be set on the model  # noqa: E501
+
+        :param provenance_sources: The provenance_sources of this ModelUpdateRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._provenance_sources = provenance_sources
+
+    @property
+    def update_mask(self):
+        """Gets the update_mask of this ModelUpdateRequest.  # noqa: E501
+
+        Describes which fields to update  # noqa: E501
+
+        :return: The update_mask of this ModelUpdateRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._update_mask
+
+    @update_mask.setter
+    def update_mask(self, update_mask):
+        """Sets the update_mask of this ModelUpdateRequest.
+
+        Describes which fields to update  # noqa: E501
+
+        :param update_mask: The update_mask of this ModelUpdateRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._update_mask = update_mask
+
+    def to_dict(self):
+        """Returns the model properties as a dict"""
+        result = {}
+
+        for attr, _ in six.iteritems(self.project_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
+                    lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
+                    value
+                ))
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
+            elif isinstance(value, dict):
+                result[attr] = dict(map(
+                    lambda item: (item[0], item[1].to_dict())
+                    if hasattr(item[1], "to_dict") else item,
+                    value.items()
+                ))
+            else:
+                result[attr] = value
+
+        return result
+
+    def to_str(self):
+        """Returns the string representation of the model"""
+        return pprint.pformat(self.to_dict())
+
+    def __repr__(self):
+        """For `print` and `pprint`"""
+        return self.to_str()
+
+    def __eq__(self, other):
+        """Returns true if both objects are equal"""
+        if not isinstance(other, ModelUpdateRequest):
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        """Returns true if both objects are not equal"""
+        return not self == other
+

--- a/src/kaggle/models/dataset_new_request.py
+++ b/src/kaggle/models/dataset_new_request.py
@@ -1,0 +1,385 @@
+#!/usr/bin/python
+#
+# Copyright 2024 Kaggle Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# coding: utf-8
+
+import pprint
+import re  # noqa: F401
+
+import six
+
+from kaggle.models.upload_file import UploadFile  # noqa: F401,E501
+
+
+class DatasetNewRequest(object):
+    """
+    Attributes:
+      project_types (dict): The key is attribute name
+                            and the value is attribute type.
+      attribute_map (dict): The key is attribute name
+                            and the value is json key in definition.
+    """
+    project_types = {
+        'title': 'str',
+        'slug': 'str',
+        'owner_slug': 'str',
+        'license_name': 'str',
+        'subtitle': 'str',
+        'description': 'str',
+        'files': 'list[UploadFile]',
+        'is_private': 'bool',
+        'convert_to_csv': 'bool',
+        'category_ids': 'list[str]'
+    }
+
+    attribute_map = {
+        'title': 'title',
+        'slug': 'slug',
+        'owner_slug': 'ownerSlug',
+        'license_name': 'licenseName',
+        'subtitle': 'subtitle',
+        'description': 'description',
+        'files': 'files',
+        'is_private': 'isPrivate',
+        'convert_to_csv': 'convertToCsv',
+        'category_ids': 'categoryIds'
+    }
+
+    def __init__(self, title=None, slug=None, owner_slug=None, license_name='unknown', subtitle=None, description='', files=None, is_private=True, convert_to_csv=True, category_ids=None):  # noqa: E501
+
+        self._title = None
+        self._slug = None
+        self._owner_slug = None
+        self._license_name = None
+        self._subtitle = None
+        self._description = None
+        self._files = None
+        self._is_private = None
+        self._convert_to_csv = None
+        self._category_ids = None
+        self.discriminator = None
+
+        self.title = title
+        if slug is not None:
+            self.slug = slug
+        if owner_slug is not None:
+            self.owner_slug = owner_slug
+        if license_name is not None:
+            self.license_name = license_name
+        if subtitle is not None:
+            self.subtitle = subtitle
+        if description is not None:
+            self.description = description
+        self.files = files
+        if is_private is not None:
+            self.is_private = is_private
+        if convert_to_csv is not None:
+            self.convert_to_csv = convert_to_csv
+        if category_ids is not None:
+            self.category_ids = category_ids
+
+    @property
+    def title(self):
+        """Gets the title of this DatasetNewRequest.  # noqa: E501
+
+        The title of the new dataset  # noqa: E501
+
+        :return: The title of this DatasetNewRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._title
+
+    @title.setter
+    def title(self, title):
+        """Sets the title of this DatasetNewRequest.
+
+        The title of the new dataset  # noqa: E501
+
+        :param title: The title of this DatasetNewRequest.  # noqa: E501
+        :type: str
+        """
+        if title is None:
+            raise ValueError("Invalid value for `title`, must not be `None`")  # noqa: E501
+
+        self._title = title
+
+    @property
+    def slug(self):
+        """Gets the slug of this DatasetNewRequest.  # noqa: E501
+
+        The slug that the dataset should be created with  # noqa: E501
+
+        :return: The slug of this DatasetNewRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._slug
+
+    @slug.setter
+    def slug(self, slug):
+        """Sets the slug of this DatasetNewRequest.
+
+        The slug that the dataset should be created with  # noqa: E501
+
+        :param slug: The slug of this DatasetNewRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._slug = slug
+
+    @property
+    def owner_slug(self):
+        """Gets the owner_slug of this DatasetNewRequest.  # noqa: E501
+
+        The owner's username  # noqa: E501
+
+        :return: The owner_slug of this DatasetNewRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._owner_slug
+
+    @owner_slug.setter
+    def owner_slug(self, owner_slug):
+        """Sets the owner_slug of this DatasetNewRequest.
+
+        The owner's username  # noqa: E501
+
+        :param owner_slug: The owner_slug of this DatasetNewRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._owner_slug = owner_slug
+
+    @property
+    def license_name(self):
+        """Gets the license_name of this DatasetNewRequest.  # noqa: E501
+
+        The license that should be associated with the dataset  # noqa: E501
+
+        :return: The license_name of this DatasetNewRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._license_name
+
+    @license_name.setter
+    def license_name(self, license_name):
+        """Sets the license_name of this DatasetNewRequest.
+
+        The license that should be associated with the dataset  # noqa: E501
+
+        :param license_name: The license_name of this DatasetNewRequest.  # noqa: E501
+        :type: str
+        """
+        allowed_values = ["CC0-1.0", "CC-BY-SA-4.0", "GPL-2.0", "ODbL-1.0", "CC-BY-NC-SA-4.0", "unknown", "DbCL-1.0", "CC-BY-SA-3.0", "copyright-authors", "other", "reddit-api", "world-bank", "CC-BY-4.0", "CC-BY-NC-4.0", "PDDL", "CC-BY-3.0", "CC-BY-3.0-IGO", "US-Government-Works", "CC-BY-NC-SA-3.0-IGO", "CDLA-Permissive-1.0", "CDLA-Sharing-1.0", "CC-BY-ND-4.0", "CC-BY-NC-ND-4.0", "ODC-BY-1.0", "LGPL-3.0", "AGPL-3.0", "FDL-1.3", "EU-ODP-Legal-Notice", "apache-2.0", "GPL-3.0"]  # noqa: E501
+        if license_name not in allowed_values:
+            raise ValueError(
+                "Invalid value for `license_name` ({0}), must be one of {1}"  # noqa: E501
+                .format(license_name, allowed_values)
+            )
+        else:
+            license_name = license_name.lower()
+            if license_name[0-1] == 'cc':
+                license_name = 'cc'
+            elif license_name[0-3] == 'gpl':
+                license_name = 'gpl'
+            elif license_name[0-3] == 'odb':
+                license_name = 'odb'
+            else:
+                license_name = 'other'
+        self._license_name = license_name
+
+    @property
+    def subtitle(self):
+        """Gets the subtitle of this DatasetNewRequest.  # noqa: E501
+
+        The subtitle to be set on the dataset  # noqa: E501
+
+        :return: The subtitle of this DatasetNewRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._subtitle
+
+    @subtitle.setter
+    def subtitle(self, subtitle):
+        """Sets the subtitle of this DatasetNewRequest.
+
+        The subtitle to be set on the dataset  # noqa: E501
+
+        :param subtitle: The subtitle of this DatasetNewRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._subtitle = subtitle
+
+    @property
+    def description(self):
+        """Gets the description of this DatasetNewRequest.  # noqa: E501
+
+        The description to be set on the dataset  # noqa: E501
+
+        :return: The description of this DatasetNewRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """Sets the description of this DatasetNewRequest.
+
+        The description to be set on the dataset  # noqa: E501
+
+        :param description: The description of this DatasetNewRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._description = description
+
+    @property
+    def files(self):
+        """Gets the files of this DatasetNewRequest.  # noqa: E501
+
+        A list of files that should be associated with the dataset  # noqa: E501
+
+        :return: The files of this DatasetNewRequest.  # noqa: E501
+        :rtype: list[UploadFile]
+        """
+        return self._files
+
+    @files.setter
+    def files(self, files):
+        """Sets the files of this DatasetNewRequest.
+
+        A list of files that should be associated with the dataset  # noqa: E501
+
+        :param files: The files of this DatasetNewRequest.  # noqa: E501
+        :type: list[UploadFile]
+        """
+        if files is None:
+            raise ValueError("Invalid value for `files`, must not be `None`")  # noqa: E501
+
+        self._files = files
+
+    @property
+    def is_private(self):
+        """Gets the is_private of this DatasetNewRequest.  # noqa: E501
+
+        Whether or not the dataset should be private  # noqa: E501
+
+        :return: The is_private of this DatasetNewRequest.  # noqa: E501
+        :rtype: bool
+        """
+        return self._is_private
+
+    @is_private.setter
+    def is_private(self, is_private):
+        """Sets the is_private of this DatasetNewRequest.
+
+        Whether or not the dataset should be private  # noqa: E501
+
+        :param is_private: The is_private of this DatasetNewRequest.  # noqa: E501
+        :type: bool
+        """
+
+        self._is_private = is_private
+
+    @property
+    def convert_to_csv(self):
+        """Gets the convert_to_csv of this DatasetNewRequest.  # noqa: E501
+
+        Whether or not a tabular dataset should be converted to csv  # noqa: E501
+
+        :return: The convert_to_csv of this DatasetNewRequest.  # noqa: E501
+        :rtype: bool
+        """
+        return self._convert_to_csv
+
+    @convert_to_csv.setter
+    def convert_to_csv(self, convert_to_csv):
+        """Sets the convert_to_csv of this DatasetNewRequest.
+
+        Whether or not a tabular dataset should be converted to csv  # noqa: E501
+
+        :param convert_to_csv: The convert_to_csv of this DatasetNewRequest.  # noqa: E501
+        :type: bool
+        """
+
+        self._convert_to_csv = convert_to_csv
+
+    @property
+    def category_ids(self):
+        """Gets the category_ids of this DatasetNewRequest.  # noqa: E501
+
+        A list of tag IDs to associated with the dataset  # noqa: E501
+
+        :return: The category_ids of this DatasetNewRequest.  # noqa: E501
+        :rtype: list[str]
+        """
+        return self._category_ids
+
+    @category_ids.setter
+    def category_ids(self, category_ids):
+        """Sets the category_ids of this DatasetNewRequest.
+
+        A list of tag IDs to associated with the dataset  # noqa: E501
+
+        :param category_ids: The category_ids of this DatasetNewRequest.  # noqa: E501
+        :type: list[str]
+        """
+
+        self._category_ids = category_ids
+
+    def to_dict(self):
+        """Returns the model properties as a dict"""
+        result = {}
+
+        for attr, _ in six.iteritems(self.project_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
+                    lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
+                    value
+                ))
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
+            elif isinstance(value, dict):
+                result[attr] = dict(map(
+                    lambda item: (item[0], item[1].to_dict())
+                    if hasattr(item[1], "to_dict") else item,
+                    value.items()
+                ))
+            else:
+                result[attr] = value
+
+        return result
+
+    def to_str(self):
+        """Returns the string representation of the model"""
+        return pprint.pformat(self.to_dict())
+
+    def __repr__(self):
+        """For `print` and `pprint`"""
+        return self.to_str()
+
+    def __eq__(self, other):
+        """Returns true if both objects are equal"""
+        if not isinstance(other, DatasetNewRequest):
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        """Returns true if both objects are not equal"""
+        return not self == other
+

--- a/src/kaggle/models/dataset_new_version_request.py
+++ b/src/kaggle/models/dataset_new_version_request.py
@@ -1,0 +1,287 @@
+#!/usr/bin/python
+#
+# Copyright 2024 Kaggle Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# coding: utf-8
+
+
+import pprint
+import re  # noqa: F401
+
+import six
+
+from kaggle.models.upload_file import UploadFile  # noqa: F401,E501
+
+
+class DatasetNewVersionRequest(object):
+    """
+    Attributes:
+      project_types (dict): The key is attribute name
+                            and the value is attribute type.
+      attribute_map (dict): The key is attribute name
+                            and the value is json key in definition.
+    """
+    project_types = {
+        'version_notes': 'str',
+        'subtitle': 'str',
+        'description': 'str',
+        'files': 'list[UploadFile]',
+        'convert_to_csv': 'bool',
+        'category_ids': 'list[str]',
+        'delete_old_versions': 'bool'
+    }
+
+    attribute_map = {
+        'version_notes': 'versionNotes',
+        'subtitle': 'subtitle',
+        'description': 'description',
+        'files': 'files',
+        'convert_to_csv': 'convertToCsv',
+        'category_ids': 'categoryIds',
+        'delete_old_versions': 'deleteOldVersions'
+    }
+
+    def __init__(self, version_notes=None, subtitle=None, description=None, files=None, convert_to_csv=True, category_ids=None, delete_old_versions=False):  # noqa: E501
+
+        self._version_notes = None
+        self._subtitle = None
+        self._description = None
+        self._files = None
+        self._convert_to_csv = None
+        self._category_ids = None
+        self._delete_old_versions = None
+        self.discriminator = None
+
+        self.version_notes = version_notes
+        if subtitle is not None:
+            self.subtitle = subtitle
+        if description is not None:
+            self.description = description
+        self.files = files
+        if convert_to_csv is not None:
+            self.convert_to_csv = convert_to_csv
+        if category_ids is not None:
+            self.category_ids = category_ids
+        if delete_old_versions is not None:
+            self.delete_old_versions = delete_old_versions
+
+    @property
+    def version_notes(self):
+        """Gets the version_notes of this DatasetNewVersionRequest.  # noqa: E501
+
+        The version notes for the new dataset version  # noqa: E501
+
+        :return: The version_notes of this DatasetNewVersionRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._version_notes
+
+    @version_notes.setter
+    def version_notes(self, version_notes):
+        """Sets the version_notes of this DatasetNewVersionRequest.
+
+        The version notes for the new dataset version  # noqa: E501
+
+        :param version_notes: The version_notes of this DatasetNewVersionRequest.  # noqa: E501
+        :type: str
+        """
+        if version_notes is None:
+            raise ValueError("Invalid value for `version_notes`, must not be `None`")  # noqa: E501
+
+        self._version_notes = version_notes
+
+    @property
+    def subtitle(self):
+        """Gets the subtitle of this DatasetNewVersionRequest.  # noqa: E501
+
+        The subtitle to set on the dataset  # noqa: E501
+
+        :return: The subtitle of this DatasetNewVersionRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._subtitle
+
+    @subtitle.setter
+    def subtitle(self, subtitle):
+        """Sets the subtitle of this DatasetNewVersionRequest.
+
+        The subtitle to set on the dataset  # noqa: E501
+
+        :param subtitle: The subtitle of this DatasetNewVersionRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._subtitle = subtitle
+
+    @property
+    def description(self):
+        """Gets the description of this DatasetNewVersionRequest.  # noqa: E501
+
+        The description to set on the dataset  # noqa: E501
+
+        :return: The description of this DatasetNewVersionRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """Sets the description of this DatasetNewVersionRequest.
+
+        The description to set on the dataset  # noqa: E501
+
+        :param description: The description of this DatasetNewVersionRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._description = description
+
+    @property
+    def files(self):
+        """Gets the files of this DatasetNewVersionRequest.  # noqa: E501
+
+        A list of files that should be associated with the dataset  # noqa: E501
+
+        :return: The files of this DatasetNewVersionRequest.  # noqa: E501
+        :rtype: list[UploadFile]
+        """
+        return self._files
+
+    @files.setter
+    def files(self, files):
+        """Sets the files of this DatasetNewVersionRequest.
+
+        A list of files that should be associated with the dataset  # noqa: E501
+
+        :param files: The files of this DatasetNewVersionRequest.  # noqa: E501
+        :type: list[UploadFile]
+        """
+        if files is None:
+            raise ValueError("Invalid value for `files`, must not be `None`")  # noqa: E501
+
+        self._files = files
+
+    @property
+    def convert_to_csv(self):
+        """Gets the convert_to_csv of this DatasetNewVersionRequest.  # noqa: E501
+
+        Whether or not a tabular dataset should be converted to csv  # noqa: E501
+
+        :return: The convert_to_csv of this DatasetNewVersionRequest.  # noqa: E501
+        :rtype: bool
+        """
+        return self._convert_to_csv
+
+    @convert_to_csv.setter
+    def convert_to_csv(self, convert_to_csv):
+        """Sets the convert_to_csv of this DatasetNewVersionRequest.
+
+        Whether or not a tabular dataset should be converted to csv  # noqa: E501
+
+        :param convert_to_csv: The convert_to_csv of this DatasetNewVersionRequest.  # noqa: E501
+        :type: bool
+        """
+
+        self._convert_to_csv = convert_to_csv
+
+    @property
+    def category_ids(self):
+        """Gets the category_ids of this DatasetNewVersionRequest.  # noqa: E501
+
+        A list of tag IDs to associated with the dataset  # noqa: E501
+
+        :return: The category_ids of this DatasetNewVersionRequest.  # noqa: E501
+        :rtype: list[str]
+        """
+        return self._category_ids
+
+    @category_ids.setter
+    def category_ids(self, category_ids):
+        """Sets the category_ids of this DatasetNewVersionRequest.
+
+        A list of tag IDs to associated with the dataset  # noqa: E501
+
+        :param category_ids: The category_ids of this DatasetNewVersionRequest.  # noqa: E501
+        :type: list[str]
+        """
+
+        self._category_ids = category_ids
+
+    @property
+    def delete_old_versions(self):
+        """Gets the delete_old_versions of this DatasetNewVersionRequest.  # noqa: E501
+
+        Whether or not all previous versions of the dataset should be deleted upon creating the new version  # noqa: E501
+
+        :return: The delete_old_versions of this DatasetNewVersionRequest.  # noqa: E501
+        :rtype: bool
+        """
+        return self._delete_old_versions
+
+    @delete_old_versions.setter
+    def delete_old_versions(self, delete_old_versions):
+        """Sets the delete_old_versions of this DatasetNewVersionRequest.
+
+        Whether or not all previous versions of the dataset should be deleted upon creating the new version  # noqa: E501
+
+        :param delete_old_versions: The delete_old_versions of this DatasetNewVersionRequest.  # noqa: E501
+        :type: bool
+        """
+
+        self._delete_old_versions = delete_old_versions
+
+    def to_dict(self):
+        """Returns the model properties as a dict"""
+        result = {}
+
+        for attr, _ in six.iteritems(self.project_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
+                    lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
+                    value
+                ))
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
+            elif isinstance(value, dict):
+                result[attr] = dict(map(
+                    lambda item: (item[0], item[1].to_dict())
+                    if hasattr(item[1], "to_dict") else item,
+                    value.items()
+                ))
+            else:
+                result[attr] = value
+
+        return result
+
+    def to_str(self):
+        """Returns the string representation of the model"""
+        return pprint.pformat(self.to_dict())
+
+    def __repr__(self):
+        """For `print` and `pprint`"""
+        return self.to_str()
+
+    def __eq__(self, other):
+        """Returns true if both objects are equal"""
+        if not isinstance(other, DatasetNewVersionRequest):
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        """Returns true if both objects are not equal"""
+        return not self == other
+

--- a/src/kaggle/models/dataset_update_settings_request.py
+++ b/src/kaggle/models/dataset_update_settings_request.py
@@ -1,0 +1,310 @@
+#!/usr/bin/python
+#
+# Copyright 2024 Kaggle Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# coding: utf-8
+
+import pprint
+import re  # noqa: F401
+
+import six
+
+
+class DatasetUpdateSettingsRequest(object):
+    """
+    Attributes:
+      project_types (dict): The key is attribute name
+                            and the value is attribute type.
+      attribute_map (dict): The key is attribute name
+                            and the value is json key in definition.
+    """
+    project_types = {
+        'title': 'str',
+        'subtitle': 'str',
+        'description': 'str',
+        'is_private': 'bool',
+        'licenses': 'list[object]',
+        'keywords': 'list[str]',
+        'collaborators': 'list[object]',
+        'data': 'list[object]'
+    }
+
+    attribute_map = {
+        'title': 'title',
+        'subtitle': 'subtitle',
+        'description': 'description',
+        'is_private': 'isPrivate',
+        'licenses': 'licenses',
+        'keywords': 'keywords',
+        'collaborators': 'collaborators',
+        'data': 'data'
+    }
+
+    def __init__(self, title=None, subtitle=None, description=None, is_private=None, licenses=None, keywords=None, collaborators=None, data=None):  # noqa: E501
+
+        self._title = None
+        self._subtitle = None
+        self._description = None
+        self._is_private = None
+        self._licenses = None
+        self._keywords = None
+        self._collaborators = None
+        self._data = None
+        self.discriminator = None
+
+        if title is not None:
+            self.title = title
+        if subtitle is not None:
+            self.subtitle = subtitle
+        if description is not None:
+            self.description = description
+        if is_private is not None:
+            self.is_private = is_private
+        if licenses is not None:
+            self.licenses = licenses
+        if keywords is not None:
+            self.keywords = keywords
+        if collaborators is not None:
+            self.collaborators = collaborators
+        if data is not None:
+            self.data = data
+
+    @property
+    def title(self):
+        """Gets the title of this DatasetUpdateSettingsRequest.  # noqa: E501
+
+        Title of the dataset  # noqa: E501
+
+        :return: The title of this DatasetUpdateSettingsRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._title
+
+    @title.setter
+    def title(self, title):
+        """Sets the title of this DatasetUpdateSettingsRequest.
+
+        Title of the dataset  # noqa: E501
+
+        :param title: The title of this DatasetUpdateSettingsRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._title = title
+
+    @property
+    def subtitle(self):
+        """Gets the subtitle of this DatasetUpdateSettingsRequest.  # noqa: E501
+
+        Subtitle of the dataset  # noqa: E501
+
+        :return: The subtitle of this DatasetUpdateSettingsRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._subtitle
+
+    @subtitle.setter
+    def subtitle(self, subtitle):
+        """Sets the subtitle of this DatasetUpdateSettingsRequest.
+
+        Subtitle of the dataset  # noqa: E501
+
+        :param subtitle: The subtitle of this DatasetUpdateSettingsRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._subtitle = subtitle
+
+    @property
+    def description(self):
+        """Gets the description of this DatasetUpdateSettingsRequest.  # noqa: E501
+
+        Decription of the dataset  # noqa: E501
+
+        :return: The description of this DatasetUpdateSettingsRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """Sets the description of this DatasetUpdateSettingsRequest.
+
+        Decription of the dataset  # noqa: E501
+
+        :param description: The description of this DatasetUpdateSettingsRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._description = description
+
+    @property
+    def is_private(self):
+        """Gets the is_private of this DatasetUpdateSettingsRequest.  # noqa: E501
+
+        Whether or not the dataset should be private  # noqa: E501
+
+        :return: The is_private of this DatasetUpdateSettingsRequest.  # noqa: E501
+        :rtype: bool
+        """
+        return self._is_private
+
+    @is_private.setter
+    def is_private(self, is_private):
+        """Sets the is_private of this DatasetUpdateSettingsRequest.
+
+        Whether or not the dataset should be private  # noqa: E501
+
+        :param is_private: The is_private of this DatasetUpdateSettingsRequest.  # noqa: E501
+        :type: bool
+        """
+
+        self._is_private = is_private
+
+    @property
+    def licenses(self):
+        """Gets the licenses of this DatasetUpdateSettingsRequest.  # noqa: E501
+
+        A list of licenses that apply to this dataset  # noqa: E501
+
+        :return: The licenses of this DatasetUpdateSettingsRequest.  # noqa: E501
+        :rtype: list[object]
+        """
+        return self._licenses
+
+    @licenses.setter
+    def licenses(self, licenses):
+        """Sets the licenses of this DatasetUpdateSettingsRequest.
+
+        A list of licenses that apply to this dataset  # noqa: E501
+
+        :param licenses: The licenses of this DatasetUpdateSettingsRequest.  # noqa: E501
+        :type: list[object]
+        """
+
+        self._licenses = licenses
+
+    @property
+    def keywords(self):
+        """Gets the keywords of this DatasetUpdateSettingsRequest.  # noqa: E501
+
+        A list of keywords that apply to this dataset  # noqa: E501
+
+        :return: The keywords of this DatasetUpdateSettingsRequest.  # noqa: E501
+        :rtype: list[str]
+        """
+        return self._keywords
+
+    @keywords.setter
+    def keywords(self, keywords):
+        """Sets the keywords of this DatasetUpdateSettingsRequest.
+
+        A list of keywords that apply to this dataset  # noqa: E501
+
+        :param keywords: The keywords of this DatasetUpdateSettingsRequest.  # noqa: E501
+        :type: list[str]
+        """
+
+        self._keywords = keywords
+
+    @property
+    def collaborators(self):
+        """Gets the collaborators of this DatasetUpdateSettingsRequest.  # noqa: E501
+
+        A list of collaborators that may read or edit this dataset  # noqa: E501
+
+        :return: The collaborators of this DatasetUpdateSettingsRequest.  # noqa: E501
+        :rtype: list[object]
+        """
+        return self._collaborators
+
+    @collaborators.setter
+    def collaborators(self, collaborators):
+        """Sets the collaborators of this DatasetUpdateSettingsRequest.
+
+        A list of collaborators that may read or edit this dataset  # noqa: E501
+
+        :param collaborators: The collaborators of this DatasetUpdateSettingsRequest.  # noqa: E501
+        :type: list[object]
+        """
+
+        self._collaborators = collaborators
+
+    @property
+    def data(self):
+        """Gets the data of this DatasetUpdateSettingsRequest.  # noqa: E501
+
+        A list containing metadata for each file in the dataset  # noqa: E501
+
+        :return: The data of this DatasetUpdateSettingsRequest.  # noqa: E501
+        :rtype: list[object]
+        """
+        return self._data
+
+    @data.setter
+    def data(self, data):
+        """Sets the data of this DatasetUpdateSettingsRequest.
+
+        A list containing metadata for each file in the dataset  # noqa: E501
+
+        :param data: The data of this DatasetUpdateSettingsRequest.  # noqa: E501
+        :type: list[object]
+        """
+
+        self._data = data
+
+    def to_dict(self):
+        """Returns the model properties as a dict"""
+        result = {}
+
+        for attr, _ in six.iteritems(self.project_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
+                    lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
+                    value
+                ))
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
+            elif isinstance(value, dict):
+                result[attr] = dict(map(
+                    lambda item: (item[0], item[1].to_dict())
+                    if hasattr(item[1], "to_dict") else item,
+                    value.items()
+                ))
+            else:
+                result[attr] = value
+
+        return result
+
+    def to_str(self):
+        """Returns the string representation of the model"""
+        return pprint.pformat(self.to_dict())
+
+    def __repr__(self):
+        """For `print` and `pprint`"""
+        return self.to_str()
+
+    def __eq__(self, other):
+        """Returns true if both objects are equal"""
+        if not isinstance(other, DatasetUpdateSettingsRequest):
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        """Returns true if both objects are not equal"""
+        return not self == other
+

--- a/src/kaggle/models/kernel_push_request.py
+++ b/src/kaggle/models/kernel_push_request.py
@@ -1,0 +1,556 @@
+#!/usr/bin/python
+#
+# Copyright 2024 Kaggle Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# coding: utf-8
+
+
+import pprint
+import re  # noqa: F401
+
+import six
+
+
+class KernelPushRequest(object):
+    """
+    Attributes:
+      project_types (dict): The key is attribute name
+                            and the value is attribute type.
+      attribute_map (dict): The key is attribute name
+                            and the value is json key in definition.
+    """
+    project_types = {
+        'id': 'int',
+        'slug': 'str',
+        'new_title': 'str',
+        'text': 'str',
+        'language': 'str',
+        'kernel_type': 'str',
+        'is_private': 'bool',
+        'enable_gpu': 'bool',
+        'enable_tpu': 'bool',
+        'enable_internet': 'bool',
+        'dataset_data_sources': 'list[str]',
+        'competition_data_sources': 'list[str]',
+        'kernel_data_sources': 'list[str]',
+        'model_data_sources': 'list[str]',
+        'category_ids': 'list[str]',
+        'docker_image_pinning_type': 'str'
+    }
+
+    attribute_map = {
+        'id': 'id',
+        'slug': 'slug',
+        'new_title': 'newTitle',
+        'text': 'text',
+        'language': 'language',
+        'kernel_type': 'kernelType',
+        'is_private': 'isPrivate',
+        'enable_gpu': 'enableGpu',
+        'enable_tpu': 'enableTpu',
+        'enable_internet': 'enableInternet',
+        'dataset_data_sources': 'datasetDataSources',
+        'competition_data_sources': 'competitionDataSources',
+        'kernel_data_sources': 'kernelDataSources',
+        'model_data_sources': 'modelDataSources',
+        'category_ids': 'categoryIds',
+        'docker_image_pinning_type': 'dockerImagePinningType'
+    }
+
+    def __init__(self, id=None, slug=None, new_title=None, text=None, language=None, kernel_type=None, is_private=None, enable_gpu=None, enable_tpu=None, enable_internet=None, dataset_data_sources=None, competition_data_sources=None, kernel_data_sources=None, model_data_sources=None, category_ids=None, docker_image_pinning_type=None):  # noqa: E501
+
+        self._id = None
+        self._slug = None
+        self._new_title = None
+        self._text = None
+        self._language = None
+        self._kernel_type = None
+        self._is_private = None
+        self._enable_gpu = None
+        self._enable_tpu = None
+        self._enable_internet = None
+        self._dataset_data_sources = None
+        self._competition_data_sources = None
+        self._kernel_data_sources = None
+        self._model_data_sources = None
+        self._category_ids = None
+        self._docker_image_pinning_type = None
+        self.discriminator = None
+
+        if id is not None:
+            self.id = id
+        if slug is not None:
+            self.slug = slug
+        if new_title is not None:
+            self.new_title = new_title
+        self.text = text
+        self.language = language
+        self.kernel_type = kernel_type
+        if is_private is not None:
+            self.is_private = is_private
+        if enable_gpu is not None:
+            self.enable_gpu = enable_gpu
+        if enable_tpu is not None:
+            self.enable_tpu = enable_tpu
+        if enable_internet is not None:
+            self.enable_internet = enable_internet
+        if dataset_data_sources is not None:
+            self.dataset_data_sources = dataset_data_sources
+        if competition_data_sources is not None:
+            self.competition_data_sources = competition_data_sources
+        if kernel_data_sources is not None:
+            self.kernel_data_sources = kernel_data_sources
+        if model_data_sources is not None:
+            self.model_data_sources = model_data_sources
+        if category_ids is not None:
+            self.category_ids = category_ids
+        if docker_image_pinning_type is not None:
+            self.docker_image_pinning_type = docker_image_pinning_type
+
+    @property
+    def id(self):
+        """Gets the id of this KernelPushRequest.  # noqa: E501
+
+        The kernel's ID number. One of `id` and `slug` are required. If both are specified, `id` will be preferred  # noqa: E501
+
+        :return: The id of this KernelPushRequest.  # noqa: E501
+        :rtype: int
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """Sets the id of this KernelPushRequest.
+
+        The kernel's ID number. One of `id` and `slug` are required. If both are specified, `id` will be preferred  # noqa: E501
+
+        :param id: The id of this KernelPushRequest.  # noqa: E501
+        :type: int
+        """
+
+        self._id = id
+
+    @property
+    def slug(self):
+        """Gets the slug of this KernelPushRequest.  # noqa: E501
+
+        The full slug of the kernel to push to, in the format `USERNAME/KERNEL-SLUG`. The kernel slug must be the title lowercased with dashes (`-`) replacing spaces. One of `id` and `slug` are required. If both are specified, `id` will be preferred  # noqa: E501
+
+        :return: The slug of this KernelPushRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._slug
+
+    @slug.setter
+    def slug(self, slug):
+        """Sets the slug of this KernelPushRequest.
+
+        The full slug of the kernel to push to, in the format `USERNAME/KERNEL-SLUG`. The kernel slug must be the title lowercased with dashes (`-`) replacing spaces. One of `id` and `slug` are required. If both are specified, `id` will be preferred  # noqa: E501
+
+        :param slug: The slug of this KernelPushRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._slug = slug
+
+    @property
+    def new_title(self):
+        """Gets the new_title of this KernelPushRequest.  # noqa: E501
+
+        The title to be set on the kernel  # noqa: E501
+
+        :return: The new_title of this KernelPushRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._new_title
+
+    @new_title.setter
+    def new_title(self, new_title):
+        """Sets the new_title of this KernelPushRequest.
+
+        The title to be set on the kernel  # noqa: E501
+
+        :param new_title: The new_title of this KernelPushRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._new_title = new_title
+
+    @property
+    def text(self):
+        """Gets the text of this KernelPushRequest.  # noqa: E501
+
+        The kernel's source code  # noqa: E501
+
+        :return: The text of this KernelPushRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._text
+
+    @text.setter
+    def text(self, text):
+        """Sets the text of this KernelPushRequest.
+
+        The kernel's source code  # noqa: E501
+
+        :param text: The text of this KernelPushRequest.  # noqa: E501
+        :type: str
+        """
+        if text is None:
+            raise ValueError("Invalid value for `text`, must not be `None`")  # noqa: E501
+
+        self._text = text
+
+    @property
+    def language(self):
+        """Gets the language of this KernelPushRequest.  # noqa: E501
+
+        The language that the kernel is written in  # noqa: E501
+
+        :return: The language of this KernelPushRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._language
+
+    @language.setter
+    def language(self, language):
+        """Sets the language of this KernelPushRequest.
+
+        The language that the kernel is written in  # noqa: E501
+
+        :param language: The language of this KernelPushRequest.  # noqa: E501
+        :type: str
+        """
+        if language is None:
+            raise ValueError("Invalid value for `language`, must not be `None`")  # noqa: E501
+        allowed_values = ["python", "r", "rmarkdown"]  # noqa: E501
+        if language not in allowed_values:
+            raise ValueError(
+                "Invalid value for `language` ({0}), must be one of {1}"  # noqa: E501
+                .format(language, allowed_values)
+            )
+
+        self._language = language
+
+    @property
+    def kernel_type(self):
+        """Gets the kernel_type of this KernelPushRequest.  # noqa: E501
+
+        The type of kernel. Cannot be changed once the kernel has been created  # noqa: E501
+
+        :return: The kernel_type of this KernelPushRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._kernel_type
+
+    @kernel_type.setter
+    def kernel_type(self, kernel_type):
+        """Sets the kernel_type of this KernelPushRequest.
+
+        The type of kernel. Cannot be changed once the kernel has been created  # noqa: E501
+
+        :param kernel_type: The kernel_type of this KernelPushRequest.  # noqa: E501
+        :type: str
+        """
+        if kernel_type is None:
+            raise ValueError("Invalid value for `kernel_type`, must not be `None`")  # noqa: E501
+        allowed_values = ["script", "notebook"]  # noqa: E501
+        if kernel_type not in allowed_values:
+            raise ValueError(
+                "Invalid value for `kernel_type` ({0}), must be one of {1}"  # noqa: E501
+                .format(kernel_type, allowed_values)
+            )
+
+        self._kernel_type = kernel_type
+
+    @property
+    def is_private(self):
+        """Gets the is_private of this KernelPushRequest.  # noqa: E501
+
+        Whether or not the kernel should be private  # noqa: E501
+
+        :return: The is_private of this KernelPushRequest.  # noqa: E501
+        :rtype: bool
+        """
+        return self._is_private
+
+    @is_private.setter
+    def is_private(self, is_private):
+        """Sets the is_private of this KernelPushRequest.
+
+        Whether or not the kernel should be private  # noqa: E501
+
+        :param is_private: The is_private of this KernelPushRequest.  # noqa: E501
+        :type: bool
+        """
+
+        self._is_private = is_private
+
+    @property
+    def enable_gpu(self):
+        """Gets the enable_gpu of this KernelPushRequest.  # noqa: E501
+
+        Whether or not the kernel should run on a GPU  # noqa: E501
+
+        :return: The enable_gpu of this KernelPushRequest.  # noqa: E501
+        :rtype: bool
+        """
+        return self._enable_gpu
+
+    @enable_gpu.setter
+    def enable_gpu(self, enable_gpu):
+        """Sets the enable_gpu of this KernelPushRequest.
+
+        Whether or not the kernel should run on a GPU  # noqa: E501
+
+        :param enable_gpu: The enable_gpu of this KernelPushRequest.  # noqa: E501
+        :type: bool
+        """
+
+        self._enable_gpu = enable_gpu
+
+    @property
+    def enable_tpu(self):
+        """Gets the enable_tpu of this KernelPushRequest.  # noqa: E501
+
+        Whether or not the kernel should run on a TPU  # noqa: E501
+
+        :return: The enable_tpu of this KernelPushRequest.  # noqa: E501
+        :rtype: bool
+        """
+        return self._enable_tpu
+
+    @enable_tpu.setter
+    def enable_tpu(self, enable_tpu):
+        """Sets the enable_tpu of this KernelPushRequest.
+
+        Whether or not the kernel should run on a TPU  # noqa: E501
+
+        :param enable_tpu: The enable_tpu of this KernelPushRequest.  # noqa: E501
+        :type: bool
+        """
+
+        self._enable_tpu = enable_tpu
+
+    @property
+    def enable_internet(self):
+        """Gets the enable_internet of this KernelPushRequest.  # noqa: E501
+
+        Whether or not the kernel should be able to access the internet  # noqa: E501
+
+        :return: The enable_internet of this KernelPushRequest.  # noqa: E501
+        :rtype: bool
+        """
+        return self._enable_internet
+
+    @enable_internet.setter
+    def enable_internet(self, enable_internet):
+        """Sets the enable_internet of this KernelPushRequest.
+
+        Whether or not the kernel should be able to access the internet  # noqa: E501
+
+        :param enable_internet: The enable_internet of this KernelPushRequest.  # noqa: E501
+        :type: bool
+        """
+
+        self._enable_internet = enable_internet
+
+    @property
+    def dataset_data_sources(self):
+        """Gets the dataset_data_sources of this KernelPushRequest.  # noqa: E501
+
+        A list of dataset data sources that the kernel should use. Each dataset is specified as `USERNAME/DATASET-SLUG`  # noqa: E501
+
+        :return: The dataset_data_sources of this KernelPushRequest.  # noqa: E501
+        :rtype: list[str]
+        """
+        return self._dataset_data_sources
+
+    @dataset_data_sources.setter
+    def dataset_data_sources(self, dataset_data_sources):
+        """Sets the dataset_data_sources of this KernelPushRequest.
+
+        A list of dataset data sources that the kernel should use. Each dataset is specified as `USERNAME/DATASET-SLUG`  # noqa: E501
+
+        :param dataset_data_sources: The dataset_data_sources of this KernelPushRequest.  # noqa: E501
+        :type: list[str]
+        """
+
+        self._dataset_data_sources = dataset_data_sources
+
+    @property
+    def competition_data_sources(self):
+        """Gets the competition_data_sources of this KernelPushRequest.  # noqa: E501
+
+        A list of competition data sources that the kernel should use  # noqa: E501
+
+        :return: The competition_data_sources of this KernelPushRequest.  # noqa: E501
+        :rtype: list[str]
+        """
+        return self._competition_data_sources
+
+    @competition_data_sources.setter
+    def competition_data_sources(self, competition_data_sources):
+        """Sets the competition_data_sources of this KernelPushRequest.
+
+        A list of competition data sources that the kernel should use  # noqa: E501
+
+        :param competition_data_sources: The competition_data_sources of this KernelPushRequest.  # noqa: E501
+        :type: list[str]
+        """
+
+        self._competition_data_sources = competition_data_sources
+
+    @property
+    def kernel_data_sources(self):
+        """Gets the kernel_data_sources of this KernelPushRequest.  # noqa: E501
+
+        A list of kernel data sources that the kernel should use. Each dataset is specified as `USERNAME/KERNEL-SLUG`  # noqa: E501
+
+        :return: The kernel_data_sources of this KernelPushRequest.  # noqa: E501
+        :rtype: list[str]
+        """
+        return self._kernel_data_sources
+
+    @kernel_data_sources.setter
+    def kernel_data_sources(self, kernel_data_sources):
+        """Sets the kernel_data_sources of this KernelPushRequest.
+
+        A list of kernel data sources that the kernel should use. Each dataset is specified as `USERNAME/KERNEL-SLUG`  # noqa: E501
+
+        :param kernel_data_sources: The kernel_data_sources of this KernelPushRequest.  # noqa: E501
+        :type: list[str]
+        """
+
+        self._kernel_data_sources = kernel_data_sources
+
+    @property
+    def model_data_sources(self):
+        """Gets the model_data_sources of this KernelPushRequest.  # noqa: E501
+
+        A list of model data sources that the kernel should use. Each model is specified as `USERNAME/MODEL-SLUG/FRAMEWORK/VARIATION-SLUG/VERSION-NUMBER`  # noqa: E501
+
+        :return: The model_data_sources of this KernelPushRequest.  # noqa: E501
+        :rtype: list[str]
+        """
+        return self._model_data_sources
+
+    @model_data_sources.setter
+    def model_data_sources(self, model_data_sources):
+        """Sets the model_data_sources of this KernelPushRequest.
+
+        A list of model data sources that the kernel should use. Each model is specified as `USERNAME/MODEL-SLUG/FRAMEWORK/VARIATION-SLUG/VERSION-NUMBER`  # noqa: E501
+
+        :param model_data_sources: The model_data_sources of this KernelPushRequest.  # noqa: E501
+        :type: list[str]
+        """
+
+        self._model_data_sources = model_data_sources
+
+    @property
+    def category_ids(self):
+        """Gets the category_ids of this KernelPushRequest.  # noqa: E501
+
+        A list of tag IDs to associated with the kernel  # noqa: E501
+
+        :return: The category_ids of this KernelPushRequest.  # noqa: E501
+        :rtype: list[str]
+        """
+        return self._category_ids
+
+    @category_ids.setter
+    def category_ids(self, category_ids):
+        """Sets the category_ids of this KernelPushRequest.
+
+        A list of tag IDs to associated with the kernel  # noqa: E501
+
+        :param category_ids: The category_ids of this KernelPushRequest.  # noqa: E501
+        :type: list[str]
+        """
+
+        self._category_ids = category_ids
+
+    @property
+    def docker_image_pinning_type(self):
+        """Gets the docker_image_pinning_type of this KernelPushRequest.  # noqa: E501
+
+        Which docker image to use for executing new versions going forward.  # noqa: E501
+
+        :return: The docker_image_pinning_type of this KernelPushRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._docker_image_pinning_type
+
+    @docker_image_pinning_type.setter
+    def docker_image_pinning_type(self, docker_image_pinning_type):
+        """Sets the docker_image_pinning_type of this KernelPushRequest.
+
+        Which docker image to use for executing new versions going forward.  # noqa: E501
+
+        :param docker_image_pinning_type: The docker_image_pinning_type of this KernelPushRequest.  # noqa: E501
+        :type: str
+        """
+        allowed_values = ["original", "latest"]  # noqa: E501
+        if docker_image_pinning_type not in allowed_values:
+            raise ValueError(
+                "Invalid value for `docker_image_pinning_type` ({0}), must be one of {1}"  # noqa: E501
+                .format(docker_image_pinning_type, allowed_values)
+            )
+
+        self._docker_image_pinning_type = docker_image_pinning_type
+
+    def to_dict(self):
+        """Returns the model properties as a dict"""
+        result = {}
+
+        for attr, _ in six.iteritems(self.project_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
+                    lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
+                    value
+                ))
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
+            elif isinstance(value, dict):
+                result[attr] = dict(map(
+                    lambda item: (item[0], item[1].to_dict())
+                    if hasattr(item[1], "to_dict") else item,
+                    value.items()
+                ))
+            else:
+                result[attr] = value
+
+        return result
+
+    def to_str(self):
+        """Returns the string representation of the model"""
+        return pprint.pformat(self.to_dict())
+
+    def __repr__(self):
+        """For `print` and `pprint`"""
+        return self.to_str()
+
+    def __eq__(self, other):
+        """Returns true if both objects are equal"""
+        if not isinstance(other, KernelPushRequest):
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        """Returns true if both objects are not equal"""
+        return not self == other
+

--- a/src/kaggle/models/model_instance_new_version_request.py
+++ b/src/kaggle/models/model_instance_new_version_request.py
@@ -1,0 +1,145 @@
+#!/usr/bin/python
+#
+# Copyright 2024 Kaggle Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# coding: utf-8
+
+import pprint
+import re  # noqa: F401
+
+import six
+
+from kaggle.models.upload_file import UploadFile  # noqa: F401,E501
+
+
+class ModelInstanceNewVersionRequest(object):
+    """
+    Attributes:
+      project_types (dict): The key is attribute name
+                            and the value is attribute type.
+      attribute_map (dict): The key is attribute name
+                            and the value is json key in definition.
+    """
+    project_types = {
+        'version_notes': 'str',
+        'files': 'list[UploadFile]'
+    }
+
+    attribute_map = {
+        'version_notes': 'versionNotes',
+        'files': 'files'
+    }
+
+    def __init__(self, version_notes=None, files=None):  # noqa: E501
+
+        self._version_notes = None
+        self._files = None
+        self.discriminator = None
+
+        if version_notes is not None:
+            self.version_notes = version_notes
+        self.files = files
+
+    @property
+    def version_notes(self):
+        """Gets the version_notes of this ModelInstanceNewVersionRequest.  # noqa: E501
+
+        The version notes for the model instance version  # noqa: E501
+
+        :return: The version_notes of this ModelInstanceNewVersionRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._version_notes
+
+    @version_notes.setter
+    def version_notes(self, version_notes):
+        """Sets the version_notes of this ModelInstanceNewVersionRequest.
+
+        The version notes for the model instance version  # noqa: E501
+
+        :param version_notes: The version_notes of this ModelInstanceNewVersionRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._version_notes = version_notes
+
+    @property
+    def files(self):
+        """Gets the files of this ModelInstanceNewVersionRequest.  # noqa: E501
+
+        A list of files that should be associated with the model instance version  # noqa: E501
+
+        :return: The files of this ModelInstanceNewVersionRequest.  # noqa: E501
+        :rtype: list[UploadFile]
+        """
+        return self._files
+
+    @files.setter
+    def files(self, files):
+        """Sets the files of this ModelInstanceNewVersionRequest.
+
+        A list of files that should be associated with the model instance version  # noqa: E501
+
+        :param files: The files of this ModelInstanceNewVersionRequest.  # noqa: E501
+        :type: list[UploadFile]
+        """
+        if files is None:
+            raise ValueError("Invalid value for `files`, must not be `None`")  # noqa: E501
+
+        self._files = files
+
+    def to_dict(self):
+        """Returns the model properties as a dict"""
+        result = {}
+
+        for attr, _ in six.iteritems(self.project_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
+                    lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
+                    value
+                ))
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
+            elif isinstance(value, dict):
+                result[attr] = dict(map(
+                    lambda item: (item[0], item[1].to_dict())
+                    if hasattr(item[1], "to_dict") else item,
+                    value.items()
+                ))
+            else:
+                result[attr] = value
+
+        return result
+
+    def to_str(self):
+        """Returns the string representation of the model"""
+        return pprint.pformat(self.to_dict())
+
+    def __repr__(self):
+        """For `print` and `pprint`"""
+        return self.to_str()
+
+    def __eq__(self, other):
+        """Returns true if both objects are equal"""
+        if not isinstance(other, ModelInstanceNewVersionRequest):
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        """Returns true if both objects are not equal"""
+        return not self == other
+

--- a/src/kaggle/models/model_instance_update_request.py
+++ b/src/kaggle/models/model_instance_update_request.py
@@ -1,0 +1,351 @@
+#!/usr/bin/python
+#
+# Copyright 2024 Kaggle Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# coding: utf-8
+
+import pprint
+import re  # noqa: F401
+
+import six
+
+
+class ModelInstanceUpdateRequest(object):
+    """
+    Attributes:
+      project_types (dict): The key is attribute name
+                            and the value is attribute type.
+      attribute_map (dict): The key is attribute name
+                            and the value is json key in definition.
+    """
+    project_types = {
+        'overview': 'str',
+        'usage': 'str',
+        'license_name': 'str',
+        'fine_tunable': 'bool',
+        'training_data': 'list[str]',
+        'model_instance_type': 'str',
+        'base_model_instance': 'str',
+        'external_base_model_url': 'int',
+        'update_mask': 'str'
+    }
+
+    attribute_map = {
+        'overview': 'overview',
+        'usage': 'usage',
+        'license_name': 'licenseName',
+        'fine_tunable': 'fineTunable',
+        'training_data': 'trainingData',
+        'model_instance_type': 'modelInstanceType',
+        'base_model_instance': 'baseModelInstance',
+        'external_base_model_url': 'externalBaseModelUrl',
+        'update_mask': 'updateMask'
+    }
+
+    def __init__(self, overview=None, usage=None, license_name='Apache 2.0', fine_tunable=True, training_data=None, model_instance_type=None, base_model_instance=None, external_base_model_url=None, update_mask=None):  # noqa: E501
+
+        self._overview = None
+        self._usage = None
+        self._license_name = None
+        self._fine_tunable = None
+        self._training_data = None
+        self._model_instance_type = None
+        self._base_model_instance = None
+        self._external_base_model_url = None
+        self._update_mask = None
+        self.discriminator = None
+
+        if overview is not None:
+            self.overview = overview
+        if usage is not None:
+            self.usage = usage
+        if license_name is not None:
+            self.license_name = license_name
+        if fine_tunable is not None:
+            self.fine_tunable = fine_tunable
+        if training_data is not None:
+            self.training_data = training_data
+        if model_instance_type is not None:
+            self.model_instance_type = model_instance_type
+        if base_model_instance is not None:
+            self.base_model_instance = base_model_instance
+        if external_base_model_url is not None:
+            self.external_base_model_url = external_base_model_url
+        self.update_mask = update_mask
+
+    @property
+    def overview(self):
+        """Gets the overview of this ModelInstanceUpdateRequest.  # noqa: E501
+
+        The overview of the model instance (markdown)  # noqa: E501
+
+        :return: The overview of this ModelInstanceUpdateRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._overview
+
+    @overview.setter
+    def overview(self, overview):
+        """Sets the overview of this ModelInstanceUpdateRequest.
+
+        The overview of the model instance (markdown)  # noqa: E501
+
+        :param overview: The overview of this ModelInstanceUpdateRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._overview = overview
+
+    @property
+    def usage(self):
+        """Gets the usage of this ModelInstanceUpdateRequest.  # noqa: E501
+
+        The description of how to use the model instance (markdown)  # noqa: E501
+
+        :return: The usage of this ModelInstanceUpdateRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._usage
+
+    @usage.setter
+    def usage(self, usage):
+        """Sets the usage of this ModelInstanceUpdateRequest.
+
+        The description of how to use the model instance (markdown)  # noqa: E501
+
+        :param usage: The usage of this ModelInstanceUpdateRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._usage = usage
+
+    @property
+    def license_name(self):
+        """Gets the license_name of this ModelInstanceUpdateRequest.  # noqa: E501
+
+        The license that should be associated with the model instance  # noqa: E501
+
+        :return: The license_name of this ModelInstanceUpdateRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._license_name
+
+    @license_name.setter
+    def license_name(self, license_name):
+        """Sets the license_name of this ModelInstanceUpdateRequest.
+
+        The license that should be associated with the model instance  # noqa: E501
+
+        :param license_name: The license_name of this ModelInstanceUpdateRequest.  # noqa: E501
+        :type: str
+        """
+        allowed_values = ["CC0 1.0", "CC BY-NC-SA 4.0", "Unknown", "CC BY-SA 4.0", "GPL 2", "CC BY-SA 3.0", "Other", "Other (specified in description)", "CC BY 4.0", "Attribution 4.0 International (CC BY 4.0)", "CC BY-NC 4.0", "Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)", "PDDL", "ODC Public Domain Dedication and Licence (PDDL)", "CC BY 3.0", "Attribution 3.0 Unported (CC BY 3.0)", "CC BY 3.0 IGO", "Attribution 3.0 IGO (CC BY 3.0 IGO)", "CC BY-NC-SA 3.0 IGO", "Attribution-NonCommercial-ShareAlike 3.0 IGO (CC BY-NC-SA 3.0 IGO)", "CDLA Permissive 1.0", "Community Data License Agreement - Permissive - Version 1.0", "CDLA Sharing 1.0", "Community Data License Agreement - Sharing - Version 1.0", "CC BY-ND 4.0", "Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)", "CC BY-NC-ND 4.0", "Attribution-NonCommercial-NoDerivatives 4.0 International (CC BY-NC-ND 4.0)", "ODC-BY 1.0", "ODC Attribution License (ODC-By)", "LGPL 3.0", "GNU Lesser General Public License 3.0", "AGPL 3.0", "GNU Affero General Public License 3.0", "FDL 1.3", "GNU Free Documentation License 1.3", "apache-2.0", "Apache 2.0", "mit", "MIT", "bsd-3-clause", "BSD-3-Clause", "Llama 2", "Llama 2 Community License", "Gemma", "gpl-3", "GPL 3", "RAIL-M", "AI Pubs Open RAIL-M License", "AIPubs Research-Use RAIL-M", "AI Pubs Research-Use RAIL-M License", "BigScience OpenRAIL-M", "BigScience Open RAIL-M License", "RAIL", "RAIL (specified in description)", "Llama 3", "Llama 3 Community License"]  # noqa: E501
+        if license_name not in allowed_values:
+            raise ValueError(
+                "Invalid value for `license_name` ({0}), must be one of {1}"  # noqa: E501
+                .format(license_name, allowed_values)
+            )
+
+        self._license_name = license_name
+
+    @property
+    def fine_tunable(self):
+        """Gets the fine_tunable of this ModelInstanceUpdateRequest.  # noqa: E501
+
+        Whether the model instance is fine tunable  # noqa: E501
+
+        :return: The fine_tunable of this ModelInstanceUpdateRequest.  # noqa: E501
+        :rtype: bool
+        """
+        return self._fine_tunable
+
+    @fine_tunable.setter
+    def fine_tunable(self, fine_tunable):
+        """Sets the fine_tunable of this ModelInstanceUpdateRequest.
+
+        Whether the model instance is fine tunable  # noqa: E501
+
+        :param fine_tunable: The fine_tunable of this ModelInstanceUpdateRequest.  # noqa: E501
+        :type: bool
+        """
+
+        self._fine_tunable = fine_tunable
+
+    @property
+    def training_data(self):
+        """Gets the training_data of this ModelInstanceUpdateRequest.  # noqa: E501
+
+        A list of training data (urls or names)  # noqa: E501
+
+        :return: The training_data of this ModelInstanceUpdateRequest.  # noqa: E501
+        :rtype: list[str]
+        """
+        return self._training_data
+
+    @training_data.setter
+    def training_data(self, training_data):
+        """Sets the training_data of this ModelInstanceUpdateRequest.
+
+        A list of training data (urls or names)  # noqa: E501
+
+        :param training_data: The training_data of this ModelInstanceUpdateRequest.  # noqa: E501
+        :type: list[str]
+        """
+
+        self._training_data = training_data
+
+    @property
+    def model_instance_type(self):
+        """Gets the model_instance_type of this ModelInstanceUpdateRequest.  # noqa: E501
+
+        Whether the model instance is a base model, external variant, internal variant, or unspecified  # noqa: E501
+
+        :return: The model_instance_type of this ModelInstanceUpdateRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._model_instance_type
+
+    @model_instance_type.setter
+    def model_instance_type(self, model_instance_type):
+        """Sets the model_instance_type of this ModelInstanceUpdateRequest.
+
+        Whether the model instance is a base model, external variant, internal variant, or unspecified  # noqa: E501
+
+        :param model_instance_type: The model_instance_type of this ModelInstanceUpdateRequest.  # noqa: E501
+        :type: str
+        """
+        allowed_values = ["Unspecified", "BaseModel", "KaggleVariant", "ExternalVariant"]  # noqa: E501
+        if model_instance_type not in allowed_values:
+            raise ValueError(
+                "Invalid value for `model_instance_type` ({0}), must be one of {1}"  # noqa: E501
+                .format(model_instance_type, allowed_values)
+            )
+
+        self._model_instance_type = model_instance_type
+
+    @property
+    def base_model_instance(self):
+        """Gets the base_model_instance of this ModelInstanceUpdateRequest.  # noqa: E501
+
+        If this is an internal variant, the `{owner-slug}/{model-slug}/{framework}/{instance-slug}` of the base model instance  # noqa: E501
+
+        :return: The base_model_instance of this ModelInstanceUpdateRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._base_model_instance
+
+    @base_model_instance.setter
+    def base_model_instance(self, base_model_instance):
+        """Sets the base_model_instance of this ModelInstanceUpdateRequest.
+
+        If this is an internal variant, the `{owner-slug}/{model-slug}/{framework}/{instance-slug}` of the base model instance  # noqa: E501
+
+        :param base_model_instance: The base_model_instance of this ModelInstanceUpdateRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._base_model_instance = base_model_instance
+
+    @property
+    def external_base_model_url(self):
+        """Gets the external_base_model_url of this ModelInstanceUpdateRequest.  # noqa: E501
+
+        If this is an external variant, a URL to the base model  # noqa: E501
+
+        :return: The external_base_model_url of this ModelInstanceUpdateRequest.  # noqa: E501
+        :rtype: int
+        """
+        return self._external_base_model_url
+
+    @external_base_model_url.setter
+    def external_base_model_url(self, external_base_model_url):
+        """Sets the external_base_model_url of this ModelInstanceUpdateRequest.
+
+        If this is an external variant, a URL to the base model  # noqa: E501
+
+        :param external_base_model_url: The external_base_model_url of this ModelInstanceUpdateRequest.  # noqa: E501
+        :type: int
+        """
+
+        self._external_base_model_url = external_base_model_url
+
+    @property
+    def update_mask(self):
+        """Gets the update_mask of this ModelInstanceUpdateRequest.  # noqa: E501
+
+        Describes which fields to update  # noqa: E501
+
+        :return: The update_mask of this ModelInstanceUpdateRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._update_mask
+
+    @update_mask.setter
+    def update_mask(self, update_mask):
+        """Sets the update_mask of this ModelInstanceUpdateRequest.
+
+        Describes which fields to update  # noqa: E501
+
+        :param update_mask: The update_mask of this ModelInstanceUpdateRequest.  # noqa: E501
+        :type: str
+        """
+        if update_mask is None:
+            raise ValueError("Invalid value for `update_mask`, must not be `None`")  # noqa: E501
+
+        self._update_mask = update_mask
+
+    def to_dict(self):
+        """Returns the model properties as a dict"""
+        result = {}
+
+        for attr, _ in six.iteritems(self.project_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
+                    lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
+                    value
+                ))
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
+            elif isinstance(value, dict):
+                result[attr] = dict(map(
+                    lambda item: (item[0], item[1].to_dict())
+                    if hasattr(item[1], "to_dict") else item,
+                    value.items()
+                ))
+            else:
+                result[attr] = value
+
+        return result
+
+    def to_str(self):
+        """Returns the string representation of the model"""
+        return pprint.pformat(self.to_dict())
+
+    def __repr__(self):
+        """For `print` and `pprint`"""
+        return self.to_str()
+
+    def __eq__(self, other):
+        """Returns true if both objects are equal"""
+        if not isinstance(other, ModelInstanceUpdateRequest):
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        """Returns true if both objects are not equal"""
+        return not self == other
+

--- a/src/kaggle/models/model_new_instance_request.py
+++ b/src/kaggle/models/model_new_instance_request.py
@@ -1,0 +1,417 @@
+#!/usr/bin/python
+#
+# Copyright 2024 Kaggle Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# coding: utf-8
+
+import pprint
+import re  # noqa: F401
+
+import six
+
+from kaggle.models.upload_file import UploadFile  # noqa: F401,E501
+
+
+class ModelNewInstanceRequest(object):
+    """
+    Attributes:
+      project_types (dict): The key is attribute name
+                            and the value is attribute type.
+      attribute_map (dict): The key is attribute name
+                            and the value is json key in definition.
+    """
+    project_types = {
+        'instance_slug': 'str',
+        'framework': 'str',
+        'overview': 'str',
+        'usage': 'str',
+        'license_name': 'str',
+        'fine_tunable': 'bool',
+        'training_data': 'list[str]',
+        'model_instance_type': 'str',
+        'base_model_instance': 'str',
+        'external_base_model_url': 'int',
+        'files': 'list[UploadFile]'
+    }
+
+    attribute_map = {
+        'instance_slug': 'instanceSlug',
+        'framework': 'framework',
+        'overview': 'overview',
+        'usage': 'usage',
+        'license_name': 'licenseName',
+        'fine_tunable': 'fineTunable',
+        'training_data': 'trainingData',
+        'model_instance_type': 'modelInstanceType',
+        'base_model_instance': 'baseModelInstance',
+        'external_base_model_url': 'externalBaseModelUrl',
+        'files': 'files'
+    }
+
+    def __init__(self, instance_slug=None, framework=None, overview=None, usage=None, license_name='Apache 2.0', fine_tunable=True, training_data=None, model_instance_type=None, base_model_instance=None, external_base_model_url=None, files=None):  # noqa: E501
+
+        self._instance_slug = None
+        self._framework = None
+        self._overview = None
+        self._usage = None
+        self._license_name = None
+        self._fine_tunable = None
+        self._training_data = None
+        self._model_instance_type = None
+        self._base_model_instance = None
+        self._external_base_model_url = None
+        self._files = None
+        self.discriminator = None
+
+        self.instance_slug = instance_slug
+        self.framework = framework
+        if overview is not None:
+            self.overview = overview
+        if usage is not None:
+            self.usage = usage
+        self.license_name = license_name
+        if fine_tunable is not None:
+            self.fine_tunable = fine_tunable
+        if training_data is not None:
+            self.training_data = training_data
+        if model_instance_type is not None:
+            self.model_instance_type = model_instance_type
+        if base_model_instance is not None:
+            self.base_model_instance = base_model_instance
+        if external_base_model_url is not None:
+            self.external_base_model_url = external_base_model_url
+        if files is not None:
+            self.files = files
+
+    @property
+    def instance_slug(self):
+        """Gets the instance_slug of this ModelNewInstanceRequest.  # noqa: E501
+
+        The slug that the model instance should be created with  # noqa: E501
+
+        :return: The instance_slug of this ModelNewInstanceRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._instance_slug
+
+    @instance_slug.setter
+    def instance_slug(self, instance_slug):
+        """Sets the instance_slug of this ModelNewInstanceRequest.
+
+        The slug that the model instance should be created with  # noqa: E501
+
+        :param instance_slug: The instance_slug of this ModelNewInstanceRequest.  # noqa: E501
+        :type: str
+        """
+        if instance_slug is None:
+            raise ValueError("Invalid value for `instance_slug`, must not be `None`")  # noqa: E501
+
+        self._instance_slug = instance_slug
+
+    @property
+    def framework(self):
+        """Gets the framework of this ModelNewInstanceRequest.  # noqa: E501
+
+        The framework of the model instance  # noqa: E501
+
+        :return: The framework of this ModelNewInstanceRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._framework
+
+    @framework.setter
+    def framework(self, framework):
+        """Sets the framework of this ModelNewInstanceRequest.
+
+        The framework of the model instance  # noqa: E501
+
+        :param framework: The framework of this ModelNewInstanceRequest.  # noqa: E501
+        :type: str
+        """
+        if framework is None:
+            raise ValueError("Invalid value for `framework`, must not be `None`")  # noqa: E501
+        allowed_values = ["tensorFlow1", "tensorFlow2", "tfLite", "tfJs", "pyTorch", "jax", "flax", "pax", "maxText", "gemmaCpp", "tensorRtLlm", "ggml", "gguf", "coral", "scikitLearn", "mxnet", "onnx", "keras", "transformers", "triton", "api", "triton", "tensorRtLlm","other"]  # noqa: E501
+        if framework not in allowed_values:
+            raise ValueError(
+                "Invalid value for `framework` ({0}), must be one of {1}"  # noqa: E501
+                .format(framework, allowed_values)
+            )
+
+        self._framework = framework
+
+    @property
+    def overview(self):
+        """Gets the overview of this ModelNewInstanceRequest.  # noqa: E501
+
+        The overview of the model instance (markdown)  # noqa: E501
+
+        :return: The overview of this ModelNewInstanceRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._overview
+
+    @overview.setter
+    def overview(self, overview):
+        """Sets the overview of this ModelNewInstanceRequest.
+
+        The overview of the model instance (markdown)  # noqa: E501
+
+        :param overview: The overview of this ModelNewInstanceRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._overview = overview
+
+    @property
+    def usage(self):
+        """Gets the usage of this ModelNewInstanceRequest.  # noqa: E501
+
+        The description of how to use the model instance (markdown)  # noqa: E501
+
+        :return: The usage of this ModelNewInstanceRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._usage
+
+    @usage.setter
+    def usage(self, usage):
+        """Sets the usage of this ModelNewInstanceRequest.
+
+        The description of how to use the model instance (markdown)  # noqa: E501
+
+        :param usage: The usage of this ModelNewInstanceRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._usage = usage
+
+    @property
+    def license_name(self):
+        """Gets the license_name of this ModelNewInstanceRequest.  # noqa: E501
+
+        The license that should be associated with the model instance  # noqa: E501
+
+        :return: The license_name of this ModelNewInstanceRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._license_name
+
+    @license_name.setter
+    def license_name(self, license_name):
+        """Sets the license_name of this ModelNewInstanceRequest.
+
+        The license that should be associated with the model instance  # noqa: E501
+
+        :param license_name: The license_name of this ModelNewInstanceRequest.  # noqa: E501
+        :type: str
+        """
+        if license_name is None:
+            raise ValueError("Invalid value for `license_name`, must not be `None`")  # noqa: E501
+        allowed_values = ["CC0 1.0", "CC BY-NC-SA 4.0", "Unknown", "CC BY-SA 4.0", "GPL 2", "CC BY-SA 3.0", "Other", "Other (specified in description)", "CC BY 4.0", "Attribution 4.0 International (CC BY 4.0)", "CC BY-NC 4.0", "Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)", "PDDL", "ODC Public Domain Dedication and Licence (PDDL)", "CC BY 3.0", "Attribution 3.0 Unported (CC BY 3.0)", "CC BY 3.0 IGO", "Attribution 3.0 IGO (CC BY 3.0 IGO)", "CC BY-NC-SA 3.0 IGO", "Attribution-NonCommercial-ShareAlike 3.0 IGO (CC BY-NC-SA 3.0 IGO)", "CDLA Permissive 1.0", "Community Data License Agreement - Permissive - Version 1.0", "CDLA Sharing 1.0", "Community Data License Agreement - Sharing - Version 1.0", "CC BY-ND 4.0", "Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)", "CC BY-NC-ND 4.0", "Attribution-NonCommercial-NoDerivatives 4.0 International (CC BY-NC-ND 4.0)", "ODC-BY 1.0", "ODC Attribution License (ODC-By)", "LGPL 3.0", "GNU Lesser General Public License 3.0", "AGPL 3.0", "GNU Affero General Public License 3.0", "FDL 1.3", "GNU Free Documentation License 1.3", "apache-2.0", "Apache 2.0", "mit", "MIT", "bsd-3-clause", "BSD-3-Clause", "Llama 2", "Llama 2 Community License", "Gemma", "gpl-3", "GPL 3", "RAIL-M", "AI Pubs Open RAIL-M License", "AIPubs Research-Use RAIL-M", "AI Pubs Research-Use RAIL-M License", "BigScience OpenRAIL-M", "BigScience Open RAIL-M License", "RAIL", "RAIL (specified in description)", "Llama 3", "Llama 3 Community License"]  # noqa: E501
+        if license_name not in allowed_values:
+            raise ValueError(
+                "Invalid value for `license_name` ({0}), must be one of {1}"  # noqa: E501
+                .format(license_name, allowed_values)
+            )
+
+        self._license_name = license_name
+
+    @property
+    def fine_tunable(self):
+        """Gets the fine_tunable of this ModelNewInstanceRequest.  # noqa: E501
+
+        Whether the model instance is fine tunable  # noqa: E501
+
+        :return: The fine_tunable of this ModelNewInstanceRequest.  # noqa: E501
+        :rtype: bool
+        """
+        return self._fine_tunable
+
+    @fine_tunable.setter
+    def fine_tunable(self, fine_tunable):
+        """Sets the fine_tunable of this ModelNewInstanceRequest.
+
+        Whether the model instance is fine tunable  # noqa: E501
+
+        :param fine_tunable: The fine_tunable of this ModelNewInstanceRequest.  # noqa: E501
+        :type: bool
+        """
+
+        self._fine_tunable = fine_tunable
+
+    @property
+    def training_data(self):
+        """Gets the training_data of this ModelNewInstanceRequest.  # noqa: E501
+
+        A list of training data (urls or names)  # noqa: E501
+
+        :return: The training_data of this ModelNewInstanceRequest.  # noqa: E501
+        :rtype: list[str]
+        """
+        return self._training_data
+
+    @training_data.setter
+    def training_data(self, training_data):
+        """Sets the training_data of this ModelNewInstanceRequest.
+
+        A list of training data (urls or names)  # noqa: E501
+
+        :param training_data: The training_data of this ModelNewInstanceRequest.  # noqa: E501
+        :type: list[str]
+        """
+
+        self._training_data = training_data
+
+    @property
+    def model_instance_type(self):
+        """Gets the model_instance_type of this ModelNewInstanceRequest.  # noqa: E501
+
+        Whether the model instance is a base model, external variant, internal variant, or unspecified  # noqa: E501
+
+        :return: The model_instance_type of this ModelNewInstanceRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._model_instance_type
+
+    @model_instance_type.setter
+    def model_instance_type(self, model_instance_type):
+        """Sets the model_instance_type of this ModelNewInstanceRequest.
+
+        Whether the model instance is a base model, external variant, internal variant, or unspecified  # noqa: E501
+
+        :param model_instance_type: The model_instance_type of this ModelNewInstanceRequest.  # noqa: E501
+        :type: str
+        """
+        allowed_values = ["Unspecified", "BaseModel", "KaggleVariant", "ExternalVariant"]  # noqa: E501
+        if model_instance_type not in allowed_values:
+            raise ValueError(
+                "Invalid value for `model_instance_type` ({0}), must be one of {1}"  # noqa: E501
+                .format(model_instance_type, allowed_values)
+            )
+
+        self._model_instance_type = model_instance_type
+
+    @property
+    def base_model_instance(self):
+        """Gets the base_model_instance of this ModelNewInstanceRequest.  # noqa: E501
+
+        If this is an internal variant, the `{owner-slug}/{model-slug}/{framework}/{instance-slug}` of the base model instance  # noqa: E501
+
+        :return: The base_model_instance of this ModelNewInstanceRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._base_model_instance
+
+    @base_model_instance.setter
+    def base_model_instance(self, base_model_instance):
+        """Sets the base_model_instance of this ModelNewInstanceRequest.
+
+        If this is an internal variant, the `{owner-slug}/{model-slug}/{framework}/{instance-slug}` of the base model instance  # noqa: E501
+
+        :param base_model_instance: The base_model_instance of this ModelNewInstanceRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._base_model_instance = base_model_instance
+
+    @property
+    def external_base_model_url(self):
+        """Gets the external_base_model_url of this ModelNewInstanceRequest.  # noqa: E501
+
+        If this is an external variant, a URL to the base model  # noqa: E501
+
+        :return: The external_base_model_url of this ModelNewInstanceRequest.  # noqa: E501
+        :rtype: int
+        """
+        return self._external_base_model_url
+
+    @external_base_model_url.setter
+    def external_base_model_url(self, external_base_model_url):
+        """Sets the external_base_model_url of this ModelNewInstanceRequest.
+
+        If this is an external variant, a URL to the base model  # noqa: E501
+
+        :param external_base_model_url: The external_base_model_url of this ModelNewInstanceRequest.  # noqa: E501
+        :type: int
+        """
+
+        self._external_base_model_url = external_base_model_url
+
+    @property
+    def files(self):
+        """Gets the files of this ModelNewInstanceRequest.  # noqa: E501
+
+        A list of files that should be associated with the model instance version  # noqa: E501
+
+        :return: The files of this ModelNewInstanceRequest.  # noqa: E501
+        :rtype: list[UploadFile]
+        """
+        return self._files
+
+    @files.setter
+    def files(self, files):
+        """Sets the files of this ModelNewInstanceRequest.
+
+        A list of files that should be associated with the model instance version  # noqa: E501
+
+        :param files: The files of this ModelNewInstanceRequest.  # noqa: E501
+        :type: list[UploadFile]
+        """
+
+        self._files = files
+
+    def to_dict(self):
+        """Returns the model properties as a dict"""
+        result = {}
+
+        for attr, _ in six.iteritems(self.project_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
+                    lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
+                    value
+                ))
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
+            elif isinstance(value, dict):
+                result[attr] = dict(map(
+                    lambda item: (item[0], item[1].to_dict())
+                    if hasattr(item[1], "to_dict") else item,
+                    value.items()
+                ))
+            else:
+                result[attr] = value
+
+        return result
+
+    def to_str(self):
+        """Returns the string representation of the model"""
+        return pprint.pformat(self.to_dict())
+
+    def __repr__(self):
+        """For `print` and `pprint`"""
+        return self.to_str()
+
+    def __eq__(self, other):
+        """Returns true if both objects are equal"""
+        if not isinstance(other, ModelNewInstanceRequest):
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        """Returns true if both objects are not equal"""
+        return not self == other
+

--- a/src/kaggle/models/model_new_request.py
+++ b/src/kaggle/models/model_new_request.py
@@ -1,0 +1,314 @@
+#!/usr/bin/python
+#
+# Copyright 2024 Kaggle Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# coding: utf-8
+
+import pprint
+import re  # noqa: F401
+
+import six
+
+
+class ModelNewRequest(object):
+    """
+    Attributes:
+      project_types (dict): The key is attribute name
+                            and the value is attribute type.
+      attribute_map (dict): The key is attribute name
+                            and the value is json key in definition.
+    """
+    project_types = {
+        'owner_slug': 'str',
+        'slug': 'str',
+        'title': 'str',
+        'subtitle': 'str',
+        'is_private': 'bool',
+        'description': 'str',
+        'publish_time': 'date',
+        'provenance_sources': 'str'
+    }
+
+    attribute_map = {
+        'owner_slug': 'ownerSlug',
+        'slug': 'slug',
+        'title': 'title',
+        'subtitle': 'subtitle',
+        'is_private': 'isPrivate',
+        'description': 'description',
+        'publish_time': 'publishTime',
+        'provenance_sources': 'provenanceSources'
+    }
+
+    def __init__(self, owner_slug=None, slug=None, title=None, subtitle=None, is_private=True, description='', publish_time=None, provenance_sources=''):  # noqa: E501
+
+        self._owner_slug = None
+        self._slug = None
+        self._title = None
+        self._subtitle = None
+        self._is_private = None
+        self._description = None
+        self._publish_time = None
+        self._provenance_sources = None
+        self.discriminator = None
+
+        self.owner_slug = owner_slug
+        self.slug = slug
+        self.title = title
+        if subtitle is not None:
+            self.subtitle = subtitle
+        self.is_private = is_private
+        if description is not None:
+            self.description = description
+        if publish_time is not None:
+            self.publish_time = publish_time
+        if provenance_sources is not None:
+            self.provenance_sources = provenance_sources
+
+    @property
+    def owner_slug(self):
+        """Gets the owner_slug of this ModelNewRequest.  # noqa: E501
+
+        The owner's slug  # noqa: E501
+
+        :return: The owner_slug of this ModelNewRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._owner_slug
+
+    @owner_slug.setter
+    def owner_slug(self, owner_slug):
+        """Sets the owner_slug of this ModelNewRequest.
+
+        The owner's slug  # noqa: E501
+
+        :param owner_slug: The owner_slug of this ModelNewRequest.  # noqa: E501
+        :type: str
+        """
+        if owner_slug is None:
+            raise ValueError("Invalid value for `owner_slug`, must not be `None`")  # noqa: E501
+
+        self._owner_slug = owner_slug
+
+    @property
+    def slug(self):
+        """Gets the slug of this ModelNewRequest.  # noqa: E501
+
+        The slug that the model should be created with  # noqa: E501
+
+        :return: The slug of this ModelNewRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._slug
+
+    @slug.setter
+    def slug(self, slug):
+        """Sets the slug of this ModelNewRequest.
+
+        The slug that the model should be created with  # noqa: E501
+
+        :param slug: The slug of this ModelNewRequest.  # noqa: E501
+        :type: str
+        """
+        if slug is None:
+            raise ValueError("Invalid value for `slug`, must not be `None`")  # noqa: E501
+
+        self._slug = slug
+
+    @property
+    def title(self):
+        """Gets the title of this ModelNewRequest.  # noqa: E501
+
+        The title of the new model  # noqa: E501
+
+        :return: The title of this ModelNewRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._title
+
+    @title.setter
+    def title(self, title):
+        """Sets the title of this ModelNewRequest.
+
+        The title of the new model  # noqa: E501
+
+        :param title: The title of this ModelNewRequest.  # noqa: E501
+        :type: str
+        """
+        if title is None:
+            raise ValueError("Invalid value for `title`, must not be `None`")  # noqa: E501
+
+        self._title = title
+
+    @property
+    def subtitle(self):
+        """Gets the subtitle of this ModelNewRequest.  # noqa: E501
+
+        The subtitle of the new model  # noqa: E501
+
+        :return: The subtitle of this ModelNewRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._subtitle
+
+    @subtitle.setter
+    def subtitle(self, subtitle):
+        """Sets the subtitle of this ModelNewRequest.
+
+        The subtitle of the new model  # noqa: E501
+
+        :param subtitle: The subtitle of this ModelNewRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._subtitle = subtitle
+
+    @property
+    def is_private(self):
+        """Gets the is_private of this ModelNewRequest.  # noqa: E501
+
+        Whether or not the model should be private  # noqa: E501
+
+        :return: The is_private of this ModelNewRequest.  # noqa: E501
+        :rtype: bool
+        """
+        return self._is_private
+
+    @is_private.setter
+    def is_private(self, is_private):
+        """Sets the is_private of this ModelNewRequest.
+
+        Whether or not the model should be private  # noqa: E501
+
+        :param is_private: The is_private of this ModelNewRequest.  # noqa: E501
+        :type: bool
+        """
+        if is_private is None:
+            raise ValueError("Invalid value for `is_private`, must not be `None`")  # noqa: E501
+
+        self._is_private = is_private
+
+    @property
+    def description(self):
+        """Gets the description of this ModelNewRequest.  # noqa: E501
+
+        The description to be set on the model  # noqa: E501
+
+        :return: The description of this ModelNewRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """Sets the description of this ModelNewRequest.
+
+        The description to be set on the model  # noqa: E501
+
+        :param description: The description of this ModelNewRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._description = description
+
+    @property
+    def publish_time(self):
+        """Gets the publish_time of this ModelNewRequest.  # noqa: E501
+
+        When the model was initially published  # noqa: E501
+
+        :return: The publish_time of this ModelNewRequest.  # noqa: E501
+        :rtype: date
+        """
+        return self._publish_time
+
+    @publish_time.setter
+    def publish_time(self, publish_time):
+        """Sets the publish_time of this ModelNewRequest.
+
+        When the model was initially published  # noqa: E501
+
+        :param publish_time: The publish_time of this ModelNewRequest.  # noqa: E501
+        :type: date
+        """
+
+        self._publish_time = publish_time
+
+    @property
+    def provenance_sources(self):
+        """Gets the provenance_sources of this ModelNewRequest.  # noqa: E501
+
+        The provenance sources to be set on the model  # noqa: E501
+
+        :return: The provenance_sources of this ModelNewRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._provenance_sources
+
+    @provenance_sources.setter
+    def provenance_sources(self, provenance_sources):
+        """Sets the provenance_sources of this ModelNewRequest.
+
+        The provenance sources to be set on the model  # noqa: E501
+
+        :param provenance_sources: The provenance_sources of this ModelNewRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._provenance_sources = provenance_sources
+
+    def to_dict(self):
+        """Returns the model properties as a dict"""
+        result = {}
+
+        for attr, _ in six.iteritems(self.project_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
+                    lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
+                    value
+                ))
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
+            elif isinstance(value, dict):
+                result[attr] = dict(map(
+                    lambda item: (item[0], item[1].to_dict())
+                    if hasattr(item[1], "to_dict") else item,
+                    value.items()
+                ))
+            else:
+                result[attr] = value
+
+        return result
+
+    def to_str(self):
+        """Returns the string representation of the model"""
+        return pprint.pformat(self.to_dict())
+
+    def __repr__(self):
+        """For `print` and `pprint`"""
+        return self.to_str()
+
+    def __eq__(self, other):
+        """Returns true if both objects are equal"""
+        if not isinstance(other, ModelNewRequest):
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        """Returns true if both objects are not equal"""
+        return not self == other
+

--- a/src/kaggle/models/model_update_request.py
+++ b/src/kaggle/models/model_update_request.py
@@ -1,0 +1,282 @@
+#!/usr/bin/python
+#
+# Copyright 2024 Kaggle Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# coding: utf-8
+
+import pprint
+import re  # noqa: F401
+
+import six
+
+
+class ModelUpdateRequest(object):
+    """
+    Attributes:
+      project_types (dict): The key is attribute name
+                            and the value is attribute type.
+      attribute_map (dict): The key is attribute name
+                            and the value is json key in definition.
+    """
+    project_types = {
+        'title': 'str',
+        'subtitle': 'str',
+        'is_private': 'bool',
+        'description': 'str',
+        'publish_time': 'date',
+        'provenance_sources': 'str',
+        'update_mask': 'str'
+    }
+
+    attribute_map = {
+        'title': 'title',
+        'subtitle': 'subtitle',
+        'is_private': 'isPrivate',
+        'description': 'description',
+        'publish_time': 'publishTime',
+        'provenance_sources': 'provenanceSources',
+        'update_mask': 'updateMask'
+    }
+
+    def __init__(self, title=None, subtitle=None, is_private=True, description='', publish_time=None, provenance_sources='', update_mask=None):  # noqa: E501
+
+        self._title = None
+        self._subtitle = None
+        self._is_private = None
+        self._description = None
+        self._publish_time = None
+        self._provenance_sources = None
+        self._update_mask = None
+        self.discriminator = None
+
+        if title is not None:
+            self.title = title
+        if subtitle is not None:
+            self.subtitle = subtitle
+        if is_private is not None:
+            self.is_private = is_private
+        if description is not None:
+            self.description = description
+        if publish_time is not None:
+            self.publish_time = publish_time
+        if provenance_sources is not None:
+            self.provenance_sources = provenance_sources
+        if update_mask is not None:
+            self.update_mask = update_mask
+
+    @property
+    def title(self):
+        """Gets the title of this ModelUpdateRequest.  # noqa: E501
+
+        The title of the new model  # noqa: E501
+
+        :return: The title of this ModelUpdateRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._title
+
+    @title.setter
+    def title(self, title):
+        """Sets the title of this ModelUpdateRequest.
+
+        The title of the new model  # noqa: E501
+
+        :param title: The title of this ModelUpdateRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._title = title
+
+    @property
+    def subtitle(self):
+        """Gets the subtitle of this ModelUpdateRequest.  # noqa: E501
+
+        The subtitle of the new model  # noqa: E501
+
+        :return: The subtitle of this ModelUpdateRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._subtitle
+
+    @subtitle.setter
+    def subtitle(self, subtitle):
+        """Sets the subtitle of this ModelUpdateRequest.
+
+        The subtitle of the new model  # noqa: E501
+
+        :param subtitle: The subtitle of this ModelUpdateRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._subtitle = subtitle
+
+    @property
+    def is_private(self):
+        """Gets the is_private of this ModelUpdateRequest.  # noqa: E501
+
+        Whether or not the model should be private  # noqa: E501
+
+        :return: The is_private of this ModelUpdateRequest.  # noqa: E501
+        :rtype: bool
+        """
+        return self._is_private
+
+    @is_private.setter
+    def is_private(self, is_private):
+        """Sets the is_private of this ModelUpdateRequest.
+
+        Whether or not the model should be private  # noqa: E501
+
+        :param is_private: The is_private of this ModelUpdateRequest.  # noqa: E501
+        :type: bool
+        """
+
+        self._is_private = is_private
+
+    @property
+    def description(self):
+        """Gets the description of this ModelUpdateRequest.  # noqa: E501
+
+        The description to be set on the model  # noqa: E501
+
+        :return: The description of this ModelUpdateRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """Sets the description of this ModelUpdateRequest.
+
+        The description to be set on the model  # noqa: E501
+
+        :param description: The description of this ModelUpdateRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._description = description
+
+    @property
+    def publish_time(self):
+        """Gets the publish_time of this ModelUpdateRequest.  # noqa: E501
+
+        When the model was initially published  # noqa: E501
+
+        :return: The publish_time of this ModelUpdateRequest.  # noqa: E501
+        :rtype: date
+        """
+        return self._publish_time
+
+    @publish_time.setter
+    def publish_time(self, publish_time):
+        """Sets the publish_time of this ModelUpdateRequest.
+
+        When the model was initially published  # noqa: E501
+
+        :param publish_time: The publish_time of this ModelUpdateRequest.  # noqa: E501
+        :type: date
+        """
+
+        self._publish_time = publish_time
+
+    @property
+    def provenance_sources(self):
+        """Gets the provenance_sources of this ModelUpdateRequest.  # noqa: E501
+
+        The provenance sources to be set on the model  # noqa: E501
+
+        :return: The provenance_sources of this ModelUpdateRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._provenance_sources
+
+    @provenance_sources.setter
+    def provenance_sources(self, provenance_sources):
+        """Sets the provenance_sources of this ModelUpdateRequest.
+
+        The provenance sources to be set on the model  # noqa: E501
+
+        :param provenance_sources: The provenance_sources of this ModelUpdateRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._provenance_sources = provenance_sources
+
+    @property
+    def update_mask(self):
+        """Gets the update_mask of this ModelUpdateRequest.  # noqa: E501
+
+        Describes which fields to update  # noqa: E501
+
+        :return: The update_mask of this ModelUpdateRequest.  # noqa: E501
+        :rtype: str
+        """
+        return self._update_mask
+
+    @update_mask.setter
+    def update_mask(self, update_mask):
+        """Sets the update_mask of this ModelUpdateRequest.
+
+        Describes which fields to update  # noqa: E501
+
+        :param update_mask: The update_mask of this ModelUpdateRequest.  # noqa: E501
+        :type: str
+        """
+
+        self._update_mask = update_mask
+
+    def to_dict(self):
+        """Returns the model properties as a dict"""
+        result = {}
+
+        for attr, _ in six.iteritems(self.project_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
+                    lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
+                    value
+                ))
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
+            elif isinstance(value, dict):
+                result[attr] = dict(map(
+                    lambda item: (item[0], item[1].to_dict())
+                    if hasattr(item[1], "to_dict") else item,
+                    value.items()
+                ))
+            else:
+                result[attr] = value
+
+        return result
+
+    def to_str(self):
+        """Returns the string representation of the model"""
+        return pprint.pformat(self.to_dict())
+
+    def __repr__(self):
+        """For `print` and `pprint`"""
+        return self.to_str()
+
+    def __eq__(self, other):
+        """Returns true if both objects are equal"""
+        if not isinstance(other, ModelUpdateRequest):
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        """Returns true if both objects are not equal"""
+        return not self == other
+


### PR DESCRIPTION
These objects are used by `kaggle_api.py` but not the CLI. They will be removed in the GA release (unless we decide to continue supporting `kaggle_api.py`). I just copied them from an old version of the repo.