### PR TITLE
Fix a type error in Kaggle notebook auto-auth flow

### DIFF
--- a/src/kagglesdk/kaggle_env.py
+++ b/src/kagglesdk/kaggle_env.py
@@ -65,18 +65,18 @@ def is_in_kaggle_notebook() -> bool:
 
 def _get_access_token_from_file(path):
     if not path:
-        return (None, None)
+        return None
 
     token_path = Path(path)
     if not token_path.exists():
-        return (None, None)
+        return None
 
     token_value = token_path.read_text().strip()
     if not token_value:
-        return (None, None)
+        return None
 
     get_logger().debug(f'Using access token from file: "{path}"')
-    return (token_value, path)
+    return token_value
 
 
 def get_access_token_from_env():


### PR DESCRIPTION
_get_access_token_from_file returns a tuple but the caller assumes it is a string, which fails later when it tries to use the token.