### PR TITLE
Update kagglesdk with dataset_delete endpoint, etc

### DIFF
--- a/kagglesdk/kaggle_http_client.py
+++ b/kagglesdk/kaggle_http_client.py
@@ -187,12 +187,13 @@ class KaggleHttpClient(object):
     return cookies
 
   def _prepare_response(self, response_type, http_response):
+    """Extract the kaggle response and raise an exception if it is an error."""
     self._print_response(http_response)
-    http_response.raise_for_status()
     if 'application/json' in http_response.headers['Content-Type']:
       resp = http_response.json()
       if 'code' in resp and resp['code'] >= 400:
         raise requests.exceptions.HTTPError(resp['message'], response=http_response)
+    http_response.raise_for_status()
     if response_type is None:  # Method doesn't have a return type
       return None
     return response_type.prepare_from(http_response)

--- a/kagglesdk/kernels/services/kernels_api_service.py
+++ b/kagglesdk/kernels/services/kernels_api_service.py
@@ -1,7 +1,7 @@
 from kagglesdk.common.types.file_download import FileDownload
 from kagglesdk.common.types.http_redirect import HttpRedirect
 from kagglesdk.kaggle_http_client import KaggleHttpClient
-from kagglesdk.kernels.types.kernels_api_service import ApiDownloadKernelOutputRequest, ApiDownloadKernelOutputZipRequest, ApiGetKernelRequest, ApiGetKernelResponse, ApiGetKernelSessionStatusRequest, ApiGetKernelSessionStatusResponse, ApiListKernelFilesRequest, ApiListKernelFilesResponse, ApiListKernelSessionOutputRequest, ApiListKernelSessionOutputResponse, ApiListKernelsRequest, ApiListKernelsResponse, ApiSaveKernelRequest, ApiSaveKernelResponse
+from kagglesdk.kernels.types.kernels_api_service import ApiDeleteKernelRequest, ApiDeleteKernelResponse, ApiDownloadKernelOutputRequest, ApiDownloadKernelOutputZipRequest, ApiGetKernelRequest, ApiGetKernelResponse, ApiGetKernelSessionStatusRequest, ApiGetKernelSessionStatusResponse, ApiListKernelFilesRequest, ApiListKernelFilesResponse, ApiListKernelSessionOutputRequest, ApiListKernelSessionOutputResponse, ApiListKernelsRequest, ApiListKernelsResponse, ApiSaveKernelRequest, ApiSaveKernelResponse
 
 class KernelsApiClient(object):
 
@@ -107,3 +107,15 @@ class KernelsApiClient(object):
       request = ApiDownloadKernelOutputZipRequest()
 
     return self._client.call("kernels.KernelsApiService", "ApiDownloadKernelOutputZip", request, FileDownload)
+
+  def delete_kernel(self, request: ApiDeleteKernelRequest = None) -> ApiDeleteKernelResponse:
+    r"""
+    Args:
+      request (ApiDeleteKernelRequest):
+        The request object; initialized to empty instance if not specified.
+    """
+
+    if request is None:
+      request = ApiDeleteKernelRequest()
+
+    return self._client.call("kernels.KernelsApiService", "ApiDeleteKernel", request, ApiDeleteKernelResponse)

--- a/kagglesdk/kernels/types/kernels_api_service.py
+++ b/kagglesdk/kernels/types/kernels_api_service.py
@@ -3,6 +3,81 @@ from kagglesdk.kaggle_object import *
 from kagglesdk.kernels.types.kernels_enums import KernelsListSortType, KernelsListViewType, KernelWorkerStatus
 from typing import Optional, List
 
