### PR TITLE
Enable OAuth behind an environment variable

### DIFF
--- a/src/kaggle/__init__.py
+++ b/src/kaggle/__init__.py
@@ -1,8 +1,10 @@
 # coding=utf-8
 from __future__ import absolute_import
+import os
 from kaggle.api.kaggle_api_extended import KaggleApi
 
 __version__ = "1.7.5.0.dev0"
 
-api = KaggleApi()
+enable_oauth = os.environ.get("KAGGLE_ENABLE_OAUTH") in ("1", "true", "yes")
+api = KaggleApi(enable_oauth=enable_oauth)
 api.authenticate()

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -485,6 +485,9 @@ class KaggleApi:
     model_all_fields = ["id", "ref", "author", "slug", "title", "subtitle", "isPrivate", "description", "publishTime"]
     model_file_fields = ["name", "size", "creationDate"]
 
+    def __init__(self, enable_oauth: bool = False):
+        self.enable_oauth = enable_oauth
+
     def _is_retriable(self, e: HTTPError) -> bool:
         return (
             issubclass(type(e), ConnectionError)
@@ -530,20 +533,22 @@ class KaggleApi:
     ## Authentication
 
     def authenticate(self) -> None:
-        # if self._authenticate_with_oauth_creds():
-        #     return
+        if self.enable_oauth and self._authenticate_with_oauth_creds():
+            return
         if self._authenticate_with_access_token():
             return
         if self._authenticate_with_legacy_apikey():
             return
-        print(
-            "Could not find {}. Make sure it's located in"
-            " {}. Or use the environment method. See setup"
-            " instructions at"
-            " https://github.com/Kaggle/kaggle-api/".format(self.config_file, self.config_dir)
-        )
-        # print('You must log in to Kaggle to use the Kaggle API.')
-        # print('Please run "kaggle auth login" to log in.')
+        if self.enable_oauth:
+            print("You must log in to Kaggle to use the Kaggle API.")
+            print('Please run "kaggle auth login" to log in.')
+        else:
+            print(
+                "Could not find {}. Make sure it's located in"
+                " {}. Or use the environment method. See setup"
+                " instructions at"
+                " https://github.com/Kaggle/kaggle-api/".format(self.config_file, self.config_dir)
+            )
         exit(1)
 
     def _authenticate_with_legacy_apikey(self) -> bool:

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -55,7 +55,8 @@ def main() -> None:
     parse_models(subparsers)
     parse_files(subparsers)
     parse_config(subparsers)
-    # parse_auth(subparsers)
+    if api.enable_oauth:
+        parse_auth(subparsers)
     args = parser.parse_args()
     command_args = {}
     command_args.update(vars(args))
@@ -1029,10 +1030,9 @@ class Help(object):
         + "}\nconfig {"
         + ", ".join(config_choices)
         + "}"
-        # + '}\nauth {'
-        # + ', '.join(auth_choices)
-        # + '}'
     )
+    if api.enable_oauth:
+        kaggle += "\nauth {" + ", ".join(auth_choices) + "}"
 
     group_competitions = "Commands related to Kaggle competitions"
     group_datasets = "Commands related to Kaggle datasets"


### PR DESCRIPTION
Since OAuth isn't enabled on the backend, we don't want to enable `kaggle auth login` by default for now but it is useful to have the functionality available for local testing and experimentation.