### PR TITLE
Specify model version when submitting to a comp (admin-only)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ keywords = ["Kaggle", "API"]
 requires-python = ">= 3.11"
 dependencies = [
     "bleach",
-    "kagglesdk >= 0.1.14, < 1.0", # sync with kagglehub
+    "kagglesdk >= 0.1.15, < 1.0", # sync with kagglehub
     "python-slugify",
     "requests",
     "python-dateutil",

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -1349,6 +1349,12 @@ class KaggleApi:
                     return resp
 
                 submit_request = ApiCreateSubmissionRequest()
+
+                # Admin-only feature to submit for a given model (b/475908216)
+                model_version_id = os.getenv("KAGGLE_COMPETITION_SUBMISSION_MODEL_VERSION_ID", None)
+                if model_version_id:
+                    submit_request.benchmark_model_version_id = int(model_version_id)
+
                 submit_request.competition_name = competition
                 submit_request.blob_file_tokens = response.token
                 if message:


### PR DESCRIPTION
To avoid exposing the option as a flag to all users, we are using an environment variable.

Example usage:

```sh
KAGGLE_COMPETITION_SUBMISSION_MODEL_VERSION_ID=87 kaggle competitions submit -c copy-of-connect-x-jeward -f ~/Documents/dummy-submission.py -m test-rosbo
```

http://b/475908216