### PR TITLE
Remove unused tools

### DIFF
--- a/kaggle/models/api_blob_type.py
+++ b/kaggle/models/api_blob_type.py
@@ -1,4 +1,0 @@
-class ApiBlobType(object):
-    DATASET = "dataset"
-    MODEL = "model"
-    INBOX = "inbox"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,14 +61,10 @@ packages = ["src/kaggle", "src/kagglesdk"]
 
 [tool.hatch.envs.default.scripts]
 install-unzip = """sudo apt-get install -y unzip || echo 'unzip could not be installed'"""
-install-autogen = """curl -fsSL --output /tmp/autogen.zip "https://github.com/mbrukman/autogen/archive/refs/heads/master.zip" && 
-  rm -rf /tmp/autogen && mkdir -p /tmp/autogen && unzip -qo /tmp/autogen.zip -d /tmp/autogen && 
-  mv /tmp/autogen/autogen-*/* /tmp/autogen && rm -rf /tmp/autogen/autogen-* && 
-  sudo chmod a+rx /tmp/autogen/autogen.sh"""
 # TODO: install in Mac/Windows
-install-yapf = """pip3 install yapf==0.40.2 --break-system-packages || echo 'yapf could not be installed'"""
+install-black = """pip3 install black --break-system-packages || echo 'black could not be installed'"""
 install-toml = """sudo apt-get install -y python3-toml || echo 'toml could not be installed'"""
-install-deps = "hatch run install-unzip && hatch run install-autogen && hatch run install-yapf && hatch run install-toml"
+install-deps = "hatch run install-unzip && hatch run install-black && hatch run install-toml"
 
 integration-test = "pytest {args:integration_tests}"
 

--- a/tools/GeneratePythonLibrary.sh
+++ b/tools/GeneratePythonLibrary.sh
@@ -83,15 +83,11 @@ function init {
 function reset {
   cd $SELF_DIR
 
-  echo "rm -rf kaggle/* kagglesdk/*"
-  rm -rf kaggle/* kagglesdk/*
-
-  echo "yapf3 -ir src/"
-  if [ -x "$(command -v yapf3)" ]; then
-#    yapf3 -ir --style yapf src/
-    echo skipped
+  echo "run formatter"
+  if [ -x "$(command -v black)" ]; then
+    black .
   else
-    echo "yapf3 is not installed on your system"
+    echo "black is not installed on your system"
   fi
 }
 
@@ -113,10 +109,6 @@ function copy-src {
   cp ./src/setup.cfg .
   cp -r ./src/kaggle .
   cp -r ./src/kagglesdk .
-}
-
-function run-autogen {
-  find kaggle/ -type f -name \*.py -exec /tmp/autogen/autogen.sh --no-code --no-top-level-comment --in-place --copyright "Kaggle Inc" --license apache {} \;
 }
 
 function run-tests {
@@ -171,7 +163,6 @@ function run {
   reset
 
   copy-src
-  run-autogen
   install-package
   run-tests
 

--- a/tools/releases/Dockerfile
+++ b/tools/releases/Dockerfile
@@ -8,14 +8,6 @@ RUN apt-get update -y && \
                        default-jre \
                        python3-pip
 
-# Install tools used to generate the Kaggle CLI.
-RUN apt-get install -y yapf3 python3-yapf && \
-  curl -fsSL --output /tmp/autogen.zip "https://github.com/mbrukman/autogen/archive/refs/heads/master.zip" && \
-  mkdir -p /usr/lib/autogen && unzip -qo /tmp/autogen.zip -d /usr/lib/autogen && \
-  mv /usr/lib/autogen/autogen-*/* /usr/lib/autogen && rm -rf /usr/lib/autogen/autogen-* && \
-  chmod a+rx /usr/lib/autogen/autogen.sh && \
-  ln -s /usr/lib/autogen/autogen.sh /usr/bin/autogen
-
 COPY requirements.txt requirements.txt
 RUN cat requirements.txt
 RUN pip install --require-hashes -r requirements.txt --break-system-packages


### PR DESCRIPTION
Neither `yapf` or `autogen` is used any longer. Remove them, along with an unused file.