### PR TITLE
Rename "yes" params and make confirmation consistent

### DIFF
--- a/kaggle/cli.py
+++ b/kaggle/cli.py
@@ -278,7 +278,9 @@ def parse_datasets(subparsers) -> None:
     )
     parser_datasets_delete_optional = parser_datasets_delete._action_groups.pop()
     parser_datasets_delete_optional.add_argument('dataset', help=Help.param_dataset)
-    parser_datasets_delete_optional.add_argument('-y', '--yes', dest='yes', action='store_true', help=Help.param_yes)
+    parser_datasets_delete_optional.add_argument(
+        '-y', '--yes', dest='no_confirm', action='store_true', help=Help.param_yes
+    )
     parser_datasets_delete._action_groups.append(parser_datasets_delete_optional)
     parser_datasets_delete.set_defaults(func=api.dataset_delete_cli)
 
@@ -604,7 +606,9 @@ def parse_kernels(subparsers) -> None:
     )
     parser_kernels_delete_optional = parser_kernels_delete._action_groups.pop()
     parser_kernels_delete_optional.add_argument('kernel', help=Help.param_kernel)
-    parser_kernels_delete_optional.add_argument('-y', '--yes', dest='yes', action='store_true', help=Help.param_yes)
+    parser_kernels_delete_optional.add_argument(
+        '-y', '--yes', dest='no_confirm', action='store_true', help=Help.param_yes
+    )
     parser_kernels_delete._action_groups.append(parser_kernels_delete_optional)
     parser_kernels_delete.set_defaults(func=api.kernels_delete_cli)
 
@@ -675,7 +679,9 @@ def parse_models(subparsers) -> None:
     )
     parser_models_delete_optional = parser_models_delete._action_groups.pop()
     parser_models_delete_optional.add_argument('model', help=Help.param_model)
-    parser_models_delete_optional.add_argument('-y', '--yes', dest='yes', action='store_true', help=Help.param_yes)
+    parser_models_delete_optional.add_argument(
+        '-y', '--yes', dest='no_confirm', action='store_true', help=Help.param_yes
+    )
     parser_models_delete._action_groups.append(parser_models_delete_optional)
     parser_models_delete.set_defaults(func=api.model_delete_cli)
 

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -278,7 +278,9 @@ def parse_datasets(subparsers) -> None:
     )
     parser_datasets_delete_optional = parser_datasets_delete._action_groups.pop()
     parser_datasets_delete_optional.add_argument('dataset', help=Help.param_dataset)
-    parser_datasets_delete_optional.add_argument('-y', '--yes', dest='yes', action='store_true', help=Help.param_yes)
+    parser_datasets_delete_optional.add_argument(
+        '-y', '--yes', dest='no_confirm', action='store_true', help=Help.param_yes
+    )
     parser_datasets_delete._action_groups.append(parser_datasets_delete_optional)
     parser_datasets_delete.set_defaults(func=api.dataset_delete_cli)
 
@@ -604,7 +606,9 @@ def parse_kernels(subparsers) -> None:
     )
     parser_kernels_delete_optional = parser_kernels_delete._action_groups.pop()
     parser_kernels_delete_optional.add_argument('kernel', help=Help.param_kernel)
-    parser_kernels_delete_optional.add_argument('-y', '--yes', dest='yes', action='store_true', help=Help.param_yes)
+    parser_kernels_delete_optional.add_argument(
+        '-y', '--yes', dest='no_confirm', action='store_true', help=Help.param_yes
+    )
     parser_kernels_delete._action_groups.append(parser_kernels_delete_optional)
     parser_kernels_delete.set_defaults(func=api.kernels_delete_cli)
 
@@ -675,7 +679,9 @@ def parse_models(subparsers) -> None:
     )
     parser_models_delete_optional = parser_models_delete._action_groups.pop()
     parser_models_delete_optional.add_argument('model', help=Help.param_model)
-    parser_models_delete_optional.add_argument('-y', '--yes', dest='yes', action='store_true', help=Help.param_yes)
+    parser_models_delete_optional.add_argument(
+        '-y', '--yes', dest='no_confirm', action='store_true', help=Help.param_yes
+    )
     parser_models_delete._action_groups.append(parser_models_delete_optional)
     parser_models_delete.set_defaults(func=api.model_delete_cli)
 

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -542,7 +542,7 @@ class TestKaggleApi(unittest.TestCase):
 
     def test_dataset_k_delete(self):
         self.test_dataset_ia_create_new(fail_if_exists=False)
-        api.dataset_delete(None, dataset_name)
+        api.dataset_delete(None, dataset_name, True)
 
     # Models
 
@@ -753,7 +753,7 @@ class TestKaggleApi(unittest.TestCase):
         if self.kernel_slug == '':
             self.test_kernels_c_push()
         try:
-            api.kernels_delete(self.kernel_slug, yes=True)
+            api.kernels_delete(self.kernel_slug, no_confirm=True)
             # The kernels_delete method prints success, no specific return to assert.
             # If no exception is raised, we assume success.
         except ApiException as e:


### PR DESCRIPTION
This was more involved than I expected. I noticed that `confirmation()` wasn't as informative as the generated code confirmation, but I thought a unified mechanism would be better. And it didn't make sense to `exit()` if the response was "no". If the confirmation had been done in the `_cli` then that would be OK, but it isn't. At least not today.

I haven't tested the `_cli` methods yet. I'm working on a PR (#766) to do so, but it needs to run against prod, so I need to deploy this first.