### PR TITLE
Do not try to create the symlink if already exists in Generate script

### DIFF
--- a/tools/GeneratePythonLibrary.sh
+++ b/tools/GeneratePythonLibrary.sh
@@ -105,8 +105,12 @@ function create-local-creds {
 }
 
 function copy-src {
-  ln -s ./src/kaggle .
-  ln -s ./src/kagglesdk .
+  if ! [[ -L ./kaggle ]]; then
+    ln -s ./src/kaggle .
+  fi
+  if ! [[ -L ./kagglesdk ]]; then
+    ln -s ./src/kagglesdk .
+  fi
 }
 
 function run-tests {


### PR DESCRIPTION
When run in `--watch` mode, `GeneratePythonLibrary.sh` tries to create the symlinks even though they exist already, which causes the script to fail. Therefore, only create symlinks if they don't exist already.