### PR TITLE
Use api.kaggle.com

### DIFF
--- a/src/kagglesdk/kaggle_env.py
+++ b/src/kagglesdk/kaggle_env.py
@@ -27,7 +27,7 @@ _env_to_endpoint = {
     KaggleEnv.ADMIN: "https://admin.kaggle.com",
     KaggleEnv.QA: "https://qa.kaggle.com",
     # See the comment above in KaggleEnv enum.
-    KaggleEnv.PROD: "https://www.kaggle.com",
+    KaggleEnv.PROD: "https://api.kaggle.com",
 }
 
 

--- a/src/kagglesdk/kaggle_http_client.py
+++ b/src/kagglesdk/kaggle_http_client.py
@@ -250,4 +250,4 @@ class KaggleHttpClient(object):
         self._signed_in = False
 
     def _get_request_url(self, service_name: str, request_name: str):
-        return f"{self._endpoint}/api/v1/{service_name}/{request_name}"
+        return f"{self._endpoint}/v1/{service_name}/{request_name}"


### PR DESCRIPTION
I thought I had done this before, and I had, but it was never committed. I guess I forgot to update `kapigen`.