### PR TITLE
Add `--format` flag to `datasets status` for JSON output

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -2504,17 +2504,42 @@ class KaggleApi:
         else:
             print("No files found")
 
-    def dataset_status(self, dataset: str) -> str:
+    _DATASET_STATUS_FIELDS = ("status", "current_version_number")
+
+    def dataset_status(self, dataset: str, format=None) -> str:
         """Gets the status of a dataset.
 
         Args:
             dataset (str): The string identifier of the dataset, in the format [owner]/[dataset-name].
+            format: optional output format. ``None`` (default) preserves the
+                original behavior and returns the status string. A value of
+                ``"json"`` returns a JSON-encoded object with both ``status``
+                and ``current_version_number``. ``gcloud``-style field
+                selection is supported, e.g. ``"json(current_version_number)"``
+                or ``"json(status,current_version_number)"``; only the APIs
+                required to populate the requested fields are called.
 
         Returns:
-            str: The status of the dataset.
+            str: The status of the dataset, or a JSON-encoded payload when a
+            ``format`` is requested.
         """
         if dataset is None:
             raise ValueError("A dataset must be specified")
+
+        if format is None:
+            selected_fields = None
+        else:
+            format_name, fields = _parse_format(format)
+            if format_name != "json":
+                raise ValueError(f"Unsupported format value: {format!r}. Supported formats: json")
+            if fields:
+                unknown = [f for f in fields if f not in self._DATASET_STATUS_FIELDS]
+                if unknown:
+                    raise ValueError(f"Unknown field(s) in format: {', '.join(unknown)}")
+                selected_fields = list(fields)
+            else:
+                selected_fields = list(self._DATASET_STATUS_FIELDS)
+
         if "/" in dataset:
             self.validate_dataset_string(dataset)
             dataset_urls = dataset.split("/")
@@ -2525,11 +2550,28 @@ class KaggleApi:
             dataset_slug = dataset
 
         with self.build_kaggle_client() as kaggle:
-            request = ApiGetDatasetStatusRequest()
-            request.owner_slug = owner_slug
-            request.dataset_slug = dataset_slug
-            response = kaggle.datasets.dataset_api_client.get_dataset_status(request)
-            return response.status.name.lower()
+            if selected_fields is None:
+                request = ApiGetDatasetStatusRequest()
+                request.owner_slug = owner_slug
+                request.dataset_slug = dataset_slug
+                response = kaggle.datasets.dataset_api_client.get_dataset_status(request)
+                return response.status.name.lower()
+
+            payload = {}
+            if "status" in selected_fields:
+                status_request = ApiGetDatasetStatusRequest()
+                status_request.owner_slug = owner_slug
+                status_request.dataset_slug = dataset_slug
+                status_response = kaggle.datasets.dataset_api_client.get_dataset_status(status_request)
+                payload["status"] = status_response.status.name.lower()
+            if "current_version_number" in selected_fields:
+                dataset_request = ApiGetDatasetRequest()
+                dataset_request.owner_slug = owner_slug
+                dataset_request.dataset_slug = dataset_slug
+                dataset_response = kaggle.datasets.dataset_api_client.get_dataset(dataset_request)
+                payload["current_version_number"] = dataset_response.current_version_number
+
+        return json.dumps({field: payload[field] for field in selected_fields})
 
     def dataset_status_cli(self, dataset, dataset_opt=None, format=None):
         """A wrapper for client for dataset_status, with additional dataset_opt to
@@ -2537,55 +2579,13 @@ class KaggleApi:
 
         Args:
             dataset_opt: an alternative to dataset
-            format: optional output format. ``None`` (default) preserves the
-                original text output containing only the status string. A value
-                of ``"json"`` returns a JSON object with both ``status`` and
-                ``current_version_number``. ``gcloud``-style field selection is
-                also supported, e.g. ``"json(current_version_number)"`` or
-                ``"json(status,current_version_number)"``.
+            format: see :meth:`dataset_status`. ``None`` (default) keeps the
+                historic plain-text output containing only the status string;
+                pass ``"json"`` (optionally with field selection) to receive a
+                JSON payload.
         """
         dataset = dataset or dataset_opt
