### PR TITLE
Add python-dateutil to pyproject.toml dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "kagglesdk",
     "python-slugify",
     "requests",
+    "python-dateutil",
     "setuptools>=21.0.0", # unused if setup.py is removed
     "six>=1.10", # should be unused but is still imported
     "tqdm",


### PR DESCRIPTION
The `python-dateutil` library is used in the code, but not listed in the `pyproject.toml` under dependencies. This should fix the issue.

Code used here:
https://github.com/Kaggle/kaggle-api/blob/3f8e54c5dc1121dd09be83f2ad607771b31b7457/src/kaggle/api/kaggle_api_extended.py#L36

This dependency is mentioned in several other places, but not in the `pyproject.toml` (e.g. `requirements.in`).

Fixes #868 