### PR TITLE
Give Gemini CLI some instruction about analyzing Python

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -21,6 +21,11 @@
 - Use Markdown and create an index named `intro.md` with links.
 - Document all commands, sub-commands, and options with examples.
 
+# Anlyzing Python Code
+- When analyzing Python code, use the `api` module to parse it, UNLESS instructed otherwise.
+- Use `api.get_docstring()` to locate a docstring for an item.
+- To find type hints, walk the AST using `api.walk_tree()` looking for type parameters with `ast.TypeVar()`, 'ast.ParamSpec()', and 'ast.TypeVarTuple()'.
+
 # Getting Help
 - Ask for clarification.
 - Ask for help when needed.


### PR DESCRIPTION
Sometimes, when asking Gemini CLI to find docstrings it constructs a Python function that is too simple to find them all. This instructions it to use `api.get_docstrting()`. When working with type hints it seems to also be a bit simplistic so I'm trying to get it to use tools in `ast'. Not sure if the latter actually makes sense, though, in the context of vibe-coding.