### PR TITLE
Release 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,14 @@ Changelog
 
 ### Next
 
-* Add `--sandbox` flag to `kaggle competitions submit` for sandbox submissions (competition hosts/admins only)
+### 2.0.1
+
+* Add `--sandbox` flag to `kaggle competitions submit` for sandbox submissions (competition hosts/admins only) (#932)
+* Optimize large dataset download functionality (#936, s/o katoue)
+* Fix 403s and null file handling when listing kernel session output (#951, s/o 4kaws)
+* Support updating more types of dataset metadata through `datasets metadata --update`:
+  * Expected update frequency, user specified sources (#958)
+  * Dataset images (#959)
 
 ### 2.0.0
 

--- a/src/kaggle/__init__.py
+++ b/src/kaggle/__init__.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import os
 from kaggle.api.kaggle_api_extended import KaggleApi
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 enable_oauth = os.environ.get("KAGGLE_ENABLE_OAUTH") in ("1", "true", "yes")
 api = KaggleApi(enable_oauth=enable_oauth)


### PR DESCRIPTION
Release for 2.0.1

Of note, this also contains a change that bumps `kagglesdk` dep version to `0.1.17`, which had a non-trivial release: https://github.com/Kaggle/kaggle-sdk-python/releases/tag/v0.1.17