### PR TITLE
Update unauthenticated error message

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -672,15 +672,11 @@ class KaggleApi:
         if self._authenticate_with_legacy_apikey():
             return
         if self.enable_oauth:
-            print("You must log in to Kaggle to use the Kaggle API.")
+            print("You must authenticate before you can call the Kaggle API.")
             print('Please run "kaggle auth login" to log in.')
         else:
-            print(
-                "Could not find {}. Make sure it's located in"
-                " {}. Or use the environment method. See setup"
-                " instructions at"
-                " https://github.com/Kaggle/kaggle-api/".format(self.config_file, self.config_dir)
-            )
+            print("You must authenticate before you can call the Kaggle API.")
+            print("Follow the instructions to authenticate at: https://github.com/Kaggle/kaggle-api/blob/main/docs/README.md#authentication")
         exit(1)
 
     def _authenticate_with_legacy_apikey(self) -> bool:


### PR DESCRIPTION
Before:

```
Could not find kaggle.json. Make sure it's located in /usr/local/google/home/rosbo/.kaggle. Or use the environment method. See setup instructions at https://github.com/Kaggle/kaggle-api/
```

After:

```
You must authenticate before you can call the Kaggle API.
Follow the instructions to authenticate at: https://github.com/Kaggle/kaggle-api/blob/main/docs/README.md#authentication
```

* Point directly to authentication documentation.
* Do not refer to legacy authentication method.

http://b/475847631