### PR TITLE
fix(benchmarks tasks push): handle 403 

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -5785,7 +5785,7 @@ class KaggleApi:
         if task not in task_names:
             raise ValueError(f"Task '{task}' not found in file {file}. Found tasks: {', '.join(task_names)}")
 
-    def benchmarks_tasks_push_cli(self, task, file):
+    def benchmarks_tasks_push_cli(self, task, file, yes=False):
         if not os.path.isfile(file):
             raise ValueError(f"File {file} does not exist")
         if not file.endswith(".py"):
@@ -5809,13 +5809,20 @@ class KaggleApi:
         notebook_content = jupytext.writes(notebook, fmt="ipynb")
 
         with self.build_kaggle_client() as kaggle:
+            is_new_task = False
             try:
                 task_info = self._get_benchmark_task(task, kaggle)
                 if task_info.creation_state in self._PENDING_CREATION_STATES:
                     raise ValueError(f"Task '{task}' is currently being created (pending). Cannot push now.")
             except HTTPError as e:
-                if e.response.status_code != 404:
+                if e.response.status_code not in (403, 404):
                     raise
+                is_new_task = True
+
+            if is_new_task and not yes:
+                if not self.confirmation(f"create new task '{task}'"):
+                    print("Push cancelled.")
+                    return
 
             request = ApiCreateBenchmarkTaskRequest()
             request.slug = task

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -5785,7 +5785,7 @@ class KaggleApi:
         if task not in task_names:
             raise ValueError(f"Task '{task}' not found in file {file}. Found tasks: {', '.join(task_names)}")
 
-    def benchmarks_tasks_push_cli(self, task, file, yes=False):
+    def benchmarks_tasks_push_cli(self, task, file):
         if not os.path.isfile(file):
             raise ValueError(f"File {file} does not exist")
         if not file.endswith(".py"):
@@ -5809,7 +5809,6 @@ class KaggleApi:
         notebook_content = jupytext.writes(notebook, fmt="ipynb")
 
         with self.build_kaggle_client() as kaggle:
-            is_new_task = False
             try:
                 task_info = self._get_benchmark_task(task, kaggle)
                 if task_info.creation_state in self._PENDING_CREATION_STATES:
@@ -5817,12 +5816,6 @@ class KaggleApi:
             except HTTPError as e:
                 if e.response.status_code not in (403, 404):
                     raise
-                is_new_task = True
-
-            if is_new_task and not yes:
-                if not self.confirmation(f"create new task '{task}'"):
-                    print("Push cancelled.")
-                    return
 
             request = ApiCreateBenchmarkTaskRequest()
             request.slug = task

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -1089,7 +1089,6 @@ def parse_benchmark_tasks(subparsers) -> None:
     parser_push_optional = parser_push._action_groups.pop()
     parser_push_optional.add_argument("task", help=Help.param_benchmarks_task)
     parser_push_optional.add_argument("-f", "--file", dest="file", required=True, help=Help.param_benchmarks_file)
-    parser_push_optional.add_argument("-y", "--yes", dest="yes", action="store_true", help=Help.param_yes)
     parser_push._action_groups.append(parser_push_optional)
     parser_push.set_defaults(func=api.benchmarks_tasks_push_cli)
 

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -1089,6 +1089,7 @@ def parse_benchmark_tasks(subparsers) -> None:
     parser_push_optional = parser_push._action_groups.pop()
     parser_push_optional.add_argument("task", help=Help.param_benchmarks_task)
     parser_push_optional.add_argument("-f", "--file", dest="file", required=True, help=Help.param_benchmarks_file)
+    parser_push_optional.add_argument("-y", "--yes", dest="yes", action="store_true", help=Help.param_yes)
     parser_push._action_groups.append(parser_push_optional)
     parser_push.set_defaults(func=api.benchmarks_tasks_push_cli)
 

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -192,37 +192,13 @@ class TestPush:
         assert f"Task '{task_name}' pushed." in capsys.readouterr().out
 
     @pytest.mark.parametrize("status_code", [403, 404], ids=["forbidden", "not_found"])