-        if format is None:
-            return self.dataset_status(dataset)
-
-        format_name, fields = _parse_format(format)
-        if format_name != "json":
-            raise ValueError(f"Unsupported --format value: {format!r}. Supported formats: json")
-
-        owner_slug, dataset_slug = self._split_dataset_string(dataset)
-        with self.build_kaggle_client() as kaggle:
-            status_request = ApiGetDatasetStatusRequest()
-            status_request.owner_slug = owner_slug
-            status_request.dataset_slug = dataset_slug
-            status_response = kaggle.datasets.dataset_api_client.get_dataset_status(status_request)
-            status = status_response.status.name.lower()
-
-            dataset_request = ApiGetDatasetRequest()
-            dataset_request.owner_slug = owner_slug
-            dataset_request.dataset_slug = dataset_slug
-            dataset_response = kaggle.datasets.dataset_api_client.get_dataset(dataset_request)
-            current_version_number = dataset_response.current_version_number
-
-        all_fields = {"status": status, "current_version_number": current_version_number}
-        if fields:
-            unknown = [f for f in fields if f not in all_fields]
-            if unknown:
-                raise ValueError(f"Unknown field(s) in --format: {', '.join(unknown)}")
-            payload = {f: all_fields[f] for f in fields}
-        else:
-            payload = all_fields
-        return json.dumps(payload)
-
-    def _split_dataset_string(self, dataset):
-        if dataset is None:
-            raise ValueError("A dataset must be specified")
-        if "/" in dataset:
-            self.validate_dataset_string(dataset)
-            owner_slug, dataset_slug = dataset.split("/", 1)
-        else:
-            owner_slug = self.get_config_value(self.CONFIG_NAME_USER)
-            dataset_slug = dataset
-        return owner_slug, dataset_slug
+        return self.dataset_status(dataset, format=format)
 
     def dataset_download_file(self, dataset, file_name, path=None, force=False, quiet=True, licenses=[]):
         """Download a single file for a dataset.

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -2526,6 +2526,23 @@ class KaggleApi:
         if dataset is None:
             raise ValueError("A dataset must be specified")
 
+        if format is None:
+            # Back-compat: only the status field is needed and we return it as
+            # a plain string instead of JSON.
+            selected_fields = ["status"]
+        else:
+            format_name, fields = _parse_format(format)
+            if format_name != "json":
+                raise ValueError(f"Unsupported format value: {format!r}. Supported formats: json")
+            if fields:
+                unknown = [f for f in fields if f not in self._DATASET_STATUS_FIELDS]
+                if unknown:
+                    raise ValueError(f"Unknown field(s) in format: {', '.join(unknown)}")
+                selected_fields = list(fields)
+            else:
+                # No projection: include all fields.
+                selected_fields = list(self._DATASET_STATUS_FIELDS)
+
         if "/" in dataset:
             self.validate_dataset_string(dataset)
             dataset_urls = dataset.split("/")
@@ -2534,28 +2551,6 @@ class KaggleApi:
         else:
             owner_slug = self.get_config_value(self.CONFIG_NAME_USER) or ""
             dataset_slug = dataset
-
-        # Default behavior: return only the status string for backward compat.
-        if format is None:
-            with self.build_kaggle_client() as kaggle:
-                request = ApiGetDatasetStatusRequest()
-                request.owner_slug = owner_slug
-                request.dataset_slug = dataset_slug
-                response = kaggle.datasets.dataset_api_client.get_dataset_status(request)
-                return response.status.name.lower()
-
-        # JSON format: parse fields and only call the APIs needed for them.
-        format_name, fields = _parse_format(format)
-        if format_name != "json":
-            raise ValueError(f"Unsupported format value: {format!r}. Supported formats: json")
-        if fields:
-            unknown = [f for f in fields if f not in self._DATASET_STATUS_FIELDS]
-            if unknown:
-                raise ValueError(f"Unknown field(s) in format: {', '.join(unknown)}")
-            selected_fields = list(fields)
-        else:
-            # No projection: return all fields in JSON.
-            selected_fields = list(self._DATASET_STATUS_FIELDS)
 
         payload = {}
         with self.build_kaggle_client() as kaggle:
@@ -2572,6 +2567,8 @@ class KaggleApi:
                 dataset_response = kaggle.datasets.dataset_api_client.get_dataset(dataset_request)
                 payload["current_version_number"] = dataset_response.current_version_number
 
+        if format is None:
+            return payload["status"]
         return json.dumps({field: payload[field] for field in selected_fields})
 
     def dataset_status_cli(self, dataset, dataset_opt=None, format=None):

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -2526,20 +2526,6 @@ class KaggleApi:
         if dataset is None:
             raise ValueError("A dataset must be specified")
 
-        if format is None:
-            selected_fields = None
-        else:
-            format_name, fields = _parse_format(format)
-            if format_name != "json":
-                raise ValueError(f"Unsupported format value: {format!r}. Supported formats: json")
-            if fields:
-                unknown = [f for f in fields if f not in self._DATASET_STATUS_FIELDS]
-                if unknown:
-                    raise ValueError(f"Unknown field(s) in format: {', '.join(unknown)}")
-                selected_fields = list(fields)
-            else:
-                selected_fields = list(self._DATASET_STATUS_FIELDS)
-
         if "/" in dataset:
             self.validate_dataset_string(dataset)
             dataset_urls = dataset.split("/")
@@ -2549,15 +2535,30 @@ class KaggleApi:
             owner_slug = self.get_config_value(self.CONFIG_NAME_USER) or ""
             dataset_slug = dataset
 
-        with self.build_kaggle_client() as kaggle:
-            if selected_fields is None:
+        # Default behavior: return only the status string for backward compat.
+        if format is None:
+            with self.build_kaggle_client() as kaggle:
                 request = ApiGetDatasetStatusRequest()
                 request.owner_slug = owner_slug
                 request.dataset_slug = dataset_slug
                 response = kaggle.datasets.dataset_api_client.get_dataset_status(request)
                 return response.status.name.lower()
 
-            payload = {}
+        # JSON format: parse fields and only call the APIs needed for them.
+        format_name, fields = _parse_format(format)
+        if format_name != "json":
+            raise ValueError(f"Unsupported format value: {format!r}. Supported formats: json")
+        if fields:
+            unknown = [f for f in fields if f not in self._DATASET_STATUS_FIELDS]
+            if unknown:
+                raise ValueError(f"Unknown field(s) in format: {', '.join(unknown)}")
+            selected_fields = list(fields)
+        else:
+            # No projection: return all fields in JSON.
+            selected_fields = list(self._DATASET_STATUS_FIELDS)
+
+        payload = {}
+        with self.build_kaggle_client() as kaggle:
             if "status" in selected_fields:
                 status_request = ApiGetDatasetStatusRequest()
                 status_request.owner_slug = owner_slug

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -115,6 +115,7 @@ from kagglesdk.common.types.cropped_image_upload import CroppedImageUpload, Crop
 from kagglesdk.datasets.types.dataset_api_service import (
     ApiListDatasetsRequest,
     ApiListDatasetFilesRequest,
+    ApiGetDatasetRequest,
     ApiGetDatasetStatusRequest,
     ApiDownloadDatasetRequest,
     ApiCreateDatasetRequest,
@@ -2530,15 +2531,61 @@ class KaggleApi:
             response = kaggle.datasets.dataset_api_client.get_dataset_status(request)
             return response.status.name.lower()
 
-    def dataset_status_cli(self, dataset, dataset_opt=None):
+    def dataset_status_cli(self, dataset, dataset_opt=None, format=None):
         """A wrapper for client for dataset_status, with additional dataset_opt to
         get the status of a dataset from the API.
 
         Args:
             dataset_opt: an alternative to dataset
