### PR TITLE
Support `dataset-cover-image.png` upload for `datasets metadata --update`

### DIFF
--- a/docs/datasets_metadata.md
+++ b/docs/datasets_metadata.md
@@ -176,36 +176,24 @@ You can specify the following values for `expectedUpdateFrequency`:
 * `hourly`
 
 ## Images
-You can update your dataset image using the `image` property. The value for this property should be either:
-- A relative path from your `datasets-metadata.json` to an image file
-- An absolute path to an image file
-  - Ensure that `kaggle-cli` has access to the directory and image file
+The recommended way to update your dataset's image is by placing a file named `dataset-cover-image.png` (or `.jpg`, `.jpeg`, `.webp`), as a sibling file to your `datasets-metadata.json`.
 
-### Specifying an image with a relative path:
-If your metadata file and image are located at:
+Example:
 - `/some/path/dataset-metadata.json`
-- `/some/path/image.png`
+- `/some/path/dataset-cover-image.png`
+
+The image file will only be used for dataset metadata, and not be uploaded as a file within your dataset.
+
+### Specifying an image with a relative path
+As an alternative, you can update your dataset image by providing a relative path from your `datasets-metadata.json` to an image file, using the `image` property.
+
+If your files were located at:
+- `/some/path/dataset-metadata.json`
+- `/some/path/to/my-image.jpg`
 
 This property should be specified as:
 ```
-"image": "image.png"
-```
-
-If instead, your files were located at:
-- `/some/path/dataset-metadata.json`
-- `/some/path/alternative/path/to/other-image.jpg`
-
-This property should be specified as:
-```
-"image": "alternative/path/to/other-image.jpg"
-```
-
-### Specifying an image with an absolute path:
-Note that this particular syntax deviates from the [Data Package spec](https://specs.frictionlessdata.io/data-package/#image). It can be used to avoid a scenario where your image would be included in your dataset files when using `kaggle datasets create --dir-mode` with a value of `zip` or `tar`.
-
-Simply use an absolute path to the image in your `datasets-metadata.json`:
-```
-"image": "/absolute/file/path/to/image.png"
+"image": "to/my-image.jpg"
 ```
 
 ### Supported image file types and expected dimensions

--- a/docs/datasets_metadata.md
+++ b/docs/datasets_metadata.md
@@ -176,9 +176,13 @@ You can specify the following values for `expectedUpdateFrequency`:
 * `hourly`
 
 ## Images
-You can update your dataset image by providing a relative path from your `datasets-metadata.json` to an image file, using the `image` property.
+You can update your dataset image using the `image` property. The value for this property should be either:
+- A relative path from your `datasets-metadata.json` to an image file
+- An absolute path to an image file
+  - Ensure that `kaggle-cli` has access to the directory and image file
 
-For example, if your metadata file and image are located at:
+### Specifying an image with a relative path:
+If your metadata file and image are located at:
 - `/some/path/dataset-metadata.json`
 - `/some/path/image.png`
 
@@ -194,6 +198,14 @@ If instead, your files were located at:
 This property should be specified as:
 ```
 "image": "alternative/path/to/other-image.jpg"
+```
+
+### Specifying an image with an absolute path:
+Note that this particular syntax deviates from the [Data Package spec](https://specs.frictionlessdata.io/data-package/#image). It can be used to avoid a scenario where your image would be included in your dataset files when using `kaggle datasets create --dir-mode` with a value of `zip` or `tar`.
+
+Simply use an absolute path to the image in your `datasets-metadata.json`:
+```
+"image": "/absolute/file/path/to/image.png"
 ```
 
 ### Supported image file types and expected dimensions

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -1941,9 +1941,11 @@ class KaggleApi:
             if expected_update_frequency:
                 update_settings.expected_update_frequency = expected_update_frequency
 
-            effective_relative_path_to_image = metadata.get("image")
-            if effective_relative_path_to_image:
-                cropped_image_upload = self._upload_dataset_image_file(effective_path, effective_relative_path_to_image)
+            relative_or_absolute_image_file_path = metadata.get("image")
+            if relative_or_absolute_image_file_path:
+                cropped_image_upload = self._upload_dataset_image_file(
+                    effective_path, relative_or_absolute_image_file_path
+                )
                 if cropped_image_upload:
                     update_settings.image = cropped_image_upload
 
@@ -1958,9 +1960,12 @@ class KaggleApi:
                     exit(1)
 
     def _upload_dataset_image_file(
-        self, metadata_file_path, relative_image_file_path, quiet=False
+        self, metadata_file_path, relative_or_absolute_image_file_path, quiet=False
     ) -> CroppedImageUpload:
-        image_full_path = os.path.join(metadata_file_path, relative_image_file_path)
+        if os.path.isabs(relative_or_absolute_image_file_path):
+            image_full_path = relative_or_absolute_image_file_path
+        else:
+            image_full_path = os.path.join(metadata_file_path, relative_or_absolute_image_file_path)
         ext = Path(image_full_path).suffix
         if ext not in [".jpg", ".jpeg", ".png", ".webp"]:
             raise ValueError("Image file requires an extension of .jpg, .jpeg, .png, or .webp: %s" % image_full_path)

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -522,6 +522,8 @@ class KaggleApi:
     HEADER_API_VERSION = "X-Kaggle-ApiVersion"
     DATASET_METADATA_FILE = "dataset-metadata.json"
     OLD_DATASET_METADATA_FILE = "datapackage.json"
+    DATASET_COVER_IMAGE_SUPPORTED_EXTENSIONS = [".png", ".jpg", ".jpeg", ".webp"]
+    DATASET_COVER_IMAGE_FILES = ["dataset-cover-image" + ext for ext in DATASET_COVER_IMAGE_SUPPORTED_EXTENSIONS]
     KERNEL_METADATA_FILE = "kernel-metadata.json"
     MODEL_METADATA_FILE = "model-metadata.json"
     MODEL_INSTANCE_METADATA_FILE = "model-instance-metadata.json"
@@ -1941,11 +1943,15 @@ class KaggleApi:
             if expected_update_frequency:
                 update_settings.expected_update_frequency = expected_update_frequency
 
-            relative_or_absolute_image_file_path = metadata.get("image")
-            if relative_or_absolute_image_file_path:
-                cropped_image_upload = self._upload_dataset_image_file(
-                    effective_path, relative_or_absolute_image_file_path
-                )
+            effective_relative_path_to_image = metadata.get("image")
+            if not effective_relative_path_to_image:
+                # If user did not specify an image path explicitly, check if canonical images exist as siblings to dataset-metadata.json.
+                for canonical_image_filename in self.DATASET_COVER_IMAGE_FILES:
+                    canonical_image_full_path = os.path.join(effective_path, canonical_image_filename)
+                    if os.path.exists(canonical_image_full_path):
+                        effective_relative_path_to_image = canonical_image_filename
+            if effective_relative_path_to_image:
+                cropped_image_upload = self._upload_dataset_image_file(effective_path, effective_relative_path_to_image)
                 if cropped_image_upload:
                     update_settings.image = cropped_image_upload
 
@@ -1960,14 +1966,11 @@ class KaggleApi:
                     exit(1)
 
     def _upload_dataset_image_file(
-        self, metadata_file_path, relative_or_absolute_image_file_path, quiet=False
+        self, metadata_file_path, relative_image_file_path, quiet=False
     ) -> CroppedImageUpload:
-        if os.path.isabs(relative_or_absolute_image_file_path):
-            image_full_path = relative_or_absolute_image_file_path
-        else:
-            image_full_path = os.path.join(metadata_file_path, relative_or_absolute_image_file_path)
+        image_full_path = os.path.join(metadata_file_path, relative_image_file_path)
         ext = Path(image_full_path).suffix
-        if ext not in [".jpg", ".jpeg", ".png", ".webp"]:
+        if ext not in self.DATASET_COVER_IMAGE_SUPPORTED_EXTENSIONS:
             raise ValueError("Image file requires an extension of .jpg, .jpeg, .png, or .webp: %s" % image_full_path)
 
         if not os.path.isfile(image_full_path):
@@ -4924,6 +4927,7 @@ class KaggleApi:
             if file_name in [
                 self.DATASET_METADATA_FILE,
                 self.OLD_DATASET_METADATA_FILE,
+                *self.DATASET_COVER_IMAGE_FILES,
                 self.KERNEL_METADATA_FILE,
                 self.MODEL_METADATA_FILE,
                 self.MODEL_INSTANCE_METADATA_FILE,

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -1015,9 +1015,27 @@ def parse_benchmark_tasks(subparsers) -> None:
     )
     parser_run_optional = parser_run._action_groups.pop()
     parser_run_optional.add_argument("task", help=Help.param_benchmarks_task)
-    parser_run_optional.add_argument("-m", "--model", dest="model", nargs="+", required=False, help=Help.param_benchmarks_model)
-    parser_run_optional.add_argument("--wait", dest="wait", type=int, nargs="?", const=0, default=None, required=False, help=Help.param_benchmarks_wait)
-    parser_run_optional.add_argument("--poll-interval", dest="poll_interval", type=int, default=10, required=False, help=Help.param_benchmarks_poll_interval)
+    parser_run_optional.add_argument(
+        "-m", "--model", dest="model", nargs="+", required=False, help=Help.param_benchmarks_model
+    )
+    parser_run_optional.add_argument(
+        "--wait",
+        dest="wait",
+        type=int,
+        nargs="?",
+        const=0,
+        default=None,
+        required=False,
+        help=Help.param_benchmarks_wait,
+    )
+    parser_run_optional.add_argument(
+        "--poll-interval",
+        dest="poll_interval",
+        type=int,
+        default=10,
+        required=False,
+        help=Help.param_benchmarks_poll_interval,
+    )
     parser_run._action_groups.append(parser_run_optional)
     parser_run.set_defaults(func=api.benchmarks_tasks_run_cli)
 


### PR DESCRIPTION
Follow-up to https://github.com/Kaggle/kaggle-cli/pull/959

Requiring the dataset cover / thumbnail image to be in the same dir as `dataset-metadata.json` means that if you create a dataset with `kaggle datasets create --dir-mode=(zip|tar)`, the metadata image will be included in your dataset files, which the author may not want. I had set it up that way because it adhered to [Data Package spec](https://specs.frictionlessdata.io/data-package/#image), but it's kind of annoying.

This PR adds a special named file, `dataset-cover-image.(png|jpg|jpeg|webp)` in the same location as your `dataset-metadata.json` to provide it as the image upload, without including it in your dataset.

`/some/path/dataset-metadata.json` (not uploaded)
`/some/path/my-files/*` (uploaded)
`/some/path/dataset-cover-image.png` (not uploaded)

We still support relative path via "image" property to adhere to Data Package spec. This was the first form of the API for Adaption Labs (and we don't want to break them), but there's also an edge case scenario where you want to re-use an image in your dataset as the cover image.

Local testing:
- http://go/scrcast/NjAyNDkwOTM0NzA5NDUyOHxlNGU1NWE0ZS0xYw

Note: there are some other random changes that showed up from running `./docker-hatch run lint:fmt`

http://b/500108129