### PR TITLE
Add `kaggle benchmarks init` command

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -6102,20 +6102,21 @@ class KaggleApi:
 
     # -- Public CLI methods --
 
-    def benchmarks_auth_cli(self, no_confirm=False, env_file=".env"):
-        env_file = os.path.abspath(env_file)
-
+    def _fetch_model_proxy_env(self):
         with self.build_kaggle_client() as kaggle:
             request = ApiCreateDefaultModelProxyTokenRequest()
             response = kaggle.models.model_proxy_api_client.create_default_model_proxy_token(request)
-
-        env_vars = {
+        return {
             "MODEL_PROXY_URL": response.base_uri,
             "MODEL_PROXY_API_KEY": response.token,
             "MODEL_PROXY_EXPIRY_TIME": response.expiry_time.isoformat() + "Z" if response.expiry_time else "",
         }
 
-        masked_api_key = "****************" + response.token[-4:] if len(response.token) > 4 else response.token
+    def _write_benchmarks_env(self, env_vars, no_confirm, env_file):
+        env_file = os.path.abspath(env_file)
+        api_key = env_vars.get("MODEL_PROXY_API_KEY", "")
+        masked_api_key = "****************" + api_key[-4:] if len(api_key) > 4 else api_key
+
         print(f"The following environment variables will be written to {env_file}:\n")
         for key, value in env_vars.items():
             display_value = masked_api_key if key == "MODEL_PROXY_API_KEY" else value
@@ -6131,39 +6132,21 @@ class KaggleApi:
                 f.write(f"{key}={value}\n")
 
         print(f"Environment variables have been written to {env_file}.")
+
+    def benchmarks_auth_cli(self, no_confirm=False, env_file=".env"):
+        env_vars = self._fetch_model_proxy_env()
+        self._write_benchmarks_env(env_vars, no_confirm, env_file)
 
     def benchmarks_init_cli(self, no_confirm=False, env_file=".env"):
-        env_file = os.path.abspath(env_file)
-
-        with self.build_kaggle_client() as kaggle:
-            request = ApiCreateDefaultModelProxyTokenRequest()
-            response = kaggle.models.model_proxy_api_client.create_default_model_proxy_token(request)
-
-        env_vars = {
-            "MODEL_PROXY_URL": response.base_uri,
-            "MODEL_PROXY_API_KEY": response.token,
-            "MODEL_PROXY_EXPIRY_TIME": response.expiry_time.isoformat() + "Z" if response.expiry_time else "",
-            "LLM_DEFAULT": "google/gemini-3-flash-preview",
-            "LLM_DEFAULT_EVAL": "google/gemini-3-flash-preview",
-            "LLMS_AVAILABLE": "google/gemini-3-flash-preview,google/gemini-3.1-flash-lite-preview",
-        }
-
-        masked_api_key = "****************" + response.token[-4:] if len(response.token) > 4 else response.token
-        print(f"The following environment variables will be written to {env_file}:\n")
-        for key, value in env_vars.items():
-            display_value = masked_api_key if key == "MODEL_PROXY_API_KEY" else value
-            print(f"  {key}={display_value}")
-        print()
-
-        if not no_confirm:
-            if not self.confirmation(f"write these environment variables to {env_file}"):
-                return
-
-        with open(env_file, "a") as f:
-            for key, value in env_vars.items():
-                f.write(f"{key}={value}\n")
-
-        print(f"Environment variables have been written to {env_file}.")
+        env_vars = self._fetch_model_proxy_env()
+        env_vars.update(
+            {
+                "LLM_DEFAULT": "google/gemini-3-flash-preview",
+                "LLM_DEFAULT_EVAL": "google/gemini-3-flash-preview",
+                "LLMS_AVAILABLE": "google/gemini-3-flash-preview,google/gemini-3.1-flash-lite-preview",
+            }
+        )
+        self._write_benchmarks_env(env_vars, no_confirm, env_file)
 
     def benchmarks_tasks_push_cli(self, task, file, wait=None, poll_interval=10):
         if not os.path.isfile(file):

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -6132,6 +6132,39 @@ class KaggleApi:
 
         print(f"Environment variables have been written to {env_file}.")
 
+    def benchmarks_init_cli(self, no_confirm=False, env_file=".env"):
+        env_file = os.path.abspath(env_file)
+
+        with self.build_kaggle_client() as kaggle:
+            request = ApiCreateDefaultModelProxyTokenRequest()
+            response = kaggle.models.model_proxy_api_client.create_default_model_proxy_token(request)
+
+        env_vars = {
+            "MODEL_PROXY_URL": response.base_uri,
+            "MODEL_PROXY_API_KEY": response.token,
+            "MODEL_PROXY_EXPIRY_TIME": response.expiry_time.isoformat() + "Z" if response.expiry_time else "",
+            "LLM_DEFAULT": "google/gemini-3-flash-preview",
+            "LLM_DEFAULT_EVAL": "google/gemini-3-flash-preview",
+            "LLMS_AVAILABLE": "google/gemini-3-flash-preview,google/gemini-3.1-flash-lite-preview",
+        }
+
+        masked_api_key = "****************" + response.token[-4:] if len(response.token) > 4 else response.token
+        print(f"The following environment variables will be written to {env_file}:\n")
+        for key, value in env_vars.items():
+            display_value = masked_api_key if key == "MODEL_PROXY_API_KEY" else value
+            print(f"  {key}={display_value}")
+        print()
+
+        if not no_confirm:
+            if not self.confirmation(f"write these environment variables to {env_file}"):
+                return
+
+        with open(env_file, "a") as f:
+            for key, value in env_vars.items():
+                f.write(f"{key}={value}\n")
+
+        print(f"Environment variables have been written to {env_file}.")
+
     def benchmarks_tasks_push_cli(self, task, file, wait=None, poll_interval=10):
         if not os.path.isfile(file):
             raise ValueError(f"File {file} does not exist")

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -1440,7 +1440,9 @@ class Help(object):
 
     # Benchmarks commands
     command_benchmarks_auth = "Fetch and persist Model Proxy credential information"
-    command_benchmarks_init = "Fetch and persist  Model Proxy credentials and other Kaggle Benchmarks environment variables"
+    command_benchmarks_init = (
+        "Fetch and persist  Model Proxy credentials and other Kaggle Benchmarks environment variables"
+    )
     command_benchmarks_tasks_push = "Create or update a task from a Python source file"
     command_benchmarks_tasks_run = "Run a task against model(s)"
 

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -1091,6 +1091,7 @@ def parse_benchmarks(subparsers) -> None:
 
     parse_benchmark_tasks(subparsers_benchmarks)
     parse_benchmarks_auth(subparsers_benchmarks)
+    parse_benchmarks_init(subparsers_benchmarks)
 
 
 def parse_benchmarks_auth(subparsers) -> None:
@@ -1104,6 +1105,19 @@ def parse_benchmarks_auth(subparsers) -> None:
     )
     parser_auth._action_groups.append(parser_auth_optional)
     parser_auth.set_defaults(func=api.benchmarks_auth_cli)
