### PR TITLE
fix: fix string formatting in version warning message

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -5322,9 +5322,9 @@ class KaggleApi:
             latest_version = parse(latest_version_str)
             if latest_version > current_version:
                 print(
-                    f"Warning: Looks like you're using an outdated `kaggle`` "
-                    "version (installed: {current_version}), please consider "
-                    "upgrading to the latest version ({latest_version_str})"
+                    "Warning: Looks like you're using an outdated `kaggle` "
+                    f"version (installed: {current_version}), please consider "
+                    f"upgrading to the latest version ({latest_version_str})"
                 )
                 self.already_printed_version_warning = True
 


### PR DESCRIPTION
Fixed, variables interpolation in version warning message: https://github.com/Kaggle/kaggle-cli/blob/54dc103e50dc678addd94aee1d68fd54d6a54b9e/src/kaggle/api/kaggle_api_extended.py#L5325-L5327

**Before:**

```
Warning: Looks like you're using an outdated `kaggle`` version (installed: {current_version}), please consider upgrading to the latest version ({latest_version_str})
```

**After:**

```
Warning: Looks like you're using an outdated `kaggle` version (installed: 1.8.3), please consider upgrading to the latest version (1.8.4)
```