### PR TITLE
Fix cloud deploy script

### DIFF
--- a/tools/releases/cloudbuild.yaml
+++ b/tools/releases/cloudbuild.yaml
@@ -30,8 +30,8 @@ steps:
     args:
       - "-c"
       - |
-        mkdir -p ~/.kaggle/dev # Directory expected by following script
-        ./tools/GeneratePythonLibrary.sh
+        cp -r src/kaggle .
+        cp -r src/kagglesdk .
         python3 -m pip install build --break-system-packages
         python3 -m build
         # Move the built CLI to a volume that will survive to next steps.


### PR DESCRIPTION
The Python build tool does not handle symlinks. This eliminates the dependency on the local code mgmt tool from the build script. It also makes it clear where references to source dirs are actually required. Once we start pulling `kagglesdk` from pypi.org then this will need to change. At that time other changes will need to be made to this script and it should be obvious where the current mod needs to be updated.