### PR TITLE
Add test for dataset_delete() and make script more robust

### DIFF
--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -397,9 +397,12 @@ class KaggleApi:
     config_values: Dict[str, str] = {}
     already_printed_version_warning = False
 
-    args: List[str] = []  # DEBUG Add --local to use localhost
+    args: List[str] = []
     if os.environ.get('KAGGLE_API_ENVIRONMENT') == 'LOCALHOST':
+        # Make it verbose when running in the debugger.
         args = ['--verbose', '--local']
+    elif os.environ.get('KAGGLE_API_ENDPOINT') == 'http://localhost':
+        args = ['--local']
 
     # Kernels valid types
     valid_push_kernel_types = ['script', 'notebook']
@@ -2110,7 +2113,6 @@ class KaggleApi:
             resp.status = 'error'
             resp.error = f'The requested title "{title}" is already in use by a dataset. Please choose another title.'
             return resp
-                
 
         request = ApiCreateDatasetRequest()
         request.title = title

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -397,9 +397,12 @@ class KaggleApi:
     config_values: Dict[str, str] = {}
     already_printed_version_warning = False
 
-    args: List[str] = []  # DEBUG Add --local to use localhost
+    args: List[str] = []
     if os.environ.get('KAGGLE_API_ENVIRONMENT') == 'LOCALHOST':
+        # Make it verbose when running in the debugger.
         args = ['--verbose', '--local']
+    elif os.environ.get('KAGGLE_API_ENDPOINT') == 'http://localhost':
+        args = ['--local']
 
     # Kernels valid types
     valid_push_kernel_types = ['script', 'notebook']
@@ -2110,7 +2113,6 @@ class KaggleApi:
             resp.status = 'error'
             resp.error = f'The requested title "{title}" is already in use by a dataset. Please choose another title.'
             return resp
-                
 
         request = ApiCreateDatasetRequest()
         request.title = title

--- a/tools/GeneratePythonLibrary.sh
+++ b/tools/GeneratePythonLibrary.sh
@@ -126,9 +126,10 @@ function run-tests {
   fi
 
   cd tests
+  rm -f kaggle kagglesdk
   ln -s ../kagglesdk .
   ln -s ../kaggle .
-  /usr/local/bin/python3.12 unit_tests.py
+  python3 unit_tests.py --failfast
   rm kaggle kagglesdk
   cd ..
 }


### PR DESCRIPTION
This adds `--failfast` to the test runner, which is usually what's needed (esp. if MT isn't running). But it could be problematic for some uses.