-    def test_push_creates_new_task_with_yes_flag(self, api, tmp_path, capsys, status_code):
-        """With -y flag, a 403/404 creates the task without prompting."""
+    def test_push_creates_new_task_without_prompting(self, api, tmp_path, capsys, status_code):
+        """A 403/404 means a new task — push proceeds without confirmation."""
         filepath = _write_task_file(tmp_path)
         api._mock_benchmarks.get_benchmark_task.side_effect = HTTPError(response=MagicMock(status_code=status_code))
         _setup_create_response(api)
-        jt, ctx = _mock_jupytext()
-        with ctx:
-            api.benchmarks_tasks_push_cli("my-task", filepath, yes=True)
+        _push(api, "my-task", filepath)
         assert "Task 'my-task' pushed." in capsys.readouterr().out
-
-    @pytest.mark.parametrize("status_code", [403, 404], ids=["forbidden", "not_found"])
-    def test_push_prompts_on_new_task_and_user_confirms(self, api, tmp_path, capsys, status_code):
-        """Without -y, user is prompted and confirms — task is created."""
-        filepath = _write_task_file(tmp_path)
-        api._mock_benchmarks.get_benchmark_task.side_effect = HTTPError(response=MagicMock(status_code=status_code))
-        _setup_create_response(api)
-        jt, ctx = _mock_jupytext()
-        with ctx, patch("builtins.input", return_value="yes"):
-            api.benchmarks_tasks_push_cli("my-task", filepath)
-        assert "Task 'my-task' pushed." in capsys.readouterr().out
-
-    def test_push_prompts_on_new_task_and_user_declines(self, api, tmp_path, capsys):
-        """Without -y, user declines — push is cancelled."""
-        filepath = _write_task_file(tmp_path)
-        api._mock_benchmarks.get_benchmark_task.side_effect = HTTPError(response=MagicMock(status_code=404))
-        jt, ctx = _mock_jupytext()
-        with ctx, patch("builtins.input", return_value="no"):
-            api.benchmarks_tasks_push_cli("my-task", filepath)
-        output = capsys.readouterr().out
-        assert "Push cancelled." in output
-        api._mock_benchmarks.create_benchmark_task.assert_not_called()
 
     # -- Server edge cases --
 