+
+
+def parse_benchmarks_init(subparsers) -> None:
+    parser_init = subparsers.add_parser(
+        "init", formatter_class=argparse.RawTextHelpFormatter, help=Help.command_benchmarks_init
+    )
+    parser_init_optional = parser_init._action_groups.pop()
+    parser_init_optional.add_argument("-y", "--yes", dest="no_confirm", action="store_true", help=Help.param_yes)
+    parser_init_optional.add_argument(
+        "--env-file", dest="env_file", default=".env", help=Help.param_benchmarks_env_file
+    )
+    parser_init._action_groups.append(parser_init_optional)
+    parser_init.set_defaults(func=api.benchmarks_init_cli)
 
 
 def parse_benchmark_tasks(subparsers) -> None:
@@ -1342,7 +1356,7 @@ class Help(object):
     model_instances_choices = ["versions", "v", "get", "files", "list", "init", "create", "delete", "update"]
     model_instance_versions_choices = ["init", "create", "download", "delete", "files", "list"]
     files_choices = ["upload"]
-    benchmarks_choices = ["tasks", "t", "auth"]
+    benchmarks_choices = ["tasks", "t", "auth", "init"]
     benchmarks_tasks_choices = ["push", "run", "list", "status", "download", "models", "delete"]
     config_choices = ["view", "set", "unset"]
     auth_choices = ["login", "print-access-token", "revoke"]
