### PR TITLE
Fix Example Code of competitions_list in KaggleApi.md

### DIFF
--- a/docs/KaggleApi.md
+++ b/docs/KaggleApi.md
@@ -319,6 +319,7 @@ List competitions
 from __future__ import print_function
 from pprint import pprint
 from kaggle.api import KaggleApi
+from kaggle.rest import ApiException
 
 # Create an instance of the Kaggle API class
 api = KaggleApi()

--- a/docs/KaggleApi.md
+++ b/docs/KaggleApi.md
@@ -317,27 +317,24 @@ List competitions
 ### Example
 ```python
 from __future__ import print_function
-import time
-import kaggle
-from kaggle.rest import ApiException
 from pprint import pprint
+from kaggle.api import KaggleApi
 
-# Configure HTTP basic authorization: basicAuth
-configuration = kaggle.Configuration()
-configuration.username = 'YOUR_USERNAME'
-configuration.password = 'YOUR_PASSWORD'
+# Create an instance of the Kaggle API class
+api = KaggleApi()
 
-# create an instance of the API class
-api_instance = kaggle.KaggleApi(kaggle.ApiClient(configuration))
+# Authenticate using the Kaggle API credentials (requires kaggle.json in the correct location)
+api.authenticate() 
+
 group = 'general' # str | Filter competitions by a particular group (optional) (default to general)
-category = 'all' # str | Filter competitions by a particular category (optional) (default to all)
+category = 'gettingStarted' # str | Filter competitions by a particular category (optional) (default to all)
 sort_by = 'latestDeadline' # str | Sort the results (optional) (default to latestDeadline)
 page = 1 # int | Page number (optional) (default to 1)
 search = '' # str | Search terms (optional) (default to )
 
 try:
     # List competitions
-    api_response = api_instance.competitions_list(group=group, category=category, sort_by=sort_by, page=page, search=search)
+    api_response = api.competitions_list(group=group, category=category, sort_by=sort_by, page=page, search=search)
     pprint(api_response)
 except ApiException as e:
     print("Exception when calling KaggleApi->competitions_list: %s\n" % e)


### PR DESCRIPTION
### Issue
When running the example code for `competitions_list` in `docs/KaggleApi.md` under Python 3.11, I encountered two errors:

1. **Authentication Issue**:
After investigation, the example uses outdated username/password authentication. The correct method should use Kaggle API credentials via `kaggle.json`.

2. **HTTP Response Error**:
The error occurs because the `category` parameter is set to `'all'`, which is invalid. It should be `'gettingStarted'` or others.

### Fix
I updated the example code in `competitions_list` from `docs/KaggleApi.md` to:
1. Add the `api.authenticate()` method for proper authentication.
2. Change the `category` parameter to `'gettingStarted'`.

### Testing
- The updated example code works correctly in a local Python 3.11 environment.
- The errors no longer occur, and the `competitions_list` API call returns the expected results.

---

Closes #709