+class ApiDeleteKernelRequest(KaggleObject):
+  r"""
+  Attributes:
+    user_name (str)
+    kernel_slug (str)
+  """
+
+  def __init__(self):
+    self._user_name = ""
+    self._kernel_slug = ""
+    self._freeze()
+
+  @property
+  def user_name(self) -> str:
+    return self._user_name
+
+  @user_name.setter
+  def user_name(self, user_name: str):
+    if user_name is None:
+      del self.user_name
+      return
+    if not isinstance(user_name, str):
+      raise TypeError('user_name must be of type str')
+    self._user_name = user_name
+
+  @property
+  def kernel_slug(self) -> str:
+    return self._kernel_slug
+
+  @kernel_slug.setter
+  def kernel_slug(self, kernel_slug: str):
+    if kernel_slug is None:
+      del self.kernel_slug
+      return
+    if not isinstance(kernel_slug, str):
+      raise TypeError('kernel_slug must be of type str')
+    self._kernel_slug = kernel_slug
+
+  def endpoint(self):
+    path = '/api/v1/kernels/delete/{username}/{kernel_slug}'
+    return path.format_map(self.to_field_map(self))
+
+  @staticmethod
+  def endpoint_path():
+    return '/api/v1/kernels/delete/{username}/{kernel_slug}'
+
+
+class ApiDeleteKernelResponse(KaggleObject):
+  r"""
+  Attributes:
+    error_message (str)
+  """
+
+  def __init__(self):
+    self._error_message = None
+    self._freeze()
+
+  @property
+  def error_message(self) -> str:
+    return self._error_message or ""
+
+  @error_message.setter
+  def error_message(self, error_message: Optional[str]):
+    if error_message is None:
+      del self.error_message
+      return
+    if not isinstance(error_message, str):
+      raise TypeError('error_message must be of type str')
+    self._error_message = error_message
+
+  @property
+  def errorMessage(self):
+    return self.error_message
+
+
 class ApiDownloadKernelOutputRequest(KaggleObject):
   r"""
   Attributes:
@@ -1223,6 +1298,10 @@ class ApiSaveKernelRequest(KaggleObject):
       Sets the execution priority of this kernel session request when queued,
       lower is better (10 will get run before 100).
       Only allowed or certain clients.
+    docker_image (str)
+      Which docker image to run with. This must be one of the Kaggle-provided,
+      known images. It should look something like:
+      gcr.io/kaggle-images/python@sha256:f4b6dd72d4ac48c76fbb02bce0798b80b284102886ad37e6041e9ab721dc8873
   """
 
   def __init__(self):
@@ -1244,6 +1323,7 @@ class ApiSaveKernelRequest(KaggleObject):
     self._model_data_sources = []
     self._session_timeout_seconds = None
     self._priority = None
+    self._docker_image = None
     self._freeze()
 
   @property
@@ -1540,6 +1620,24 @@ class ApiSaveKernelRequest(KaggleObject):
       raise TypeError('priority must be of type int')
     self._priority = priority
 
+  @property
+  def docker_image(self) -> str:
+    r"""
+    Which docker image to run with. This must be one of the Kaggle-provided,
+    known images. It should look something like:
+    gcr.io/kaggle-images/python@sha256:f4b6dd72d4ac48c76fbb02bce0798b80b284102886ad37e6041e9ab721dc8873
+    """
+    return self._docker_image or ""
+
+  @docker_image.setter
+  def docker_image(self, docker_image: Optional[str]):
+    if docker_image is None:
+      del self.docker_image
+      return
+    if not isinstance(docker_image, str):
+      raise TypeError('docker_image must be of type str')
+    self._docker_image = docker_image
+
   def endpoint(self):
     path = '/api/v1/kernels/push'
     return path.format_map(self.to_field_map(self))
@@ -1825,6 +1923,15 @@ class ApiListKernelFilesItem(KaggleObject):
     self._creation_date = creation_date
 
 
