### PR TITLE
Fix Kaggle access token auth KeyError when KAGGLE_API_TOKEN is unset

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -739,7 +739,7 @@ class KaggleApi:
             self.CONFIG_NAME_AUTH_METHOD: AuthMethod.ACCESS_TOKEN,
         }
         self.logger.debug(f"Authenticated with access token in: {source}")
-        del os.environ["KAGGLE_API_TOKEN"]
+        os.environ.pop("KAGGLE_API_TOKEN", None)
         return True
 
     def _authenticate_with_oauth_creds(self) -> bool:


### PR DESCRIPTION
fix to https://github.com/Kaggle/kaggle-api/issues/873 

```
del os.environ["KAGGLE_API_TOKEN"]
```

causes keyerror if `KAGGLE_API_TOKEN` is not set, so replaced it with

```
os.environ.pop("KAGGLE_API_TOKEN", None)
```