### PR TITLE
Add --quick to kaggle k push

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -527,7 +527,8 @@ optional arguments:
   -t N, --timeout N     Limit the run time of a kernel to the given number  of seconds.
                         The global maximum time will not be exceeded.
   -p FOLDER, --path FOLDER
-                        Folder for upload, containing data files and a special kernel-metadata.json file (https://github.com/Kaggle/kaggle-api/wiki/Kernel-Metadata). Defaults to current working directory
+                        Folder for upload, containing data files and a special kernel-metadata.json file (https://github.com/Kaggle/kaggle-api/wiki/Kernel-Metadata). Defaults to current working directory.
+  -q, --quick           Save the kernel quickly, without running the cells
 ```
 
 Example:

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -139,6 +139,7 @@ from kagglesdk.models.types.model_api_service import (
 )
 from kagglesdk.models.types.model_enums import ListModelsOrderBy, ModelInstanceType, ModelFramework
 from kagglesdk.models.types.model_types import Owner
+from kagglesdk.kernels.types.kernels_enums import KernelVersionType
 from ..models.dataset_column import DatasetColumn
 from ..models.upload_file import UploadFile
 import kagglesdk.kaggle_client
@@ -2520,7 +2521,7 @@ class KaggleApi:
         meta_file = self.kernels_initialize(folder)
         print('Kernel metadata template written to: ' + meta_file)
 
-    def kernels_push(self, folder: str, timeout: Optional[str] = None) -> ApiSaveKernelResponse:
+    def kernels_push(self, folder: str, timeout: Optional[str] = None, quick: bool = False) -> ApiSaveKernelResponse:
         """Read the metadata file and kernel files from a notebook, validate both,
         and use the Kernel API to push to Kaggle if all is valid.
 
@@ -2528,6 +2529,7 @@ class KaggleApi:
         ==========
         folder: the path of the folder
         timeout: maximum run time iin seconds
+        quick: use quick save, which does not run the code
         """
         if not os.path.isdir(folder):
             raise ValueError('Invalid folder: ' + folder)
@@ -2642,6 +2644,10 @@ class KaggleApi:
             request.docker_image_pinning_type = docker_pinning_type  # type: ignore[assignment]
             if timeout:
                 request.session_timeout_seconds = int(timeout)
+            if quick:
+                request.kernel_version_type = KernelVersionType.QUICK
+            else:
+                request.kernel_version_type = KernelVersionType.BATCH
             # Without the type hint, mypy thinks save_kernel() has type Any when checking warn_return_any.
             response: ApiSaveKernelResponse = kaggle.kernels.kernels_api_client.save_kernel(request)
             return response

--- a/kaggle/api/kaggle_api_extended.py
+++ b/kaggle/api/kaggle_api_extended.py
@@ -139,7 +139,7 @@ from kagglesdk.models.types.model_api_service import (
 )
 from kagglesdk.models.types.model_enums import ListModelsOrderBy, ModelInstanceType, ModelFramework
 from kagglesdk.models.types.model_types import Owner
-from kagglesdk.kernels.types.kernels_enums import KernelVersionType
+from kagglesdk.kernels.types.kernels_enums import KernelExecutionType
 from ..models.dataset_column import DatasetColumn
 from ..models.upload_file import UploadFile
 import kagglesdk.kaggle_client
@@ -2645,9 +2645,9 @@ class KaggleApi:
             if timeout:
                 request.session_timeout_seconds = int(timeout)
             if quick:
-                request.kernel_version_type = KernelVersionType.QUICK
+                request.kernel_version_type = KernelExecutionType.QUICK_SAVE
             else:
-                request.kernel_version_type = KernelVersionType.BATCH
+                request.kernel_version_type = KernelExecutionType.SAVE_AND_RUN_ALL
             # Without the type hint, mypy thinks save_kernel() has type Any when checking warn_return_any.
             response: ApiSaveKernelResponse = kaggle.kernels.kernels_api_client.save_kernel(request)
             return response

--- a/kaggle/cli.py
+++ b/kaggle/cli.py
@@ -546,6 +546,9 @@ def parse_kernels(subparsers) -> None:
     parser_kernels_push_optional.add_argument(
         '-t', '--timeout', type=int, dest='timeout', help=Help.param_kernel_timeout
     )
+    parser_kernels_push_optional.add_argument(
+        '-k', '--quick', dest='quick', action='store_true', help=Help.param_kernel_quick
+    )
     parser_kernels_push._action_groups.append(parser_kernels_push_optional)
     parser_kernels_push.set_defaults(func=api.kernels_push_cli)
 
@@ -1152,6 +1155,7 @@ class Help(object):
         'of seconds. The global maximum time will not be '
         'exceeded.'
     )
+    param_kernel_quick = 'Create a quick version of the kernel'
     param_kernel_user = 'Find kernels created by a given username'
     # TODO(b/129357583): Pull these from the same spot as the api impl
     param_kernel_language = (

--- a/prompts/quick.md
+++ b/prompts/quick.md
@@ -1,0 +1,10 @@
+Modify the code in kaggle/cli.py and kaggle/api/kaggle_api_extended.py to add an
+optional parameter named "quick" to the command `kaggle kernels push`. It should
+be abbreviated to "k" as well. If the new parameter is included then a bool should
+be passed into a new parameter to KaggleApi.kernels_push(). When that new parameter
+to `kernels_push()` is `True` then use the enum value `KernelVersionType.QUICK` as
+the value to a new property in the ApiSaveKernelRequest, named kernel_version_type.
+If the new parameter is not specified (or is `False`) use
+`KernelVersionType.BATCH` instead. Add a new section in `tests/unit_tests.py` to 
+test it. The new code can be added to `test_kernels_c_push()` before the existing
+call to `kernels_push()`. Add a small delay, like sleep for one second.

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -139,6 +139,7 @@ from kagglesdk.models.types.model_api_service import (
 )
 from kagglesdk.models.types.model_enums import ListModelsOrderBy, ModelInstanceType, ModelFramework
 from kagglesdk.models.types.model_types import Owner
+from kagglesdk.kernels.types.kernels_enums import KernelVersionType
 from ..models.dataset_column import DatasetColumn
 from ..models.upload_file import UploadFile
 import kagglesdk.kaggle_client
@@ -2520,7 +2521,7 @@ class KaggleApi:
         meta_file = self.kernels_initialize(folder)
         print('Kernel metadata template written to: ' + meta_file)
 
-    def kernels_push(self, folder: str, timeout: Optional[str] = None) -> ApiSaveKernelResponse:
+    def kernels_push(self, folder: str, timeout: Optional[str] = None, quick: bool = False) -> ApiSaveKernelResponse:
         """Read the metadata file and kernel files from a notebook, validate both,
         and use the Kernel API to push to Kaggle if all is valid.
 
@@ -2528,6 +2529,7 @@ class KaggleApi:
         ==========
         folder: the path of the folder
         timeout: maximum run time iin seconds
+        quick: use quick save, which does not run the code
         """
         if not os.path.isdir(folder):
             raise ValueError('Invalid folder: ' + folder)
@@ -2642,6 +2644,10 @@ class KaggleApi:
             request.docker_image_pinning_type = docker_pinning_type  # type: ignore[assignment]
             if timeout:
                 request.session_timeout_seconds = int(timeout)
+            if quick:
+                request.kernel_version_type = KernelVersionType.QUICK
+            else:
+                request.kernel_version_type = KernelVersionType.BATCH
             # Without the type hint, mypy thinks save_kernel() has type Any when checking warn_return_any.
             response: ApiSaveKernelResponse = kaggle.kernels.kernels_api_client.save_kernel(request)
             return response

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -139,7 +139,7 @@ from kagglesdk.models.types.model_api_service import (
 )
 from kagglesdk.models.types.model_enums import ListModelsOrderBy, ModelInstanceType, ModelFramework
 from kagglesdk.models.types.model_types import Owner
-from kagglesdk.kernels.types.kernels_enums import KernelVersionType
+from kagglesdk.kernels.types.kernels_enums import KernelExecutionType
 from ..models.dataset_column import DatasetColumn
 from ..models.upload_file import UploadFile
 import kagglesdk.kaggle_client
@@ -2645,9 +2645,9 @@ class KaggleApi:
             if timeout:
                 request.session_timeout_seconds = int(timeout)
             if quick:
-                request.kernel_version_type = KernelVersionType.QUICK
+                request.kernel_version_type = KernelExecutionType.QUICK_SAVE
             else:
-                request.kernel_version_type = KernelVersionType.BATCH
+                request.kernel_version_type = KernelExecutionType.SAVE_AND_RUN_ALL
             # Without the type hint, mypy thinks save_kernel() has type Any when checking warn_return_any.
             response: ApiSaveKernelResponse = kaggle.kernels.kernels_api_client.save_kernel(request)
             return response

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -546,6 +546,9 @@ def parse_kernels(subparsers) -> None:
     parser_kernels_push_optional.add_argument(
         '-t', '--timeout', type=int, dest='timeout', help=Help.param_kernel_timeout
     )
+    parser_kernels_push_optional.add_argument(
+        '-k', '--quick', dest='quick', action='store_true', help=Help.param_kernel_quick
+    )
     parser_kernels_push._action_groups.append(parser_kernels_push_optional)
     parser_kernels_push.set_defaults(func=api.kernels_push_cli)
 
@@ -1152,6 +1155,7 @@ class Help(object):
         'of seconds. The global maximum time will not be '
         'exceeded.'
     )
+    param_kernel_quick = 'Create a quick version of the kernel'
     param_kernel_user = 'Find kernels created by a given username'
     # TODO(b/129357583): Pull these from the same spot as the api impl
     param_kernel_language = (

--- a/src/kagglesdk/kernels/types/kernels_api_service.py
+++ b/src/kagglesdk/kernels/types/kernels_api_service.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from kagglesdk.kaggle_object import *
-from kagglesdk.kernels.types.kernels_enums import KernelsListSortType, KernelsListViewType, KernelWorkerStatus
+from kagglesdk.kernels.types.kernels_enums import KernelsListSortType, KernelsListViewType, KernelVersionType, KernelWorkerStatus
 from typing import Optional, List
 
 class ApiDeleteKernelRequest(KaggleObject):
@@ -1317,6 +1317,8 @@ class ApiSaveKernelRequest(KaggleObject):
       Which docker image to run with. This must be one of the Kaggle-provided,
       known images. It should look something like:
       gcr.io/kaggle-images/python@sha256:f4b6dd72d4ac48c76fbb02bce0798b80b284102886ad37e6041e9ab721dc8873
+    kernel_version_type (KernelVersionType)
+      Which kernel version type to use.
   """
 
   def __init__(self):
@@ -1339,6 +1341,7 @@ class ApiSaveKernelRequest(KaggleObject):
     self._session_timeout_seconds = None
     self._priority = None
     self._docker_image = None
+    self._kernel_version_type = None
     self._freeze()
 
   @property
@@ -1652,6 +1655,20 @@ class ApiSaveKernelRequest(KaggleObject):
     if not isinstance(docker_image, str):
       raise TypeError('docker_image must be of type str')
     self._docker_image = docker_image
+
+  @property
+  def kernel_version_type(self) -> 'KernelVersionType':
+    """Which kernel version type to use."""
+    return self._kernel_version_type or KernelVersionType.KERNEL_VERSION_TYPE_UNSPECIFIED
+
+  @kernel_version_type.setter
+  def kernel_version_type(self, kernel_version_type: Optional['KernelVersionType']):
+    if kernel_version_type is None:
+      del self.kernel_version_type
+      return
+    if not isinstance(kernel_version_type, KernelVersionType):
+      raise TypeError('kernel_version_type must be of type KernelVersionType')
+    self._kernel_version_type = kernel_version_type
 
   def endpoint(self):
     path = '/api/v1/kernels/push'
@@ -2072,6 +2089,7 @@ ApiSaveKernelRequest._fields = [
   FieldMetadata("sessionTimeoutSeconds", "session_timeout_seconds", "_session_timeout_seconds", int, None, PredefinedSerializer(), optional=True),
   FieldMetadata("priority", "priority", "_priority", int, None, PredefinedSerializer(), optional=True),
   FieldMetadata("dockerImage", "docker_image", "_docker_image", str, None, PredefinedSerializer(), optional=True),
+  FieldMetadata("kernelVersionType", "kernel_version_type", "_kernel_version_type", KernelVersionType, None, EnumSerializer(), optional=True),
 ]
 
 ApiSaveKernelResponse._fields = [

--- a/src/kagglesdk/kernels/types/kernels_enums.py
+++ b/src/kagglesdk/kernels/types/kernels_enums.py
@@ -22,6 +22,12 @@ class KernelsListViewType(enum.Enum):
   RECENTLY_VIEWED = 7
   PUBLIC_AND_USERS_PRIVATE = 8
 
+class KernelVersionType(enum.Enum):
+  KERNEL_VERSION_TYPE_UNSPECIFIED = 0
+  BATCH = 1
+  INTERACTIVE = 2
+  QUICK = 3
+
 class KernelWorkerStatus(enum.Enum):
   QUEUED = 0
   RUNNING = 1

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -245,6 +245,8 @@ class TestKaggleApi(unittest.TestCase):
             push_result_quick = api.kernels_push(kernel_directory, quick=True)
             self.assertIsNotNone(push_result_quick.ref)
             self.assertTrue(isinstance(push_result_quick.version_number, int))
+            if len(push_result_quick.error) > 0:
+                self.fail(push_result_quick.error)
             # Add a small delay
             time.sleep(1)
 
@@ -252,6 +254,8 @@ class TestKaggleApi(unittest.TestCase):
             push_result_batch = api.kernels_push(kernel_directory, quick=False)
             self.assertIsNotNone(push_result_batch.ref)
             self.assertTrue(isinstance(push_result_batch.version_number, int))
+            if len(push_result_quick.error) > 0:
+                self.fail(push_result_quick.error)
 
             self.kernel_slug = md['id']
             time.sleep(30)

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -240,9 +240,19 @@ class TestKaggleApi(unittest.TestCase):
             self.test_kernels_b_initialize()
         try:
             md = update_kernel_metadata_file(self.kernel_metadata_path, kernel_name)
-            push_result = api.kernels_push(kernel_directory)
-            self.assertIsNotNone(push_result.ref)
-            self.assertTrue(isinstance(push_result.version_number, int))
+
+            # Test with quick parameter
+            push_result_quick = api.kernels_push(kernel_directory, quick=True)
+            self.assertIsNotNone(push_result_quick.ref)
+            self.assertTrue(isinstance(push_result_quick.version_number, int))
+            # Add a small delay
+            time.sleep(1)
+
+            # Test without quick parameter
+            push_result_batch = api.kernels_push(kernel_directory, quick=False)
+            self.assertIsNotNone(push_result_batch.ref)
+            self.assertTrue(isinstance(push_result_batch.version_number, int))
+
             self.kernel_slug = md['id']
             time.sleep(30)
         except ApiException as e:


### PR DESCRIPTION
From Gemini. I had to make some small edits. The help text was embedded so I moved it to a constant like the others. And it added `sleep(1)` after the second test, which I removed because it has `sleep(30)` just after.