### PR TITLE
Add `kaggle benchmarks auth` command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ keywords = ["Kaggle", "API"]
 requires-python = ">= 3.11"
 dependencies = [
     "bleach",
-    "kagglesdk >= 0.1.19, < 1.0", # sync with kagglehub
+    "kagglesdk >= 0.1.20, < 1.0", # sync with kagglehub
     "python-slugify",
     "requests",
     "python-dateutil",

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -5891,7 +5891,7 @@ class KaggleApi:
             "MODEL_PROXY_EXPIRY_TIME": response.expiry_time.isoformat() + "Z" if response.expiry_time else "",
         }
 
-        masked_api_key = "***" + response.token[-6:] if len(response.token) > 6 else response.token
+        masked_api_key = "****************" + response.token[-4:] if len(response.token) > 4 else response.token
         print(f"The following environment variables will be written to {env_file}:\n")
         for key, value in env_vars.items():
             display_value = masked_api_key if key == "MODEL_PROXY_API_KEY" else value
@@ -5902,7 +5902,7 @@ class KaggleApi:
             if not self.confirmation(f"write these environment variables to {env_file}"):
                 return
 
-        with open(env_file, "w") as f:
+        with open(env_file, "a") as f:
             for key, value in env_vars.items():
                 f.write(f"{key}={value}\n")
 

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -166,6 +166,7 @@ from kagglesdk.models.types.model_api_service import (
     ApiListModelInstancesResponse,
 )
 from kagglesdk.models.types.model_enums import ListModelsOrderBy, ModelInstanceType, ModelFramework
+from kagglesdk.models.types.model_proxy_api_service import ApiCreateDefaultModelProxyTokenRequest
 from kagglesdk.models.types.model_types import Owner
 from kagglesdk.security.types.oauth_service import IntrospectTokenRequest
 from ..models.upload_file import UploadFile
@@ -5876,6 +5877,36 @@ class KaggleApi:
             raise ValueError(f"No @task decorators found in file {file}. The file must define at least one task.")
         if task not in task_names:
             raise ValueError(f"Task '{task}' not found in file {file}. Found tasks: {', '.join(task_names)}")
+
+    def benchmarks_auth_cli(self, no_confirm=False, env_file=".env"):
+        env_file = os.path.abspath(env_file)
+
+        with self.build_kaggle_client() as kaggle:
+            request = ApiCreateDefaultModelProxyTokenRequest()
+            response = kaggle.models.model_proxy_api_client.create_default_model_proxy_token(request)
+
+        env_vars = {
+            "MODEL_PROXY_URL": response.base_uri,
+            "MODEL_PROXY_API_KEY": response.token,
+            "MODEL_PROXY_EXPIRY_TIME": response.expiry_time.isoformat() + "Z" if response.expiry_time else "",
+        }
+
+        masked_api_key = "***" + response.token[-6:] if len(response.token) > 6 else response.token
+        print(f"The following environment variables will be written to {env_file}:\n")
+        for key, value in env_vars.items():
+            display_value = masked_api_key if key == "MODEL_PROXY_API_KEY" else value
+            print(f"  {key}={display_value}")
+        print()
+
+        if not no_confirm:
+            if not self.confirmation(f"write these environment variables to {env_file}"):
+                return
+
+        with open(env_file, "w") as f:
+            for key, value in env_vars.items():
+                f.write(f"{key}={value}\n")
+
+        print(f"Environment variables have been written to {env_file}.")
 
     def benchmarks_tasks_push_cli(self, task, file):
         if not os.path.isfile(file):

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -1090,6 +1090,22 @@ def parse_benchmarks(subparsers) -> None:
     subparsers_benchmarks.choices = Help.benchmarks_choices
 
     parse_benchmark_tasks(subparsers_benchmarks)
+    parse_benchmarks_auth(subparsers_benchmarks)
+
+
+def parse_benchmarks_auth(subparsers) -> None:
+    parser_auth = subparsers.add_parser(
+        "auth", formatter_class=argparse.RawTextHelpFormatter, help=Help.command_benchmarks_auth
+    )
+    parser_auth_optional = parser_auth._action_groups.pop()
+    parser_auth_optional.add_argument(
+        "-y", "--yes", dest="no_confirm", action="store_true", help=Help.param_yes
+    )
+    parser_auth_optional.add_argument(
+        "--env-file", dest="env_file", default=".env", help=Help.param_benchmarks_env_file
+    )
+    parser_auth._action_groups.append(parser_auth_optional)
+    parser_auth.set_defaults(func=api.benchmarks_auth_cli)
 
 
 def parse_benchmark_tasks(subparsers) -> None:
