### PR TITLE
Fix escaped-quote issue in HTTP requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog
 ====
+### 1.7.3b1
+
+* Fix escaped-quote issue in HTTP requests.
+
 ### 1.7.3b0
 
 * Remove Swagger. No user-visible changes to the command-line tool. However, projects that

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -2369,7 +2369,7 @@ class KaggleApi:
     meta_file = self.kernels_initialize(folder)
     print('Kernel metadata template written to: ' + meta_file)
 
-  def kernels_push(self, folder, timeout):
+  def kernels_push(self, folder, timeout=None):
     """ Read the metadata file and kernel files from a notebook, validate
             both, and use the Kernel API to push to Kaggle if all is valid.
             Parameters
@@ -2465,7 +2465,7 @@ class KaggleApi:
           # but the server expects just one
           if 'source' in cell and isinstance(cell['source'], list):
             cell['source'] = ''.join(cell['source'])
-      script_body = json.dumps(json_body).replace("'", "\\'")
+      script_body = json.dumps(json_body)
 
     with self.build_kaggle_client() as kaggle:
       request = ApiSaveKernelRequest()


### PR DESCRIPTION
Fix escaped-quote issue in HTTP requests, and prepare for new beta release.

Note: I incremented the release number in a previous PR.