### PR TITLE
Add --gpu to set machine_shape for push

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -3039,7 +3039,7 @@ class KaggleApi:
         print("Kernel metadata template written to: " + meta_file)
 
     def kernels_push(
-        self, folder: str, timeout: Optional[str] = None, gpu: Optional[str] = None
+        self, folder: str, timeout: Optional[str] = None, acc: Optional[str] = None
     ) -> ApiSaveKernelResponse:
         """Pushes a kernel to Kaggle.
 
@@ -3049,8 +3049,8 @@ class KaggleApi:
         Args:
             folder (str): The path to the folder.
             timeout (Optional[str]): The maximum run time in seconds.
-            gpu (Optional[str]): The type of GPU to use for the kernel run. If set, this value overrides boolean
-                settings for GPU/TPU found int metadata.
+            acc (Optional[str]): The type of accelerator to use for the kernel run. If set, this value overrides boolean
+                settings for GPU/TPU found in the metadata file.
 
         Returns:
             ApiSaveKernelResponse: An ApiSaveKernelResponse object.
@@ -3170,7 +3170,7 @@ class KaggleApi:
             if timeout:
                 request.session_timeout_seconds = int(timeout)
             # The allowed names are in an enum that is not currently included in kagglesdk.
-            request.machine_shape = gpu if gpu else self.get_or_default(meta_data, "machine_shape", None)
+            request.machine_shape = acc if acc else self.get_or_default(meta_data, "machine_shape", None)
             # Without the type hint, mypy thinks save_kernel() has type Any when checking warn_return_any.
             response: ApiSaveKernelResponse = kaggle.kernels.kernels_api_client.save_kernel(request)
             return response

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -550,7 +550,7 @@ def parse_kernels(subparsers) -> None:
     parser_kernels_push_optional.add_argument(
         "-t", "--timeout", type=int, dest="timeout", help=Help.param_kernel_timeout
     )
-    parser_kernels_push_optional.add_argument("--gpu", dest="gpu", help=Help.param_kernel_gpu)
+    parser_kernels_push_optional.add_argument("--accelerator", dest="acc", help=Help.param_kernel_acc, alias=["acc"])
     parser_kernels_push._action_groups.append(parser_kernels_push_optional)
     parser_kernels_push.set_defaults(func=api.kernels_push_cli)
 
@@ -1300,7 +1300,7 @@ class Help(object):
     param_kernel_output_file_pattern = (
         "Regex pattern to match against filenames. Only files matching the pattern will be downloaded."
     )
-    param_kernel_gpu = "Specify the type of GPU to use for the kernel run"
+    param_kernel_acc = "Specify the type of accelerator to use for the kernel run"
 
     # Models params
     param_model = "Model URL suffix in format <owner>/<model-name>"


### PR DESCRIPTION
Writing the code seemed simpler than creating a text doc to describe this proposal. The alternative is to change the metadata file handling to use `machine_shape` there. It is already partially supported. I'm kinda in favor of doing both this plus the metadata change.

Let me know if `--gpu` seems like a poor name. I considered `--use-gpu` but decided the extra chars weren't helpful.