### PR TITLE
Add a no response action to auto-close issues

### DIFF
--- a/.github/no-response.yaml
+++ b/.github/no-response.yaml
@@ -1,0 +1,33 @@
+name: No Response
+
+# Both `issue_comment` and `scheduled` event types are required for this Action
+# to work properly.
+on:
+  issue_comment:
+    types: [created]
+  schedule:
+    # Schedule for five minutes after midnight, every day
+    - cron: '5 0 * * *'
+
+# By specifying the access of one of the scopes, all of those that are not
+# specified are set to 'none'.
+permissions:
+  issues: write
+
+jobs:
+  noResponse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lee-dohm/no-response@9bb0a4b5e6a45046f00353d5de7d90fb8bd773bb
+        with:
+          token: ${{ github.token }}
+          # Comment to post when closing an Issue for lack of response. Set to `false` to disable
+          closeComment: >
+            Without additional information we're not able to resolve this issue,
+            so it will be closed at this time. You're still free to add more info
+            and respond to any questions above, though. We'll reopen the case
+            if you do. Thanks for your contribution!
+          # Number of days of inactivity before an issue is closed for lack of response.
+          daysUntilClose: 14
+          # Label requiring a response.
+          responseRequiredLabel: "waiting for response"


### PR DESCRIPTION
Copied from https://github.com/flutter/flutter-intellij/blob/master/.github/workflows/no-response.yaml, which I created a few years ago.

I added a new label `waiting for response`. Add that to an issue when asking for more info, and if there's no response in two weeks, it will be closed.