### PR TITLE
Begin renaming instance to variation

### DIFF
--- a/documentation/intro.md
+++ b/documentation/intro.md
@@ -56,8 +56,8 @@ Explore these tutorials to learn how to perform common tasks:
     *   [Create a Dataset](./tutorials.md#tutorial-create-a-dataset)
     *   [Download a Dataset and Prepare for Analysis](./tutorials.md#tutorial-download-a-dataset-and-prepare-for-analysis)
     *   [Create a Model](./tutorials.md#tutorial-create-a-model)
-    *   [Create a Model Instance](./tutorials.md#tutorial-create-a-model-instance)
-    *   [Create a Model Instance Version](./tutorials.md#tutorial-create-a-model-instance-version)
+    *   [Create a Model Variation](./tutorials.md#tutorial-create-a-model-instance)
+    *   [Create a Model Variation Version](./tutorials.md#tutorial-create-a-model-instance-version)
     *   [How to Submit to a Competition](./tutorials.md#tutorial-how-to-submit-to-a-competition)
     *   [How to Submit to a Code Competition](./tutorials.md#tutorial-how-to-submit-to-a-code-competition)
 
@@ -69,8 +69,8 @@ The Kaggle CLI is organized into several command groups:
 *   [Datasets](./datasets.md): Search, download, and manage Kaggle datasets.
 *   [Kernels](./kernels.md): Interact with Kaggle Kernels (notebooks and scripts).
 *   [Models](./models.md): Manage your Kaggle Models.
-*   [Model Instances](./model_instances.md): Manage instances of your Kaggle Models.
-*   [Model Instance Versions](./model_instance_versions.md): Manage variations of your Kaggle Model Instances.
+*   [Model Variations](./model_instances.md): Manage variations of your Kaggle Models.
+*   [Model Variation Versions](./model_instances_versions.md): Manage versions of your Kaggle Model Variations.
 *   [Configuration](./configuration.md): Configure the Kaggle CLI.
 
 ## Python API Reference

--- a/documentation/model_instances.md
+++ b/documentation/model_instances.md
@@ -1,15 +1,15 @@
-# Model Instances Commands
+# Model Variation Commands
 
-Commands for interacting with instances of Kaggle Models. A model instance typically represents a specific framework of a parent model.
+Commands for interacting with variations of Kaggle Models. A model variation typically represents a specific framework of a parent model.
 
-## `kaggle models instances init`
+## `kaggle models variations init`
 
 Initializes a metadata file (`model-instance-metadata.json`) for creating a new model instance.
 
 **Usage:**
 
 ```bash
-kaggle models instances init -p <FOLDER_PATH>
+kaggle models variations init -p <FOLDER_PATH>
 ```
 
 **Options:**
@@ -18,35 +18,35 @@ kaggle models instances init -p <FOLDER_PATH>
 
 **Example:**
 
-Initialize a model instance metadata file in the `tmp` folder:
+Initialize a model variation metadata file in the `tmp` folder:
 
 ```bash
-kaggle models instances init -p tmp
+kaggle models variations init -p tmp
 ```
 
 **Purpose:**
 
-This command creates a template `model-instance-metadata.json` file. You must edit this file with details such as the owner slug, the parent model slug, the instance slug (URL-friendly name for this instance), and the framework (e.g., `tensorflow`, `pytorch`, `jax`, `sklearn`) before creating the instance.
+This command creates a template `model-instance-metadata.json` file. You must edit this file with details such as the owner slug, the parent model slug, the variation (or instance) slug (URL-friendly name for this variations), and the framework (e.g., `tensorflow`, `pytorch`, `jax`, `sklearn`) before creating the variation.
 
-## `kaggle models instances create`
+## `kaggle models variations create`
 
-Creates a new model instance under an existing model on Kaggle.
+Creates a new model variation under an existing model on Kaggle.
 
 **Usage:**
 
 ```bash
-kaggle models instances create -p <FOLDER_PATH> [options]
+kaggle models variations create -p <FOLDER_PATH> [options]
 ```
 
 **Options:**
 
-*   `-p, --path <FOLDER_PATH>`: Path to the folder containing the model instance files and the `model-instance-metadata.json` file (defaults to the current directory).
+*   `-p, --path <FOLDER_PATH>`: Path to the folder containing the model variation files and the `model-instance-metadata.json` file (defaults to the current directory).
 *   `-q, --quiet`: Suppress verbose output.
 *   `-r, --dir-mode <MODE>`: How to handle directories within the upload: `skip` (ignore), `zip` (compressed upload), `tar` (uncompressed upload) (default: `skip`).
 
 **Example:**
 
-Create a new model instance using the metadata and files in the `tmp` folder, quietly, skipping subdirectories. (Assumes `model-instance-metadata.json` in `tmp` has been properly edited):
+Create a new model variation using the metadata and files in the `tmp` folder, quietly, skipping subdirectories. (Assumes `model-instance-metadata.json` in `tmp` has been properly edited):
 
 ```bash
 # Example: Edit model-instance-metadata.json first
@@ -56,26 +56,26 @@ Create a new model instance using the metadata and files in the `tmp` folder, qu
 # sed -i 's/INSERT_FRAMEWORK_HERE/jax/' tmp/model-instance-metadata.json
 # echo "a,b,c,d" > tmp/data.csv # Example model file
 
-kaggle models instances create -p tmp -q -r skip
+kaggle models variations create -p tmp -q -r skip
 ```
 
 **Purpose:**
 
-This command uploads your local model files (e.g., weights, architecture definition) and the associated instance metadata to create a new instance under a specified parent model on Kaggle. This effectively creates the first version of this model instance.
+This command uploads your local model files (e.g., weights, architecture definition) and the associated variation metadata to create a new variation under a specified parent model on Kaggle. This effectively creates the first version of this model variation.
 
-## `kaggle models instances get`
+## `kaggle models variations get`
 
-Downloads the `model-instance-metadata.json` file for an existing model instance.
+Downloads the `model-instance-metadata.json` file for an existing model variation.
 
 **Usage:**
 
 ```bash
-kaggle models instances get <MODEL_INSTANCE> -p <FOLDER_PATH>
+kaggle models variations get <MODEL_INSTANCE> -p <FOLDER_PATH>
 ```
 
 **Arguments:**
 
-*   `<MODEL_INSTANCE>`: Model instance URL suffix in the format `owner/model-slug/framework/instance-slug` (e.g., `$KAGGLE_DEVELOPER/test-model/jax/main`).
+*   `<MODEL_INSTANCE>`: Model variation URL suffix in the format `owner/model-slug/framework/instance-slug` (e.g., `$KAGGLE_DEVELOPER/test-model/jax/main`).
 
 **Options:**
 
@@ -83,29 +83,29 @@ kaggle models instances get <MODEL_INSTANCE> -p <FOLDER_PATH>
 
 **Example:**
 
-Download the metadata for model instance `$KAGGLE_DEVELOPER/test-model/jax/main` into the `tmp` folder:
+Download the metadata for model variation `$KAGGLE_DEVELOPER/test-model/jax/main` into the `tmp` folder:
 
 ```bash
-kaggle models instances get $KAGGLE_DEVELOPER/test-model/jax/main -p tmp
+kaggle models variations get $KAGGLE_DEVELOPER/test-model/jax/main -p tmp
 ```
 
 **Purpose:**
 
-This command retrieves the metadata file for an existing model instance. This can be useful for inspection or as a basis for an update.
+This command retrieves the metadata file for an existing model variation. This can be useful for inspection or as a basis for an update.
 
-## `kaggle models instances files`
+## `kaggle models variations files`
 
-Lists files for the current version of a model instance.
+Lists files for the current version of a model variation.
 
 **Usage:**
 
 ```bash
-kaggle models instances files <MODEL_INSTANCE> [options]
+kaggle models variations files <MODEL_INSTANCE> [options]
 ```
 
 **Arguments:**
 
-*   `<MODEL_INSTANCE>`: Model instance URL suffix (e.g., `$KAGGLE_DEVELOPER/test-model/jax/main`).
+*   `<MODEL_INSTANCE>`: Model variation URL suffix (e.g., `$KAGGLE_DEVELOPER/test-model/jax/main`).
 
 **Options:**
 
@@ -115,55 +115,55 @@ kaggle models instances files <MODEL_INSTANCE> [options]
 
 **Example:**
 
-List the first 5 files for the model instance `$KAGGLE_DEVELOPER/test-model/jax/main` in CSV format:
+List the first 5 files for the model variation `$KAGGLE_DEVELOPER/test-model/jax/main` in CSV format:
 
 ```bash
-kaggle models instances files $KAGGLE_DEVELOPER/test-model/jax/main -v --page-size 5
+kaggle models variations files $KAGGLE_DEVELOPER/test-model/jax/main -v --page-size 5
 ```
 
 **Purpose:**
 
-Use this command to see the files associated with the latest version of a specific model instance.
+Use this command to see the files associated with the latest version of a specific model variation.
 
-## `kaggle models instances update`
+## `kaggle models variations update`
 
-Updates an existing model instance on Kaggle using a local `model-instance-metadata.json` file.
+Updates an existing model variation on Kaggle using a local `model-instance-metadata.json` file.
 
 **Usage:**
 
 ```bash
-kaggle models instances update -p <FOLDER_PATH>
+kaggle models variations update -p <FOLDER_PATH>
 ```
 
 **Options:**
 
-*   `-p, --path <FOLDER_PATH>`: Path to the folder containing the `model-instance-metadata.json` file with the updated information (defaults to the current directory). Note: This command only updates the metadata of the instance, not the files. To update files, create a new version.
+*   `-p, --path <FOLDER_PATH>`: Path to the folder containing the `model-instance-metadata.json` file with the updated information (defaults to the current directory). Note: This command only updates the metadata of the variation, not the files. To update files, create a new version.
 
 **Example:**
 
-Update the model instance whose details are in `tmp/model-instance-metadata.json` (ensure the slugs and owner in the JSON match an existing model instance):
+Update the model variation whose details are in `tmp/model-instance-metadata.json` (ensure the slugs and owner in the JSON match an existing model variation):
 
 ```bash
-kaggle models instances update -p tmp
+kaggle models variations update -p tmp
 ```
 
 **Purpose:**
 
-Use this command to change the metadata of an existing model instance, such as its description or other fields defined in the `model-instance-metadata.json` file. This does not upload new files or create a new version.
+Use this command to change the metadata of an existing model variation, such as its description or other fields defined in the `model-instance-metadata.json` file. This does not upload new files or create a new version.
 
-## `kaggle models instances delete`
+## `kaggle models variations delete`
 
-Deletes a model instance from Kaggle.
+Deletes a model variation from Kaggle.
 
 **Usage:**
 
 ```bash
-kaggle models instances delete <MODEL_INSTANCE> [options]
+kaggle models variations delete <MODEL_INSTANCE> [options]
 ```
 
 **Arguments:**
 
-*   `<MODEL_INSTANCE>`: Model instance URL suffix in the format `owner/model-slug/framework/instance-slug` (e.g., `$KAGGLE_DEVELOPER/test-model/jax/main`).
+*   `<MODEL_INSTANCE>`: Model variation URL suffix in the format `owner/model-slug/framework/instance-slug` (e.g., `$KAGGLE_DEVELOPER/test-model/jax/main`).
 
 **Options:**
 
@@ -171,12 +171,12 @@ kaggle models instances delete <MODEL_INSTANCE> [options]
 
 **Example:**
 
-Delete the model instance `$KAGGLE_DEVELOPER/test-model/jax/main` and automatically confirm:
+Delete the model variation `$KAGGLE_DEVELOPER/test-model/jax/main` and automatically confirm:
 
 ```bash
-kaggle models instances delete $KAGGLE_DEVELOPER/test-model/jax/main -y
+kaggle models variations delete $KAGGLE_DEVELOPER/test-model/jax/main -y
 ```
 
 **Purpose:**
 
-This command permanently removes one of your model instances (and all its versions) from Kaggle. Use with caution.
+This command permanently removes one of your model variations (and all its versions) from Kaggle. Use with caution.


### PR DESCRIPTION
Changes `instance` to `variation` in docs, preserving agreement. Does not change meta-names, esp. those that appear in code. (Some meta-names are doc-only and will get changed in a separate pass.)

Probably need to add some comment about changing "instance" to "variation" in the text somewhere, too.