+            format: optional output format. ``None`` (default) preserves the
+                original text output containing only the status string. A value
+                of ``"json"`` returns a JSON object with both ``status`` and
+                ``current_version_number``. ``gcloud``-style field selection is
+                also supported, e.g. ``"json(current_version_number)"`` or
+                ``"json(status,current_version_number)"``.
         """
         dataset = dataset or dataset_opt
-        return self.dataset_status(dataset)
+        if format is None:
+            return self.dataset_status(dataset)
+
+        format_name, fields = _parse_format(format)
+        if format_name != "json":
+            raise ValueError(f"Unsupported --format value: {format!r}. Supported formats: json")
+
+        owner_slug, dataset_slug = self._split_dataset_string(dataset)
+        with self.build_kaggle_client() as kaggle:
+            status_request = ApiGetDatasetStatusRequest()
+            status_request.owner_slug = owner_slug
+            status_request.dataset_slug = dataset_slug
+            status_response = kaggle.datasets.dataset_api_client.get_dataset_status(status_request)
+            status = status_response.status.name.lower()
+
+            dataset_request = ApiGetDatasetRequest()
+            dataset_request.owner_slug = owner_slug
+            dataset_request.dataset_slug = dataset_slug
+            dataset_response = kaggle.datasets.dataset_api_client.get_dataset(dataset_request)
+            current_version_number = dataset_response.current_version_number
+
+        all_fields = {"status": status, "current_version_number": current_version_number}
+        if fields:
+            unknown = [f for f in fields if f not in all_fields]
+            if unknown:
+                raise ValueError(f"Unknown field(s) in --format: {', '.join(unknown)}")
+            payload = {f: all_fields[f] for f in fields}
+        else:
+            payload = all_fields
+        return json.dumps(payload)
+
+    def _split_dataset_string(self, dataset):
+        if dataset is None:
+            raise ValueError("A dataset must be specified")
+        if "/" in dataset:
+            self.validate_dataset_string(dataset)
+            owner_slug, dataset_slug = dataset.split("/", 1)
+        else:
+            owner_slug = self.get_config_value(self.CONFIG_NAME_USER)
+            dataset_slug = dataset
+        return owner_slug, dataset_slug
 
     def dataset_download_file(self, dataset, file_name, path=None, force=False, quiet=True, licenses=[]):
         """Download a single file for a dataset.
