### PR TITLE
Fix invalid argparse alias parameter

### DIFF
--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -550,7 +550,7 @@ def parse_kernels(subparsers) -> None:
     parser_kernels_push_optional.add_argument(
         "-t", "--timeout", type=int, dest="timeout", help=Help.param_kernel_timeout
     )
-    parser_kernels_push_optional.add_argument("--accelerator", dest="acc", help=Help.param_kernel_acc, alias=["acc"])
+    parser_kernels_push_optional.add_argument("--accelerator", "--acc", dest="acc", help=Help.param_kernel_acc)
     parser_kernels_push._action_groups.append(parser_kernels_push_optional)
     parser_kernels_push.set_defaults(func=api.kernels_push_cli)
 


### PR DESCRIPTION
## Summary

Fixes a TypeError when running any kaggle CLI command:

```
TypeError: _StoreAction.__init__() got an unexpected keyword argument 'alias'
```

The `alias` keyword doesn't exist in argparse. This was introduced in #907. The fix uses the standard argparse way of adding argument aliases by passing multiple argument names.

## Test

```bash
kaggle --version
# Before: TypeError
# After: Kaggle API 1.8.3
```