### PR TITLE
JSON parsing errors are silently swallowed in `__parse_body`

### DIFF
--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -93,8 +93,8 @@ from typing import Any
 def __parse_body(body) -> Any:
     try:
         return json.loads(body)
-    except Exception as e:
-        return {}
+    except json.JSONDecodeError as e:
+        raise ValueError("Failed to parse response body as JSON") from e
 
 
 def parse_competitions(subparsers) -> None:


### PR DESCRIPTION
## Summary

`__parse_body` catches all exceptions and returns `{}`. This hides malformed/invalid response payloads and converts hard failures into silent bad state, which can propagate incorrect behavior (e.g., missing required fields interpreted as absent data rather than parse failure).

## Files changed

- `src/kaggle/cli.py` (modified)

## Testing

- Not run in this environment.


Closes #942