@@ -6525,3 +6572,30 @@ def attributes(obj):
 
 def print_attributes(obj):
     pprint(attributes(obj))
+
+
+def _parse_format(format_value):
+    """Parses a ``--format`` value modeled after gcloud.
+
+    Returns a tuple ``(format_name, fields)`` where ``fields`` is a list of
+    selected field names (empty when no projection was provided). Examples:
+
+    >>> _parse_format("json")
+    ('json', [])
+    >>> _parse_format("json(current_version_number)")
+    ('json', ['current_version_number'])
+    >>> _parse_format("json(status, current_version_number)")
+    ('json', ['status', 'current_version_number'])
+    """
+    if format_value is None:
+        return None, []
+    value = format_value.strip()
+    paren = value.find("(")
+    if paren == -1:
+        return value, []
+    if not value.endswith(")"):
+        raise ValueError(f"Malformed --format value: {format_value!r}")
+    name = value[:paren].strip()
+    inner = value[paren + 1 : -1]
+    fields = [f.strip() for f in inner.split(",") if f.strip()]
+    return name, fields

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -2579,10 +2579,11 @@ class KaggleApi:
 
         Args:
             dataset_opt: an alternative to dataset
-            format: see :meth:`dataset_status`. ``None`` (default) keeps the
-                historic plain-text output containing only the status string;
-                pass ``"json"`` (optionally with field selection) to receive a
-                JSON payload.
+            format: optional output format forwarded to ``dataset_status``.
+                ``None`` (default) keeps the historic plain-text output
+                containing only the status string; pass ``"json"`` (optionally
+                with field selection like ``"json(current_version_number)"``)
+                to receive a JSON payload.
         """
         dataset = dataset or dataset_opt
         return self.dataset_status(dataset, format=format)

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -617,6 +617,13 @@ def parse_datasets(subparsers) -> None:
     parser_datasets_status_optional.add_argument(
         "-d", "--dataset", dest="dataset_opt", required=False, help=argparse.SUPPRESS
     )
+    parser_datasets_status_optional.add_argument(
+        "--format",
+        dest="format",
+        required=False,
+        default=None,
+        help=Help.param_dataset_status_format,
+    )
     parser_datasets_status._action_groups.append(parser_datasets_status_optional)
     parser_datasets_status.set_defaults(func=api.dataset_status_cli)
 
@@ -1611,6 +1618,12 @@ class Help(object):
         "File name, all files downloaded if not provided\n(use " '"kaggle datasets files -d <dataset>" to show options)'
     )
     param_dataset_version_notes = "Message describing the new version"
+    param_dataset_status_format = (
+        "Output format. Defaults to plain text containing only the status. "
+        "Use 'json' to emit a JSON object with the status and the current "
+        "version number. Field selection is supported gcloud-style, e.g. "
+        "'json(current_version_number)' or 'json(status,current_version_number)'."
+    )
     param_dataset_upfile = (
         "Folder for upload, containing data files and a "
         "special datasets-metadata.json file "

--- a/tests/test_dataset_status.py
+++ b/tests/test_dataset_status.py
@@ -92,6 +92,23 @@ class TestDatasetStatus(unittest.TestCase):
         )
 
         self.assertEqual(json.loads(result), {"current_version_number": 7})
+        # Field selection should skip the unrelated API call.
+        mock_kaggle.datasets.dataset_api_client.get_dataset_status.assert_not_called()
+        mock_kaggle.datasets.dataset_api_client.get_dataset.assert_called_once()
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_dataset_status_cli_format_json_status_only(self, mock_build):
+        mock_kaggle = _mock_kaggle_client("READY", 9)
+        mock_build.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_build.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = self.api.dataset_status_cli(
+            "owner/dataset-name", format="json(status)"
+        )
+
+        self.assertEqual(json.loads(result), {"status": "ready"})
+        mock_kaggle.datasets.dataset_api_client.get_dataset.assert_not_called()
+        mock_kaggle.datasets.dataset_api_client.get_dataset_status.assert_called_once()
 
     @patch.object(KaggleApi, "build_kaggle_client")
     def test_dataset_status_cli_format_json_multi_field_selection(self, mock_build):

--- a/tests/test_dataset_status.py
+++ b/tests/test_dataset_status.py
@@ -1,0 +1,151 @@
+# coding=utf-8
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+import sys
+
+sys.path.insert(0, "..")
+
+from kaggle.api.kaggle_api_extended import KaggleApi, _parse_format
+
+
+def _make_api():
+    api = KaggleApi.__new__(KaggleApi)
+    api.already_printed_version_warning = True
+    api.config_values = {"username": "owner"}
+    return api
+
+
+def _mock_kaggle_client(status_name, current_version_number):
+    mock_kaggle = MagicMock()
+    mock_status_response = MagicMock()
+    mock_status_response.status.name = status_name
+    mock_kaggle.datasets.dataset_api_client.get_dataset_status.return_value = mock_status_response
+
+    mock_dataset_response = MagicMock()
+    mock_dataset_response.current_version_number = current_version_number
+    mock_kaggle.datasets.dataset_api_client.get_dataset.return_value = mock_dataset_response
+    return mock_kaggle
+
+
+class TestDatasetStatus(unittest.TestCase):
+    """Tests for dataset_status() and dataset_status_cli() including --format support."""
+
+    def setUp(self):
+        self.api = _make_api()
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_dataset_status_returns_status_string(self, mock_build):
+        """Library function dataset_status() must continue returning just the
+        status string for backward compatibility with notebooks/scripts that
+        import the kaggle package."""
+        mock_kaggle = _mock_kaggle_client("READY", 3)
+        mock_build.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_build.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = self.api.dataset_status("owner/dataset-name")
+
+        self.assertEqual(result, "ready")
+        # Library helper must not call get_dataset; it should only fetch status.
+        mock_kaggle.datasets.dataset_api_client.get_dataset.assert_not_called()
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_dataset_status_cli_default_format_is_text_status_only(self, mock_build):
+        """Default CLI behavior is the historic text output containing only
+        the status (no version), for back-compat."""
+        mock_kaggle = _mock_kaggle_client("READY", 5)
+        mock_build.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_build.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = self.api.dataset_status_cli("owner/dataset-name")
+
+        self.assertEqual(result, "ready")
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_dataset_status_cli_uses_dataset_opt(self, mock_build):
+        mock_kaggle = _mock_kaggle_client("READY", 3)
+        mock_build.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_build.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = self.api.dataset_status_cli(None, dataset_opt="owner/dataset-name")
+
+        self.assertEqual(result, "ready")
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_dataset_status_cli_format_json(self, mock_build):
+        mock_kaggle = _mock_kaggle_client("READY", 3)
+        mock_build.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_build.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = self.api.dataset_status_cli("owner/dataset-name", format="json")
+
+        self.assertEqual(json.loads(result), {"status": "ready", "current_version_number": 3})
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_dataset_status_cli_format_json_field_selection(self, mock_build):
+        mock_kaggle = _mock_kaggle_client("PENDING", 7)
+        mock_build.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_build.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = self.api.dataset_status_cli(
+            "owner/dataset-name", format="json(current_version_number)"
+        )
+
+        self.assertEqual(json.loads(result), {"current_version_number": 7})
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_dataset_status_cli_format_json_multi_field_selection(self, mock_build):
+        mock_kaggle = _mock_kaggle_client("READY", 2)
+        mock_build.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_build.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = self.api.dataset_status_cli(
+            "owner/dataset-name", format="json(status, current_version_number)"
+        )
+
+        self.assertEqual(
+            json.loads(result), {"status": "ready", "current_version_number": 2}
+        )
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_dataset_status_cli_unknown_format_raises(self, mock_build):
+        with self.assertRaises(ValueError):
+            self.api.dataset_status_cli("owner/dataset-name", format="yaml")
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_dataset_status_cli_unknown_field_raises(self, mock_build):
+        mock_kaggle = _mock_kaggle_client("READY", 3)
+        mock_build.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_build.return_value.__exit__ = MagicMock(return_value=False)
+
+        with self.assertRaises(ValueError):
+            self.api.dataset_status_cli("owner/dataset-name", format="json(bogus)")
+
+    def test_dataset_status_raises_on_none(self):
+        with self.assertRaises(ValueError):
+            self.api.dataset_status(None)
+
+
+class TestParseFormat(unittest.TestCase):
+    def test_parse_format_plain(self):
+        self.assertEqual(_parse_format("json"), ("json", []))
+
+    def test_parse_format_single_field(self):
+        self.assertEqual(
+            _parse_format("json(current_version_number)"),
+            ("json", ["current_version_number"]),
+        )
+
+    def test_parse_format_multiple_fields_with_whitespace(self):
+        self.assertEqual(
+            _parse_format("json( status , current_version_number )"),
+            ("json", ["status", "current_version_number"]),
+        )
+
+    def test_parse_format_malformed_raises(self):
+        with self.assertRaises(ValueError):
+            _parse_format("json(status")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dataset_status.py
+++ b/tests/test_dataset_status.py
@@ -87,9 +87,7 @@ class TestDatasetStatus(unittest.TestCase):
         mock_build.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
         mock_build.return_value.__exit__ = MagicMock(return_value=False)
 
-        result = self.api.dataset_status_cli(
-            "owner/dataset-name", format="json(current_version_number)"
-        )
+        result = self.api.dataset_status_cli("owner/dataset-name", format="json(current_version_number)")
 
         self.assertEqual(json.loads(result), {"current_version_number": 7})
         # Field selection should skip the unrelated API call.
@@ -102,9 +100,7 @@ class TestDatasetStatus(unittest.TestCase):
         mock_build.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
         mock_build.return_value.__exit__ = MagicMock(return_value=False)
 
-        result = self.api.dataset_status_cli(
-            "owner/dataset-name", format="json(status)"
-        )
+        result = self.api.dataset_status_cli("owner/dataset-name", format="json(status)")
 
         self.assertEqual(json.loads(result), {"status": "ready"})
         mock_kaggle.datasets.dataset_api_client.get_dataset.assert_not_called()
@@ -116,13 +112,9 @@ class TestDatasetStatus(unittest.TestCase):
         mock_build.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
         mock_build.return_value.__exit__ = MagicMock(return_value=False)
 
-        result = self.api.dataset_status_cli(
-            "owner/dataset-name", format="json(status, current_version_number)"
-        )
+        result = self.api.dataset_status_cli("owner/dataset-name", format="json(status, current_version_number)")
 
-        self.assertEqual(
-            json.loads(result), {"status": "ready", "current_version_number": 2}
-        )
+        self.assertEqual(json.loads(result), {"status": "ready", "current_version_number": 2})
 
     @patch.object(KaggleApi, "build_kaggle_client")
     def test_dataset_status_cli_unknown_format_raises(self, mock_build):


### PR DESCRIPTION
Reviewers flagged that returning a tuple from `dataset_status()` breaks
back-compat for the tens of thousands of notebooks that import the
package. Per @rosbo's suggestion, keep the library function returning
just the status string and expose the version number through a new
gcloud-style `--format` flag (`json`, `json(current_version_number)`)
on the CLI instead.

Co-authored-by: kaggle-agent <kaggle-agent@users.noreply.github.com>

---

Task: [bovard-20260421235151-526d73b2](https://agents.dev.kaggle.net/tasks/bovard-20260421235151-526d73b2)
Context: https://chat.kaggle.net/kaggle/pl/t8x7spahciyymqygpicoeoq69c