+ApiDeleteKernelRequest._fields = [
+  FieldMetadata("userName", "user_name", "_user_name", str, "", PredefinedSerializer()),
+  FieldMetadata("kernelSlug", "kernel_slug", "_kernel_slug", str, "", PredefinedSerializer()),
+]
+
+ApiDeleteKernelResponse._fields = [
+  FieldMetadata("errorMessage", "error_message", "_error_message", str, None, PredefinedSerializer(), optional=True),
+]
+
 ApiDownloadKernelOutputRequest._fields = [
   FieldMetadata("ownerSlug", "owner_slug", "_owner_slug", str, "", PredefinedSerializer()),
   FieldMetadata("kernelSlug", "kernel_slug", "_kernel_slug", str, "", PredefinedSerializer()),
@@ -1948,6 +2055,7 @@ ApiSaveKernelRequest._fields = [
   FieldMetadata("modelDataSources", "model_data_sources", "_model_data_sources", str, [], ListSerializer(PredefinedSerializer())),
   FieldMetadata("sessionTimeoutSeconds", "session_timeout_seconds", "_session_timeout_seconds", int, None, PredefinedSerializer(), optional=True),
   FieldMetadata("priority", "priority", "_priority", int, None, PredefinedSerializer(), optional=True),
+  FieldMetadata("dockerImage", "docker_image", "_docker_image", str, None, PredefinedSerializer(), optional=True),
 ]
 
 ApiSaveKernelResponse._fields = [

--- a/kagglesdk/models/types/model_types.py
+++ b/kagglesdk/models/types/model_types.py
@@ -141,6 +141,8 @@ class Owner(KaggleObject):
     profile_url (str)
     slug (str)
     user_tier (UserAchievementTier)
+    user_progression_opt_out (bool)
+      Whether or not the owner is progression opted-out (only for user owners).
     allow_model_gating (bool)
   """
 
@@ -152,6 +154,7 @@ class Owner(KaggleObject):
     self._profile_url = None
     self._slug = ""
     self._user_tier = UserAchievementTier.NOVICE
+    self._user_progression_opt_out = None
     self._allow_model_gating = None
     self._freeze()
 
@@ -247,6 +250,20 @@ class Owner(KaggleObject):
     self._user_tier = user_tier
 
   @property
+  def user_progression_opt_out(self) -> bool:
+    """Whether or not the owner is progression opted-out (only for user owners)."""
+    return self._user_progression_opt_out or False
+
+  @user_progression_opt_out.setter
+  def user_progression_opt_out(self, user_progression_opt_out: Optional[bool]):
+    if user_progression_opt_out is None:
+      del self.user_progression_opt_out
+      return
+    if not isinstance(user_progression_opt_out, bool):
+      raise TypeError('user_progression_opt_out must be of type bool')
+    self._user_progression_opt_out = user_progression_opt_out
+
+  @property
   def allow_model_gating(self) -> bool:
     return self._allow_model_gating or False
 
@@ -281,6 +298,7 @@ Owner._fields = [
   FieldMetadata("profileUrl", "profile_url", "_profile_url", str, None, PredefinedSerializer(), optional=True),
   FieldMetadata("slug", "slug", "_slug", str, "", PredefinedSerializer()),
   FieldMetadata("userTier", "user_tier", "_user_tier", UserAchievementTier, UserAchievementTier.NOVICE, EnumSerializer()),
+  FieldMetadata("userProgressionOptOut", "user_progression_opt_out", "_user_progression_opt_out", bool, None, PredefinedSerializer(), optional=True),
   FieldMetadata("allowModelGating", "allow_model_gating", "_allow_model_gating", bool, None, PredefinedSerializer(), optional=True),
 ]
 

--- a/src/kagglesdk/kaggle_http_client.py
+++ b/src/kagglesdk/kaggle_http_client.py
@@ -187,12 +187,13 @@ class KaggleHttpClient(object):
     return cookies
 
   def _prepare_response(self, response_type, http_response):
+    """Extract the kaggle response and raise an exception if it is an error."""
     self._print_response(http_response)
-    http_response.raise_for_status()
     if 'application/json' in http_response.headers['Content-Type']:
       resp = http_response.json()
       if 'code' in resp and resp['code'] >= 400:
         raise requests.exceptions.HTTPError(resp['message'], response=http_response)
+    http_response.raise_for_status()
     if response_type is None:  # Method doesn't have a return type
       return None
     return response_type.prepare_from(http_response)

--- a/src/kagglesdk/kernels/services/kernels_api_service.py
+++ b/src/kagglesdk/kernels/services/kernels_api_service.py
@@ -1,7 +1,7 @@
 from kagglesdk.common.types.file_download import FileDownload
 from kagglesdk.common.types.http_redirect import HttpRedirect
 from kagglesdk.kaggle_http_client import KaggleHttpClient
-from kagglesdk.kernels.types.kernels_api_service import ApiDownloadKernelOutputRequest, ApiDownloadKernelOutputZipRequest, ApiGetKernelRequest, ApiGetKernelResponse, ApiGetKernelSessionStatusRequest, ApiGetKernelSessionStatusResponse, ApiListKernelFilesRequest, ApiListKernelFilesResponse, ApiListKernelSessionOutputRequest, ApiListKernelSessionOutputResponse, ApiListKernelsRequest, ApiListKernelsResponse, ApiSaveKernelRequest, ApiSaveKernelResponse
+from kagglesdk.kernels.types.kernels_api_service import ApiDeleteKernelRequest, ApiDeleteKernelResponse, ApiDownloadKernelOutputRequest, ApiDownloadKernelOutputZipRequest, ApiGetKernelRequest, ApiGetKernelResponse, ApiGetKernelSessionStatusRequest, ApiGetKernelSessionStatusResponse, ApiListKernelFilesRequest, ApiListKernelFilesResponse, ApiListKernelSessionOutputRequest, ApiListKernelSessionOutputResponse, ApiListKernelsRequest, ApiListKernelsResponse, ApiSaveKernelRequest, ApiSaveKernelResponse
 
 class KernelsApiClient(object):
 
@@ -107,3 +107,15 @@ class KernelsApiClient(object):
       request = ApiDownloadKernelOutputZipRequest()
 
     return self._client.call("kernels.KernelsApiService", "ApiDownloadKernelOutputZip", request, FileDownload)
+
+  def delete_kernel(self, request: ApiDeleteKernelRequest = None) -> ApiDeleteKernelResponse:
+    r"""
+    Args:
+      request (ApiDeleteKernelRequest):
+        The request object; initialized to empty instance if not specified.
+    """
+
+    if request is None:
+      request = ApiDeleteKernelRequest()
+
+    return self._client.call("kernels.KernelsApiService", "ApiDeleteKernel", request, ApiDeleteKernelResponse)

--- a/src/kagglesdk/kernels/types/kernels_api_service.py
+++ b/src/kagglesdk/kernels/types/kernels_api_service.py
@@ -3,6 +3,81 @@ from kagglesdk.kaggle_object import *
 from kagglesdk.kernels.types.kernels_enums import KernelsListSortType, KernelsListViewType, KernelWorkerStatus
 from typing import Optional, List
 
+class ApiDeleteKernelRequest(KaggleObject):
+  r"""
+  Attributes:
+    user_name (str)
+    kernel_slug (str)
+  """
+
+  def __init__(self):
+    self._user_name = ""
+    self._kernel_slug = ""
+    self._freeze()
+
+  @property
+  def user_name(self) -> str:
+    return self._user_name
+
+  @user_name.setter
+  def user_name(self, user_name: str):
+    if user_name is None:
+      del self.user_name
+      return
+    if not isinstance(user_name, str):
+      raise TypeError('user_name must be of type str')
+    self._user_name = user_name
+
+  @property
+  def kernel_slug(self) -> str:
+    return self._kernel_slug
+
+  @kernel_slug.setter
+  def kernel_slug(self, kernel_slug: str):
+    if kernel_slug is None:
+      del self.kernel_slug
+      return
+    if not isinstance(kernel_slug, str):
+      raise TypeError('kernel_slug must be of type str')
+    self._kernel_slug = kernel_slug
+
+  def endpoint(self):
+    path = '/api/v1/kernels/delete/{username}/{kernel_slug}'
+    return path.format_map(self.to_field_map(self))
+
+  @staticmethod
+  def endpoint_path():
+    return '/api/v1/kernels/delete/{username}/{kernel_slug}'
+
+
+class ApiDeleteKernelResponse(KaggleObject):
+  r"""
+  Attributes:
+    error_message (str)
+  """
+
+  def __init__(self):
+    self._error_message = None
+    self._freeze()
+
+  @property
+  def error_message(self) -> str:
+    return self._error_message or ""
+
+  @error_message.setter
+  def error_message(self, error_message: Optional[str]):
+    if error_message is None:
+      del self.error_message
+      return
+    if not isinstance(error_message, str):
+      raise TypeError('error_message must be of type str')
+    self._error_message = error_message
+
+  @property
+  def errorMessage(self):
+    return self.error_message
+
+
 class ApiDownloadKernelOutputRequest(KaggleObject):
   r"""
   Attributes:
@@ -1223,6 +1298,10 @@ class ApiSaveKernelRequest(KaggleObject):
       Sets the execution priority of this kernel session request when queued,
       lower is better (10 will get run before 100).
       Only allowed or certain clients.
+    docker_image (str)
+      Which docker image to run with. This must be one of the Kaggle-provided,
+      known images. It should look something like:
+      gcr.io/kaggle-images/python@sha256:f4b6dd72d4ac48c76fbb02bce0798b80b284102886ad37e6041e9ab721dc8873
   """
 
   def __init__(self):
@@ -1244,6 +1323,7 @@ class ApiSaveKernelRequest(KaggleObject):
     self._model_data_sources = []
     self._session_timeout_seconds = None
     self._priority = None
+    self._docker_image = None
     self._freeze()
 
   @property
@@ -1540,6 +1620,24 @@ class ApiSaveKernelRequest(KaggleObject):
       raise TypeError('priority must be of type int')
     self._priority = priority
 
+  @property
+  def docker_image(self) -> str:
+    r"""
+    Which docker image to run with. This must be one of the Kaggle-provided,
+    known images. It should look something like:
+    gcr.io/kaggle-images/python@sha256:f4b6dd72d4ac48c76fbb02bce0798b80b284102886ad37e6041e9ab721dc8873
+    """
+    return self._docker_image or ""
+
+  @docker_image.setter
+  def docker_image(self, docker_image: Optional[str]):
+    if docker_image is None:
+      del self.docker_image
+      return
+    if not isinstance(docker_image, str):
+      raise TypeError('docker_image must be of type str')
+    self._docker_image = docker_image
+
   def endpoint(self):
     path = '/api/v1/kernels/push'
     return path.format_map(self.to_field_map(self))
@@ -1825,6 +1923,15 @@ class ApiListKernelFilesItem(KaggleObject):
     self._creation_date = creation_date
 
 
+ApiDeleteKernelRequest._fields = [
+  FieldMetadata("userName", "user_name", "_user_name", str, "", PredefinedSerializer()),
+  FieldMetadata("kernelSlug", "kernel_slug", "_kernel_slug", str, "", PredefinedSerializer()),
+]
+
+ApiDeleteKernelResponse._fields = [
+  FieldMetadata("errorMessage", "error_message", "_error_message", str, None, PredefinedSerializer(), optional=True),
+]
+
 ApiDownloadKernelOutputRequest._fields = [
   FieldMetadata("ownerSlug", "owner_slug", "_owner_slug", str, "", PredefinedSerializer()),
   FieldMetadata("kernelSlug", "kernel_slug", "_kernel_slug", str, "", PredefinedSerializer()),
@@ -1948,6 +2055,7 @@ ApiSaveKernelRequest._fields = [
   FieldMetadata("modelDataSources", "model_data_sources", "_model_data_sources", str, [], ListSerializer(PredefinedSerializer())),
   FieldMetadata("sessionTimeoutSeconds", "session_timeout_seconds", "_session_timeout_seconds", int, None, PredefinedSerializer(), optional=True),
   FieldMetadata("priority", "priority", "_priority", int, None, PredefinedSerializer(), optional=True),
+  FieldMetadata("dockerImage", "docker_image", "_docker_image", str, None, PredefinedSerializer(), optional=True),
 ]
 
 ApiSaveKernelResponse._fields = [

--- a/src/kagglesdk/models/types/model_types.py
+++ b/src/kagglesdk/models/types/model_types.py
@@ -141,6 +141,8 @@ class Owner(KaggleObject):
     profile_url (str)
     slug (str)
     user_tier (UserAchievementTier)
+    user_progression_opt_out (bool)
+      Whether or not the owner is progression opted-out (only for user owners).
     allow_model_gating (bool)
   """
 
@@ -152,6 +154,7 @@ class Owner(KaggleObject):
     self._profile_url = None
     self._slug = ""
     self._user_tier = UserAchievementTier.NOVICE
+    self._user_progression_opt_out = None
     self._allow_model_gating = None
     self._freeze()
 
@@ -247,6 +250,20 @@ class Owner(KaggleObject):
     self._user_tier = user_tier
 
   @property
+  def user_progression_opt_out(self) -> bool:
+    """Whether or not the owner is progression opted-out (only for user owners)."""
+    return self._user_progression_opt_out or False
+
+  @user_progression_opt_out.setter
+  def user_progression_opt_out(self, user_progression_opt_out: Optional[bool]):
+    if user_progression_opt_out is None:
+      del self.user_progression_opt_out
+      return
+    if not isinstance(user_progression_opt_out, bool):
+      raise TypeError('user_progression_opt_out must be of type bool')
+    self._user_progression_opt_out = user_progression_opt_out
+
+  @property
   def allow_model_gating(self) -> bool:
     return self._allow_model_gating or False
 
@@ -281,6 +298,7 @@ Owner._fields = [
   FieldMetadata("profileUrl", "profile_url", "_profile_url", str, None, PredefinedSerializer(), optional=True),
   FieldMetadata("slug", "slug", "_slug", str, "", PredefinedSerializer()),
   FieldMetadata("userTier", "user_tier", "_user_tier", UserAchievementTier, UserAchievementTier.NOVICE, EnumSerializer()),
+  FieldMetadata("userProgressionOptOut", "user_progression_opt_out", "_user_progression_opt_out", bool, None, PredefinedSerializer(), optional=True),
   FieldMetadata("allowModelGating", "allow_model_gating", "_allow_model_gating", bool, None, PredefinedSerializer(), optional=True),
 ]
 


### PR DESCRIPTION
@jplotts This has my latest with some of yours, too. No need to review, unless you want to.

The change to the http client is from Auto-Kaggle. I updated kapigen earlier, but not here.

And yes, some day (soonish) I need to start using the official `kagglesdk` repo. That's going to require more mucking about in the build and setup scripts, so I keep putting it off.