@@ -1426,6 +1440,7 @@ class Help(object):
 
     # Benchmarks commands
     command_benchmarks_auth = "Fetch and persist Model Proxy credential information"
+    command_benchmarks_init = "Fetch and persist  Model Proxy credentials and other Kaggle Benchmarks environment variables"
     command_benchmarks_tasks_push = "Create or update a task from a Python source file"
     command_benchmarks_tasks_run = "Run a task against model(s)"
 

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -864,6 +864,19 @@ class TestCliArgParsing:
         args = self._parse("benchmarks auth --env-file custom.env")
         assert args.env_file == "custom.env"
 
+    def test_parse_benchmarks_init(self):
+        args = self._parse("benchmarks init")
+        assert args.no_confirm is False
+        assert args.env_file == ".env"
+
+    def test_parse_benchmarks_init_yes(self):
+        args = self._parse("benchmarks init -y")
+        assert args.no_confirm is True
+
+    def test_parse_benchmarks_init_env_file(self):
+        args = self._parse("benchmarks init --env-file custom.env")
+        assert args.env_file == "custom.env"
+
 
 # ============================================================
 # Benchmarks Auth
@@ -945,3 +958,50 @@ class TestBenchmarksAuth:
         assert (tmp_path / "custom.env").exists()
         out = capsys.readouterr().out
         assert "custom.env" in out
+
+
+# ============================================================
+# Benchmarks Init
+# ============================================================
+
+
+class TestBenchmarksInit:
+    """Tests for ``kaggle benchmarks init``."""
+
+    def test_writes_all_vars(self, api, capsys, tmp_path):
+        api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.return_value = (
+            _make_token_response()
+        )
+        env_file = str(tmp_path / ".env")
+        api.benchmarks_init_cli(no_confirm=True, env_file=env_file)
+        content = (tmp_path / ".env").read_text()
+        assert "MODEL_PROXY_URL=https://mp-staging.kaggle.net/models/openapi\n" in content
+        assert "MODEL_PROXY_API_KEY=kaggle-benchmarks:cool-token\n" in content
+        assert "MODEL_PROXY_EXPIRY_TIME=2026-04-17T12:00:00Z\n" in content
+        assert "LLM_DEFAULT=google/gemini-3-flash-preview\n" in content
+        assert "LLM_DEFAULT_EVAL=google/gemini-3-flash-preview\n" in content
+        assert "LLMS_AVAILABLE=google/gemini-3-flash-preview,google/gemini-3.1-flash-lite-preview\n" in content
+        out = capsys.readouterr().out
+        assert "MODEL_PROXY_API_KEY=****************oken" in out
+        assert "LLM_DEFAULT=google/gemini-3-flash-preview" in out
+        assert "have been written to" in out
+
+    def test_aborted_on_no_confirm(self, api, capsys, tmp_path):
+        api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.return_value = (
+            _make_token_response()
+        )
+        env_file = str(tmp_path / ".env")
+        with patch("builtins.input", return_value="no"):
+            api.benchmarks_init_cli(no_confirm=False, env_file=env_file)
+        assert not (tmp_path / ".env").exists()
+
+    def test_appends_to_existing_file(self, api, capsys, tmp_path):
+        api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.return_value = (
+            _make_token_response()
+        )
+        env_file = tmp_path / ".env"
+        env_file.write_text("EXISTING_VAR=hello\n")
+        api.benchmarks_init_cli(no_confirm=True, env_file=str(env_file))
+        content = env_file.read_text()
+        assert content.startswith("EXISTING_VAR=hello\n")
+        assert "LLM_DEFAULT=google/gemini-3-flash-preview\n" in content


### PR DESCRIPTION
Counterpart command to `kaggle benchmarks auth` that sets up additionally required environment variables for locally running the `benchmarks-sdk`

Behaves essentially the same as the `kaggle benchmarks auth` command.