@@ -398,10 +374,8 @@ class TestCliArgParsing:
     @pytest.mark.parametrize(
         "cmd, expected",
         [
-            ("benchmarks tasks push my-task -f ./task.py", {"task": "my-task", "file": "./task.py", "yes": False}),
-            ("benchmarks tasks push my-task -f ./task.py -y", {"task": "my-task", "file": "./task.py", "yes": True}),
-            ("b t push my-task -f ./task.py --yes", {"task": "my-task", "file": "./task.py", "yes": True}),
-            ("b t push my-task -f ./task.py", {"task": "my-task", "file": "./task.py", "yes": False}),
+            ("benchmarks tasks push my-task -f ./task.py", {"task": "my-task", "file": "./task.py"}),
+            ("b t push my-task -f ./task.py", {"task": "my-task", "file": "./task.py"}),
             ("benchmarks tasks run my-task", {"task": "my-task", "model": None, "wait": None}),
             ("benchmarks tasks run my-task -m gemini-3 --wait", {"model": ["gemini-3"], "wait": 0}),
             (

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -191,13 +191,38 @@ class TestPush:
 
         assert f"Task '{task_name}' pushed." in capsys.readouterr().out
 
-    def test_push_creates_new_task_on_404(self, api, tmp_path, capsys):
-        """A 404 from get_benchmark_task means new task — still creates successfully."""
+    @pytest.mark.parametrize("status_code", [403, 404], ids=["forbidden", "not_found"])
+    def test_push_creates_new_task_with_yes_flag(self, api, tmp_path, capsys, status_code):
+        """With -y flag, a 403/404 creates the task without prompting."""
+        filepath = _write_task_file(tmp_path)
+        api._mock_benchmarks.get_benchmark_task.side_effect = HTTPError(response=MagicMock(status_code=status_code))
+        _setup_create_response(api)
+        jt, ctx = _mock_jupytext()
+        with ctx:
+            api.benchmarks_tasks_push_cli("my-task", filepath, yes=True)
+        assert "Task 'my-task' pushed." in capsys.readouterr().out
+
+    @pytest.mark.parametrize("status_code", [403, 404], ids=["forbidden", "not_found"])
+    def test_push_prompts_on_new_task_and_user_confirms(self, api, tmp_path, capsys, status_code):
+        """Without -y, user is prompted and confirms — task is created."""
+        filepath = _write_task_file(tmp_path)
+        api._mock_benchmarks.get_benchmark_task.side_effect = HTTPError(response=MagicMock(status_code=status_code))
+        _setup_create_response(api)
+        jt, ctx = _mock_jupytext()
+        with ctx, patch("builtins.input", return_value="yes"):
+            api.benchmarks_tasks_push_cli("my-task", filepath)
+        assert "Task 'my-task' pushed." in capsys.readouterr().out
+
+    def test_push_prompts_on_new_task_and_user_declines(self, api, tmp_path, capsys):
+        """Without -y, user declines — push is cancelled."""
         filepath = _write_task_file(tmp_path)
         api._mock_benchmarks.get_benchmark_task.side_effect = HTTPError(response=MagicMock(status_code=404))
-        _setup_create_response(api)
-        _push(api, "my-task", filepath)
-        assert "Task 'my-task' pushed." in capsys.readouterr().out
+        jt, ctx = _mock_jupytext()
+        with ctx, patch("builtins.input", return_value="no"):
+            api.benchmarks_tasks_push_cli("my-task", filepath)
+        output = capsys.readouterr().out
+        assert "Push cancelled." in output
+        api._mock_benchmarks.create_benchmark_task.assert_not_called()
 
     # -- Server edge cases --
 
@@ -210,7 +235,7 @@ class TestPush:
             _push(api, "my-task", filepath)
 
     def test_push_propagates_server_error(self, api, tmp_path):
-        """Non-404 HTTP errors (e.g. 500) are re-raised, not swallowed."""
+        """Non-403/404 HTTP errors (e.g. 500) are re-raised, not swallowed."""
         filepath = _write_task_file(tmp_path)
         api._mock_benchmarks.get_benchmark_task.side_effect = HTTPError(response=MagicMock(status_code=500))
         with pytest.raises(HTTPError):
@@ -373,8 +398,10 @@ class TestCliArgParsing:
     @pytest.mark.parametrize(
         "cmd, expected",
         [
-            ("benchmarks tasks push my-task -f ./task.py", {"task": "my-task", "file": "./task.py"}),
-            ("b t push my-task -f ./task.py", {"task": "my-task", "file": "./task.py"}),
+            ("benchmarks tasks push my-task -f ./task.py", {"task": "my-task", "file": "./task.py", "yes": False}),
+            ("benchmarks tasks push my-task -f ./task.py -y", {"task": "my-task", "file": "./task.py", "yes": True}),
+            ("b t push my-task -f ./task.py --yes", {"task": "my-task", "file": "./task.py", "yes": True}),
+            ("b t push my-task -f ./task.py", {"task": "my-task", "file": "./task.py", "yes": False}),
             ("benchmarks tasks run my-task", {"task": "my-task", "model": None, "wait": None}),
             ("benchmarks tasks run my-task -m gemini-3 --wait", {"model": ["gemini-3"], "wait": 0}),
             (


### PR DESCRIPTION
**Title:** `benchmarks tasks push: handle 403 for missing tasks`

**Summary:**

Fix `benchmarks tasks push` to handle both 403 and 404 when a task doesn't exist (the server returns 403, not just 404). 

Changes:
- Accept both 403 and 404 as "task not found" in `benchmarks_tasks_push_cli`