@@ -1253,7 +1269,7 @@ class Help(object):
     model_instances_choices = ["versions", "v", "get", "files", "list", "init", "create", "delete", "update"]
     model_instance_versions_choices = ["init", "create", "download", "delete", "files", "list"]
     files_choices = ["upload"]
-    benchmarks_choices = ["tasks", "t"]
+    benchmarks_choices = ["tasks", "t", "auth"]
     benchmarks_tasks_choices = ["push", "run"]
     config_choices = ["view", "set", "unset"]
     auth_choices = ["login", "print-access-token", "revoke"]
@@ -1336,6 +1352,7 @@ class Help(object):
     command_models_update = "Update a model"
 
     # Benchmarks commands
+    command_benchmarks_auth = "Fetch and persist Model Proxy credential information"
     command_benchmarks_tasks_push = "Create or update a task from a Python source file"
     command_benchmarks_tasks_run = "Run a task against model(s)"
 
@@ -1558,6 +1575,7 @@ class Help(object):
     param_files_upload_no_resume = "Whether to skip resumable uploads."
 
     # Benchmarks params
+    param_benchmarks_env_file = 'File to write environment variables to (default: .env)'
     param_benchmarks_task = "Task name"
     param_benchmarks_file = "Python source file containing the task definition"
     param_benchmarks_model = "Model slug(s) to run the task against"

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -1098,9 +1098,7 @@ def parse_benchmarks_auth(subparsers) -> None:
         "auth", formatter_class=argparse.RawTextHelpFormatter, help=Help.command_benchmarks_auth
     )
     parser_auth_optional = parser_auth._action_groups.pop()
-    parser_auth_optional.add_argument(
-        "-y", "--yes", dest="no_confirm", action="store_true", help=Help.param_yes
-    )
+    parser_auth_optional.add_argument("-y", "--yes", dest="no_confirm", action="store_true", help=Help.param_yes)
     parser_auth_optional.add_argument(
         "--env-file", dest="env_file", default=".env", help=Help.param_benchmarks_env_file
     )
@@ -1575,7 +1573,7 @@ class Help(object):
     param_files_upload_no_resume = "Whether to skip resumable uploads."
 
     # Benchmarks params
-    param_benchmarks_env_file = 'File to write environment variables to (default: .env)'
+    param_benchmarks_env_file = "File to write environment variables to (default: .env)"
     param_benchmarks_task = "Task name"
     param_benchmarks_file = "Python source file containing the task definition"
     param_benchmarks_model = "Model slug(s) to run the task against"

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -17,6 +17,7 @@ import pytest
 from requests.exceptions import HTTPError
 
 from kaggle.api.kaggle_api_extended import KaggleApi
