### PR TITLE
Add competitions topics and topic-messages CLI commands

### DIFF
--- a/docs/simulation_competitions.md
+++ b/docs/simulation_competitions.md
@@ -24,6 +24,30 @@ This lists the available pages (e.g., `description`, `rules`, `evaluation`, `dat
 kaggle competitions pages connectx --content
 ```
 
+You can also browse the competition's discussion forum to see what other participants are talking about — top strategies, common pitfalls, environment quirks. List the topics with:
+
+```bash
+kaggle competitions topics connectx
+```
+
+This prints a table of topics with `id`, `title`, `authorName`, `commentCount`, `votes`, and `postDate`. Sort and paginate with `-s/--sort-by` (one of `hot`, `top`, `new`, `recent`, `active`, `relevance`) and `-p/--page`:
+
+```bash
+kaggle competitions topics connectx -s top -p 1
+```
+
+To read the full discussion under a topic, pass the topic id to `topic-messages`:
+
+```bash
+kaggle competitions topic-messages connectx 12345
+```
+
+By default this returns the top 30 top-level messages (replies are flattened in-order beneath their parent). Use `-n -1` to fetch them all, or `-s` (one of `hot`, `new`, `old`, `top`) to change ordering:
+
+```bash
+kaggle competitions topic-messages connectx 12345 -s new -n -1
+```
+
 ## 2. Accept the Competition Rules
 
 Before you can submit or download data, you **must** accept the competition rules on the Kaggle website. Navigate to the competition page (e.g., `https://www.kaggle.com/competitions/connectx`) and click "Join Competition" or "I Understand and Accept".
@@ -126,6 +150,10 @@ Here's a typical workflow for iterating on a simulation competition agent:
 ```bash
 # Download competition data
 kaggle competitions download connectx -p connectx-data
+
+# Skim discussion topics for tips before iterating
+kaggle competitions topics connectx -s top
+kaggle competitions topic-messages connectx <topic-id>
 
 # Submit your agent (single file)
 kaggle competitions submit connectx -f main.py -m "v1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ keywords = ["Kaggle", "API"]
 requires-python = ">= 3.11"
 dependencies = [
     "bleach",
-    "kagglesdk >= 0.1.20, < 1.0", # sync with kagglehub
+    "kagglesdk >= 0.1.21, < 1.0", # sync with kagglehub
     "python-slugify",
     "requests",
     "python-dateutil",

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -93,6 +93,14 @@ from kagglesdk.competitions.types.competition_api_service import (
     ApiGetEpisodeAgentLogsRequest,
     ApiListCompetitionPagesRequest,
     ApiListCompetitionPagesResponse,
+    ApiListCompetitionTopicsRequest,
+    ApiListCompetitionTopicsResponse,
+    ApiListTopicMessagesRequest,
+    ApiListTopicMessagesResponse,
+)
+from kagglesdk.discussions.types.discussions_enums import (
+    CommentListSortBy,
+    TopicListSortBy,
 )
 from kagglesdk.competitions.types.competition_enums import (
     CompetitionListTab,
@@ -639,6 +647,10 @@ class KaggleApi:
     episode_fields = ["id", "createTime", "endTime", "state", "type"]
     episode_agent_fields = ["submissionId", "index", "reward", "state", "teamName", "teamId"]
     competition_page_fields = ["name"]
+    competition_topic_fields = ["id", "title", "authorName", "commentCount", "votes", "postDate"]
+    competition_topic_message_fields = ["id", "authorName", "postDate", "votes", "content"]
+    valid_topic_sort_by = ["hot", "top", "new", "recent", "active", "relevance"]
+    valid_comment_sort_by = ["hot", "new", "old", "top"]
 
     def __init__(self, enable_oauth: bool = False):
         self.enable_oauth = enable_oauth
@@ -1985,6 +1997,132 @@ class KaggleApi:
                 self.print_table(pages, fields)
         else:
             print("No pages found")
+
+    def competition_list_topics(self, competition: str, sort_by: Optional[str] = None, page: Optional[int] = None):
+        """List discussion topics for a competition.
+
+        Args:
+            competition (str): The competition name.
+            sort_by (Optional[str]): Sort order; one of valid_topic_sort_by.
+            page (Optional[int]): Page number (1-based).
+
+        Returns:
+            ApiListCompetitionTopicsResponse: response with topics and total_count.
+        """
+        with self.build_kaggle_client() as kaggle:
+            request = ApiListCompetitionTopicsRequest()
+            request.competition_name = competition
+            if sort_by:
+                if sort_by not in self.valid_topic_sort_by:
+                    raise ValueError("Invalid sort_by specified. Valid options are " + str(self.valid_topic_sort_by))
+                request.sort_by = TopicListSortBy["TOPIC_LIST_SORT_BY_" + sort_by.upper()]
+            if page is not None:
+                request.page = page
+            return kaggle.competitions.competition_api_client.list_competition_topics(request)
+
+    def competition_list_topics_cli(
+        self,
+        competition=None,
+        competition_opt=None,
+        sort_by=None,
+        page=None,
+        csv_display=False,
+        quiet=False,
+    ):
+        """CLI wrapper for competition_list_topics."""
+        competition = competition or competition_opt
+        if competition is None:
+            competition = self.get_config_value(self.CONFIG_NAME_COMPETITION)
+            if competition is not None and not quiet:
+                print("Using competition: " + competition)
+
+        if competition is None:
+            raise ValueError("No competition specified")
+
+        response = self.competition_list_topics(competition, sort_by=sort_by, page=page)
+        topics = response.topics
+        if topics:
+            fields = self.competition_topic_fields
+            if csv_display:
+                self.print_csv(topics, fields)
+            else:
+                self.print_table(topics, fields)
+        else:
+            print("No topics found")
+
+    def competition_list_topic_messages(
+        self,
+        competition: str,
+        topic_id: int,
+        sort_by: Optional[str] = None,
+        page_size: Optional[int] = None,
+    ):
+        """List messages within a competition discussion topic.
+
+        Args:
+            competition (str): The competition name.
+            topic_id (int): The topic id.
+            sort_by (Optional[str]): Sort order; one of valid_comment_sort_by.
+            page_size (Optional[int]): Max top-level messages to return; -1 for all.
+
+        Returns:
+            ApiListTopicMessagesResponse: response with the messages tree.
+        """
+        with self.build_kaggle_client() as kaggle:
+            request = ApiListTopicMessagesRequest()
+            request.competition_name = competition
+            request.topic_id = topic_id
+            if sort_by:
+                if sort_by not in self.valid_comment_sort_by:
+                    raise ValueError("Invalid sort_by specified. Valid options are " + str(self.valid_comment_sort_by))
+                request.sort_by = CommentListSortBy["COMMENT_LIST_SORT_BY_" + sort_by.upper()]
+            if page_size is not None:
+                request.page_size = page_size
+            return kaggle.competitions.competition_api_client.list_topic_messages(request)
+
+    def competition_list_topic_messages_cli(
+        self,
+        competition=None,
+        topic_id=None,
+        competition_opt=None,
+        sort_by=None,
+        page_size=None,
+        csv_display=False,
+        quiet=False,
+    ):
+        """CLI wrapper for competition_list_topic_messages."""
+        competition = competition or competition_opt
+        if competition is None:
+            competition = self.get_config_value(self.CONFIG_NAME_COMPETITION)
+            if competition is not None and not quiet:
+                print("Using competition: " + competition)
+
+        if competition is None:
+            raise ValueError("No competition specified")
+        if topic_id is None:
+            raise ValueError("No topic_id specified")
+
+        response = self.competition_list_topic_messages(
+            competition, int(topic_id), sort_by=sort_by, page_size=page_size
+        )
+        messages = self._flatten_topic_messages(response.messages)
+        if messages:
+            fields = self.competition_topic_message_fields
+            if csv_display:
+                self.print_csv(messages, fields)
+            else:
+                self.print_table(messages, fields)
+        else:
+            print("No messages found")
+
+    def _flatten_topic_messages(self, messages, depth=0):
+        """Flatten the nested replies tree into a single list, preserving order."""
+        flat = []
+        for m in messages or []:
+            flat.append(m)
+            if getattr(m, "replies", None):
+                flat.extend(self._flatten_topic_messages(m.replies, depth + 1))
+        return flat
 
     def dataset_list(
         self,

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -359,6 +359,76 @@ def parse_competitions(subparsers) -> None:
     parser_competitions_pages._action_groups.append(parser_competitions_pages_optional)
     parser_competitions_pages.set_defaults(func=api.competition_list_pages_cli)
 
+    # Competitions list discussion topics
+    parser_competitions_topics = subparsers_competitions.add_parser(
+        "topics", formatter_class=argparse.RawTextHelpFormatter, help=Help.command_competitions_topics
+    )
+    parser_competitions_topics_optional = parser_competitions_topics._action_groups.pop()
+    parser_competitions_topics_optional.add_argument(
+        "competition", nargs="?", default=None, help=Help.param_competition
+    )
+    parser_competitions_topics_optional.add_argument(
+        "-c", "--competition", dest="competition_opt", required=False, help=argparse.SUPPRESS
+    )
+    parser_competitions_topics_optional.add_argument(
+        "-s",
+        "--sort-by",
+        dest="sort_by",
+        required=False,
+        help="Sort order. One of: " + ", ".join(KaggleApi.valid_topic_sort_by),
+    )
+    parser_competitions_topics_optional.add_argument(
+        "-p", "--page", dest="page", type=int, required=False, help="Page number (1-based)"
+    )
+    parser_competitions_topics_optional.add_argument(
+        "-v", "--csv", dest="csv_display", action="store_true", help=Help.param_csv
+    )
+    parser_competitions_topics_optional.add_argument(
+        "-q", "--quiet", dest="quiet", action="store_true", help=Help.param_quiet
+    )
+    parser_competitions_topics._action_groups.append(parser_competitions_topics_optional)
+    parser_competitions_topics.set_defaults(func=api.competition_list_topics_cli)
+
+    # Competitions list messages within a topic
+    parser_competitions_topic_messages = subparsers_competitions.add_parser(
+        "topic-messages",
+        formatter_class=argparse.RawTextHelpFormatter,
+        help=Help.command_competitions_topic_messages,
+    )
+    parser_competitions_topic_messages_optional = parser_competitions_topic_messages._action_groups.pop()
+    parser_competitions_topic_messages_optional.add_argument(
+        "competition", nargs="?", default=None, help=Help.param_competition
+    )
+    parser_competitions_topic_messages_optional.add_argument(
+        "topic_id", nargs="?", default=None, type=int, help="The discussion topic id"
+    )
+    parser_competitions_topic_messages_optional.add_argument(
+        "-c", "--competition", dest="competition_opt", required=False, help=argparse.SUPPRESS
+    )
+    parser_competitions_topic_messages_optional.add_argument(
+        "-s",
+        "--sort-by",
+        dest="sort_by",
+        required=False,
+        help="Sort order. One of: " + ", ".join(KaggleApi.valid_comment_sort_by),
+    )
+    parser_competitions_topic_messages_optional.add_argument(
+        "-n",
+        "--page-size",
+        dest="page_size",
+        type=int,
+        required=False,
+        help="Max top-level messages to return; -1 for all",
+    )
+    parser_competitions_topic_messages_optional.add_argument(
+        "-v", "--csv", dest="csv_display", action="store_true", help=Help.param_csv
+    )
+    parser_competitions_topic_messages_optional.add_argument(
+        "-q", "--quiet", dest="quiet", action="store_true", help=Help.param_quiet
+    )
+    parser_competitions_topic_messages._action_groups.append(parser_competitions_topic_messages_optional)
+    parser_competitions_topic_messages.set_defaults(func=api.competition_list_topic_messages_cli)
+
 
 def parse_datasets(subparsers) -> None:
     parser_datasets = subparsers.add_parser(
@@ -1335,6 +1405,8 @@ class Help(object):
         "replay",
         "logs",
         "pages",
+        "topics",
+        "topic-messages",
     ]
     datasets_choices = ["list", "files", "download", "create", "version", "init", "metadata", "status", "delete"]
     kernels_choices = ["list", "files", "get", "init", "push", "pull", "output", "status", "logs", "update", "delete"]
@@ -1392,6 +1464,8 @@ class Help(object):
     command_competitions_episode_replay = "Download the replay for a simulation episode"
     command_competitions_episode_logs = "Download agent logs for a simulation episode"
     command_competitions_pages = "List pages for a competition"
+    command_competitions_topics = "List discussion topics for a competition"
+    command_competitions_topic_messages = "List messages within a competition discussion topic"
 
     # Datasets commands
     command_datasets_list = "List available datasets"

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -416,6 +416,39 @@ class TestKaggleApi(unittest.TestCase):
             if os.path.exists("tmp"):
                 os.rmdir("tmp")
 
+    def test_competition_i_topics(self):
+        try:
+            response = api.competition_list_topics(competition)
+            self.assertTrue(hasattr(response, "topics"))
+            self.assertTrue(hasattr(response, "total_count"))
+            topics = response.topics
+            self.assertIsInstance(topics, list)
+            self.assertGreaterEqual(response.total_count, 0)
+            if topics:
+                [self.assertTrue(hasattr(topics[0], api.camel_to_snake(f))) for f in api.competition_topic_fields]
+                self.competition_topic_id = topics[0].id
+            else:
+                self.competition_topic_id = None
+        except ApiException as e:
+            self.fail(f"competition_list_topics failed: {e}")
+
+    def test_competition_j_topic_messages(self):
+        if not getattr(self, "competition_topic_id", None):
+            self.test_competition_i_topics()
+        if not getattr(self, "competition_topic_id", None):
+            self.skipTest("No topics available to fetch messages from")
+        try:
+            response = api.competition_list_topic_messages(competition, self.competition_topic_id)
+            self.assertTrue(hasattr(response, "messages"))
+            self.assertIsInstance(response.messages, list)
+            if response.messages:
+                [
+                    self.assertTrue(hasattr(response.messages[0], api.camel_to_snake(f)))
+                    for f in api.competition_topic_message_fields
+                ]
+        except ApiException as e:
+            self.fail(f"competition_list_topic_messages failed: {e}")
+
     # Datasets
 
     def test_dataset_a_list(self):


### PR DESCRIPTION
Wires the new ListCompetitionTopics and ListTopicMessages public APIs (shipped in kagglesdk 0.1.21) into the CLI so users can browse a competition's discussion forum without leaving the terminal. Also bumps the kagglesdk floor to 0.1.21 and updates the simulation tutorial to showcase the new commands.