### PR TITLE
Do not use existing tokens/keys when executing an OAuth flow

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -598,6 +598,7 @@ class KaggleApi:
             self.CONFIG_NAME_AUTH_METHOD: AuthMethod.ACCESS_TOKEN,
         }
         self.logger.debug(f"Authenticated with access token in: {source}")
+        del os.environ["KAGGLE_API_TOKEN"]
         return True
 
     def _authenticate_with_oauth_creds(self) -> bool:
@@ -847,7 +848,7 @@ class KaggleApi:
     def auth_login_cli(self, no_launch_browser: bool = False):
         # Allow access to all ApiV1 endpoints.
         default_scopes = ["resources.admin:*"]
-        with self.build_kaggle_client() as kaggle:
+        with KaggleApi.build_kaggle_client_with_params(args=self.args) as kaggle:
             oAuth = KaggleOAuth(client=kaggle)
             oAuth.authenticate(scopes=default_scopes, no_launch_browser=no_launch_browser)
 
@@ -881,22 +882,29 @@ class KaggleApi:
             creds.revoke_token(reason or "Manually revoked by user with kaggle-cli")
 
     def build_kaggle_client(self) -> kagglesdk.kaggle_client.KaggleClient:
-        env = (
-            KaggleEnv.STAGING
-            if "--staging" in self.args
-            else (
-                KaggleEnv.ADMIN
-                if "--admin" in self.args
-                else KaggleEnv.LOCAL if "--local" in self.args else KaggleEnv.PROD
-            )
-        )
-        verbose = "--verbose" in self.args or "-v" in self.args
-        return KaggleClient(
-            env=env,
-            verbose=verbose,
+        return KaggleApi.build_kaggle_client_with_params(
+            args=self.args,
             username=self.config_values.get(self.CONFIG_NAME_USER),
             password=self.config_values.get(self.CONFIG_NAME_KEY),
             api_token=self.config_values.get(self.CONFIG_NAME_TOKEN),
+        )
+
+    @staticmethod
+    def build_kaggle_client_with_params(
+        args: List[str], username: str = None, password: str = None, api_token: str = None
+    ) -> kagglesdk.kaggle_client.KaggleClient:
+        env = (
+            KaggleEnv.STAGING
+            if "--staging" in args
+            else (KaggleEnv.ADMIN if "--admin" in args else KaggleEnv.LOCAL if "--local" in args else KaggleEnv.PROD)
+        )
+        verbose = "--verbose" in args or "-v" in args
+        return KaggleClient(
+            env=env,
+            verbose=verbose,
+            username=username,
+            password=password,
+            api_token=api_token,
         )
 
     def camel_to_snake(self, name: str) -> str:

--- a/src/kagglesdk/kaggle_http_client.py
+++ b/src/kagglesdk/kaggle_http_client.py
@@ -320,7 +320,7 @@ class KaggleHttpClient(object):
         if self._signed_in is not None:
             return
 
-        api_token = self._api_token or os.getenv("KAGGLE_API_TOKEN")
+        (api_token, _) = get_access_token_from_env()
         if api_token is not None:
             self._session.auth = KaggleHttpClient.BearerAuth(api_token)
             self._signed_in = True
@@ -332,12 +332,6 @@ class KaggleHttpClient(object):
             apikey_creds = _get_apikey_creds()
         if apikey_creds is not None:
             self._session.auth = apikey_creds
-            self._signed_in = True
-            return
-
-        (api_token, _) = get_access_token_from_env()
-        if api_token is not None:
-            self._session.auth = KaggleHttpClient.BearerAuth(api_token)
             self._signed_in = True
             return
 


### PR DESCRIPTION
Even if KAGGLE_API_TOKEN or legacy api key is set, we should not use it when `KaggleOAuth` to avoid confusion. It is possible user might be starting the OAuth flow to switch to another user so including existing tokens/keys can be very confusin and lead to errors.