+from kagglesdk.models.types.model_proxy_api_service import ApiCreateDefaultModelProxyTokenResponse
 from kagglesdk.benchmarks.types.benchmark_enums import (
     BenchmarkTaskVersionCreationState,
     BenchmarkTaskRunState,
@@ -404,3 +405,86 @@ class TestCliArgParsing:
     def test_parse_error(self, cmd):
         with pytest.raises(SystemExit):
             self._parse(cmd)
+
+    def test_parse_benchmarks_auth(self):
+        args = self._parse("benchmarks auth")
+        assert args.no_confirm is False
+        assert args.env_file == ".env"
+
+    def test_parse_benchmarks_auth_yes(self):
+        args = self._parse("benchmarks auth -y")
+        assert args.no_confirm is True
+
+    def test_parse_benchmarks_auth_env_file(self):
+        args = self._parse("benchmarks auth --env-file custom.env")
+        assert args.env_file == "custom.env"
+
+
+# ============================================================
+# Benchmarks Auth
+# ============================================================
+
+
+def _make_token_response(base_uri="https://mp-staging.kaggle.net/models/openapi",
+                         token="kaggle-benchmarks:cool-token",
+                         expiry_time=None):
+    from datetime import datetime
+    if expiry_time is None:
+        expiry_time = datetime(2026, 4, 17, 12, 0, 0)
+    response = ApiCreateDefaultModelProxyTokenResponse()
+    response.base_uri = base_uri
+    response.token = token
+    response.expiry_time = expiry_time
+    return response
+
+
+class TestBenchmarksAuth:
+    """Tests for ``kaggle benchmarks auth``."""
+
+    def test_writes_env_file_with_yes_flag(self, api, capsys, tmp_path):
+        api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.return_value = (
+            _make_token_response()
+        )
+        env_file = str(tmp_path / ".env")
+        api.benchmarks_auth_cli(no_confirm=True, env_file=env_file)
+        content = (tmp_path / ".env").read_text()
+        assert "MODEL_PROXY_URL=https://mp-staging.kaggle.net/models/openapi\n" in content
+        assert "MODEL_PROXY_API_KEY=kaggle-benchmarks:cool-token\n" in content
+        assert "MODEL_PROXY_EXPIRY_TIME=2026-04-17T12:00:00Z\n" in content
+        out = capsys.readouterr().out
+        assert "MODEL_PROXY_API_KEY=***-token" in out
+        assert "kaggle-benchmarks:cool-token" not in out
+        assert "have been written to" in out
+
+    def test_aborted_on_no_confirm(self, api, capsys, tmp_path):
+        api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.return_value = (
+            _make_token_response()
+        )
+        env_file = str(tmp_path / ".env")
+        with patch("builtins.input", return_value="no"):
+            api.benchmarks_auth_cli(no_confirm=False, env_file=env_file)
+        assert not (tmp_path / ".env").exists()
+        out = capsys.readouterr().out
+        assert "MODEL_PROXY_URL" in out
+        assert "have been written to" not in out
+
+    def test_confirmed_on_yes(self, api, capsys, tmp_path):
+        api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.return_value = (
+            _make_token_response()
+        )
+        env_file = str(tmp_path / ".env")
+        with patch("builtins.input", return_value="yes"):
+            api.benchmarks_auth_cli(no_confirm=False, env_file=env_file)
+        assert (tmp_path / ".env").exists()
+        out = capsys.readouterr().out
+        assert "have been written to" in out
+
+    def test_custom_env_file(self, api, capsys, tmp_path):
+        api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.return_value = (
+            _make_token_response()
+        )
+        env_file = str(tmp_path / "custom.env")
+        api.benchmarks_auth_cli(no_confirm=True, env_file=env_file)
+        assert (tmp_path / "custom.env").exists()
+        out = capsys.readouterr().out
+        assert "custom.env" in out

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -425,10 +425,11 @@ class TestCliArgParsing:
 # ============================================================
 
 
-def _make_token_response(base_uri="https://mp-staging.kaggle.net/models/openapi",
-                         token="kaggle-benchmarks:cool-token",
-                         expiry_time=None):
+def _make_token_response(
+    base_uri="https://mp-staging.kaggle.net/models/openapi", token="kaggle-benchmarks:cool-token", expiry_time=None
+):
     from datetime import datetime
+
     if expiry_time is None:
         expiry_time = datetime(2026, 4, 17, 12, 0, 0)
     response = ApiCreateDefaultModelProxyTokenResponse()
@@ -452,7 +453,7 @@ class TestBenchmarksAuth:
         assert "MODEL_PROXY_API_KEY=kaggle-benchmarks:cool-token\n" in content
         assert "MODEL_PROXY_EXPIRY_TIME=2026-04-17T12:00:00Z\n" in content
         out = capsys.readouterr().out
-        assert "MODEL_PROXY_API_KEY=***-token" in out
+        assert "MODEL_PROXY_API_KEY=****************oken" in out
         assert "kaggle-benchmarks:cool-token" not in out
         assert "have been written to" in out
 
@@ -478,6 +479,17 @@ class TestBenchmarksAuth:
         assert (tmp_path / ".env").exists()
         out = capsys.readouterr().out
         assert "have been written to" in out
+
+    def test_appends_to_existing_file(self, api, capsys, tmp_path):
+        api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.return_value = (
+            _make_token_response()
+        )
+        env_file = tmp_path / ".env"
+        env_file.write_text("EXISTING_VAR=hello\n")
+        api.benchmarks_auth_cli(no_confirm=True, env_file=str(env_file))
+        content = env_file.read_text()
+        assert content.startswith("EXISTING_VAR=hello\n")
+        assert "MODEL_PROXY_URL=https://mp-staging.kaggle.net/models/openapi\n" in content
 
     def test_custom_env_file(self, api, capsys, tmp_path):
         api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.return_value = (


### PR DESCRIPTION
This command allows users to pull Model Proxy token credentials from the server and persist them into a local file (default `.env`).

```
$ kaggle benchmarks auth -h
usage: kaggle benchmarks auth [-h] [-y] [--env-file ENV_FILE]

options:
  -h, --help           show this help message and exit
  -y, --yes            Sets any confirmation values to "yes" automatically. Users will not be asked to confirm.
  --env-file ENV_FILE  File to write environment variables to (default: .env)
  ```