### PR TITLE
Update link for the integration test auth instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,3 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 ## License
 
 The Kaggle CLI is released under the [Apache 2.0 license](LICENSE.txt).
-
-
-
-


### PR DESCRIPTION
Was missing the anchor as discussed here: https://github.com/Kaggle/kaggle-cli/pull/925#discussion_r2766288797