### PR TITLE
fix (cli): kaggle benchmark tasks

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -58,6 +58,7 @@ The Kaggle CLI is organized into several command groups:
 *   [Models](./models.md): Manage your Kaggle Models.
 *   [Model Variations](./model_variations.md): Manage variations of your Kaggle Models.
 *   [Model Variation Versions](./model_variations_versions.md): Manage versions of your Kaggle Model Variations.
+*   [Benchmarks](./benchmarks.md): Define evaluation tasks, run them against LLM models, and download results.
 *   [Configuration](./configuration.md): Configure the Kaggle CLI.
 
 ## Tutorials

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,337 @@
+# Benchmarks Commands
+
+Commands for interacting with Kaggle Benchmarks. Benchmarks let you define evaluation tasks as Python scripts, run them against one or more LLM models via the Kaggle Model Proxy, and download the results.
+
+The top-level command is `kaggle benchmarks` (alias: `kaggle b`), which has three sub-groups:
+
+*   **`auth`** — Fetch Model Proxy credentials.
+*   **`init`** — Fetch credentials and default environment variables for local development.
+*   **`tasks`** (alias: `t`) — Manage benchmark tasks (push, run, list, status, download, models, delete).
+
+## `kaggle benchmarks auth`
+
+Fetches a Model Proxy token and persists the credential environment variables to a file.
+
+**Usage:**
+
+```bash
+kaggle benchmarks auth [options]
+```
+
+**Options:**
+
+*   `-y, --yes`: Automatically confirm without prompting.
+*   `--env-file <FILE>`: File to write environment variables to (default: `.env`).
+
+**Example:**
+
+Write Model Proxy credentials to the default `.env` file, confirming automatically:
+
+```bash
+kaggle b auth -y
+```
+
+**Purpose:**
+
+This command fetches a short-lived Model Proxy API key and URL from Kaggle and appends them to your environment file. The variables written are:
+
+*   `MODEL_PROXY_URL`
+*   `MODEL_PROXY_API_KEY`
+*   `MODEL_PROXY_EXPIRY_TIME`
+
+## `kaggle benchmarks init`
+
+Fetches Model Proxy credentials **and** additional default environment variables useful for local benchmark development.
+
+**Usage:**
+
+```bash
+kaggle benchmarks init [options]
+```
+
+**Options:**
+
+*   `-y, --yes`: Automatically confirm without prompting.
+*   `--env-file <FILE>`: File to write environment variables to (default: `.env`).
+
+**Example:**
+
+Initialize a `.env` file with all benchmark environment variables:
+
+```bash
+kaggle b init -y --env-file my_project/.env
+```
+
+**Purpose:**
+
+In addition to the three credential variables written by `auth`, `init` also writes:
+
+*   `LLM_DEFAULT` — Default model slug for tasks.
+*   `LLM_DEFAULT_EVAL` — Default model slug for evaluation.
+*   `LLMS_AVAILABLE` — Comma-separated list of available model slugs.
+
+---
+
+## Tasks Commands
+
+All tasks commands live under `kaggle benchmarks tasks` (alias: `kaggle b t`).
+
+### `kaggle benchmarks tasks push`
+
+Creates or updates a benchmark task from a local Python source file. The file must contain at least one function decorated with `@task`.
+
+**Usage:**
+
+```bash
+kaggle benchmarks tasks push <TASK> -f <FILE> [options]
+```
+
+**Arguments:**
+
+*   `<TASK>`: Task name. Automatically normalized to a URL-safe slug (e.g., `my_task` or `My Task` becomes `my-task`).
+
+**Options:**
+
+*   `-f, --file <FILE>` *(required)*: Path to the source Python file defining the task.
+*   `--wait [TIMEOUT]`: Wait for the task creation to complete. Optionally specify a timeout in seconds (`0` or omit value = wait indefinitely).
+*   `--poll-interval <SECONDS>`: Seconds between status polls when using `--wait` (default: `10`).
+
+**Examples:**
+
+1.  Push a task and return immediately:
+
+    ```bash
+    kaggle b t push my-task -f benchmark.py
+    ```
+
+2.  Push a task and wait for creation to finish:
+
+    ```bash
+    kaggle b t push my-task -f benchmark.py --wait
+    ```
+
+3.  Push a task and wait with a 60-second timeout, polling every 5 seconds:
+
+    ```bash
+    kaggle b t push my-task -f benchmark.py --wait 60 --poll-interval 5
+    ```
+
+**Purpose:**
+
+This command reads a `.py` file, converts it to a Jupyter notebook format, and uploads it to Kaggle as a benchmark task. If a task with the same slug already exists, a new version is created. The file is validated to ensure it contains a `@task` decorator matching the given task name.
+
+---
+
+### `kaggle benchmarks tasks run`
+
+Runs a previously pushed task against one or more models.
+
+**Usage:**
+
+```bash
+kaggle benchmarks tasks run <TASK> [options]
+```
+
+**Arguments:**
+
+*   `<TASK>`: Task name (slug).
+
+**Options:**
+
+*   `-m, --model <MODEL> [MODEL ...]`: One or more model slugs to run against. If omitted, an interactive model picker is displayed.
+*   `--wait [TIMEOUT]`: Wait for runs to complete. Optionally specify a timeout in seconds (`0` or omit value = wait indefinitely).
+*   `--poll-interval <SECONDS>`: Seconds between status polls when using `--wait` (default: `10`).
+
+**Examples:**
+
+1.  Run a task with interactive model selection:
+
+    ```bash
+    kaggle b t run my-task
+    ```
+
+2.  Run a task against specific models:
+
+    ```bash
+    kaggle b t run my-task -m google/gemini-2.5-pro anthropic/claude-sonnet-4
+    ```
+
+3.  Run a task and wait for all runs to finish:
+
+    ```bash
+    kaggle b t run my-task -m google/gemini-2.5-pro --wait
+    ```
+
+**Purpose:**
+
+This command schedules benchmark runs on the server. The task must be in a `COMPLETED` creation state before it can be run. If no models are specified, the CLI presents a paginated list of available models for interactive selection.
+
+---
+
+### `kaggle benchmarks tasks list`
+
+Lists benchmark tasks owned by the current user.
+
+**Usage:**
+
+```bash
+kaggle benchmarks tasks list [options]
+```
+
+**Options:**
+
+*   `--name-regex <REGEX>`: Filter task names by regular expression.
+*   `--status <STATUS>`: Filter tasks by creation status. Valid values: `queued`, `running`, `completed`, `errored`.
+
+**Examples:**
+
+1.  List all your tasks:
+
+    ```bash
+    kaggle b t list
+    ```
+
+2.  List only completed tasks whose names contain "gemini":
+
+    ```bash
+    kaggle b t list --name-regex gemini --status completed
+    ```
+
+**Purpose:**
+
+Displays a table of your benchmark tasks showing the task slug, creation status, and creation timestamp.
+
+---
+
+### `kaggle benchmarks tasks status`
+
+Shows task details and per-model run status.
+
+**Usage:**
+
+```bash
+kaggle benchmarks tasks status <TASK> [options]
+```
+
+**Arguments:**
+
+*   `<TASK>`: Task name (slug).
+
+**Options:**
+
+*   `-m, --model <MODEL> [MODEL ...]`: Filter the run table to specific model slug(s).
+
+**Examples:**
+
+1.  Show full status for a task:
+
+    ```bash
+    kaggle b t status my-task
+    ```
+
+2.  Show status for specific models only:
+
+    ```bash
+    kaggle b t status my-task -m google/gemini-2.5-pro
+    ```
+
+**Purpose:**
+
+Prints the task's metadata (slug, creation status, creation time, URL) followed by a table of all runs. Each run row shows the model name, run state, start time, and end time. Any errored runs display their error messages below the table.
+
+---
+
+### `kaggle benchmarks tasks download`
+
+Downloads output files for completed benchmark runs.
+
+**Usage:**
+
+```bash
+kaggle benchmarks tasks download <TASK> [options]
+```
+
+**Arguments:**
+
+*   `<TASK>`: Task name (slug).
+
+**Options:**
+
+*   `-m, --model <MODEL> [MODEL ...]`: Download outputs only for specific model slug(s).
+*   `-o, --output <DIRECTORY>`: Directory to download output files into (defaults to current working directory).
+
+**Examples:**
+
+1.  Download all completed run outputs for a task:
+
+    ```bash
+    kaggle b t download my-task
+    ```
+
+2.  Download outputs for a specific model into a custom directory:
+
+    ```bash
+    kaggle b t download my-task -m google/gemini-2.5-pro -o ./results
+    ```
+
+**Purpose:**
+
+Downloads and extracts the output zip archive for each completed run. Files are organized in a hierarchical layout:
+
+```
+<output>/<task>/<model>/<run_id>/
+```
+
+Already-downloaded runs (where the output directory exists) are automatically skipped.
+
+---
+
+### `kaggle benchmarks tasks models`
+
+Lists all available benchmark models.
+
+**Usage:**
+
+```bash
+kaggle benchmarks tasks models
+```
+
+**Example:**
+
+```bash
+kaggle b t models
+```
+
+**Purpose:**
+
+Prints a table of all models available for benchmark runs, showing each model's slug and display name. This is useful for discovering valid model slugs to pass to `run`, `status`, or `download` commands.
+
+---
+
+### `kaggle benchmarks tasks delete`
+
+Removes a benchmark task.
+
+**Usage:**
+
+```bash
+kaggle benchmarks tasks delete <TASK> [options]
+```
+
+**Arguments:**
+
+*   `<TASK>`: Task name (slug).
+
+**Options:**
+
+*   `-y, --yes`: Automatically confirm deletion without prompting.
+
+**Example:**
+
+```bash
+kaggle b t delete my-task -y
+```
+
+**Purpose:**
+
+Deletes a benchmark task and all associated runs. **Note:** This command is not yet supported by the server.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -41,7 +41,7 @@ This command fetches a short-lived Model Proxy API key and URL from Kaggle and a
 
 ## `kaggle benchmarks init`
 
-Fetches Model Proxy credentials **and** additional default environment variables useful for local benchmark development.
+Fetches Model Proxy credentials **and** additional default environment variables useful for local benchmark development. Also generates a starter example task file and a syntax reference document.
 
 **Usage:**
 
@@ -53,14 +53,21 @@ kaggle benchmarks init [options]
 
 *   `-y, --yes`: Automatically confirm without prompting.
 *   `--env-file <FILE>`: File to write environment variables to (default: `.env`).
+*   `--example-file <FILE>`: File to write the example benchmark task to (default: `example_task.py`).
 
-**Example:**
+**Examples:**
 
-Initialize a `.env` file with all benchmark environment variables:
+1.  Initialize with defaults (writes `.env`, `example_task.py`, and `kaggle_benchmarks_reference.md`):
 
-```bash
-kaggle b init -y --env-file my_project/.env
-```
+    ```bash
+    kaggle b init -y
+    ```
+
+2.  Initialize with a custom env file and example file:
+
+    ```bash
+    kaggle b init -y --env-file my_project/.env --example-file my_project/my_task.py
+    ```
 
 **Purpose:**
 
@@ -69,6 +76,13 @@ In addition to the three credential variables written by `auth`, `init` also wri
 *   `LLM_DEFAULT` — Default model slug for tasks.
 *   `LLM_DEFAULT_EVAL` — Default model slug for evaluation.
 *   `LLMS_AVAILABLE` — Comma-separated list of available model slugs.
+
+`init` also creates two files alongside the example file:
+
+*   **`example_task.py`** (or custom name via `--example-file`) — A starter Python script demonstrating how to define a benchmark task using `@task` decorators and the `kaggle_benchmarks` library.
+*   **`kaggle_benchmarks_reference.md`** — A syntax reference document for the `kaggle-benchmarks` task API.
+
+If either file already exists, it is skipped without overwriting.
 
 ---
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,4 +20,5 @@ kaggle-cli documentation
    models
    model_instances
    model_instances_versions
+   benchmarks
    tutorials

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -6684,9 +6684,18 @@ class KaggleApi:
                 outdir = os.path.join(output, f"{slug}_{r.id}")
                 zipfile_path = outdir + ".zip"
                 self.download_file(response, zipfile_path, kaggle.http_client(), quiet=False)
-                # Extract the zip archive into the output directory
-                with zipfile.ZipFile(zipfile_path, "r") as zf:
-                    zf.extractall(outdir)
+                # Extract the zip archive into the output directory.
+                # Note: extractall() is safe here because the zip originates from
+                # the trusted Kaggle server, not user-supplied input (zip-slip).
+                try:
+                    with zipfile.ZipFile(zipfile_path, "r") as zf:
+                        zf.extractall(outdir)
+                except zipfile.BadZipFile:
+                    print(
+                        f"Warning: Downloaded file for {slug} (run {r.id}) is not a valid zip archive. "
+                        f"The raw file has been kept at {zipfile_path}."
+                    )
+                    continue
                 os.remove(zipfile_path)
                 print(f"Downloaded output for {slug} to {outdir}")
 

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -3364,9 +3364,7 @@ class KaggleApi:
                         else:
                             remaining = ""
                         if retry_count > 0:
-                            print(
-                                f"Retry {retry_count}/{max_retries}: Resuming from {size_read} bytes{remaining}..."
-                            )
+                            print(f"Retry {retry_count}/{max_retries}: Resuming from {size_read} bytes{remaining}...")
                         else:
                             print(f"Resuming from {size_read} bytes{remaining}...")
 
@@ -6271,11 +6269,7 @@ class KaggleApi:
                         None,
                     )
                     # Check first positional arg: @task("...")
-                    if (
-                        name is None
-                        and decorator.args
-                        and isinstance(decorator.args[0], ast.Constant)
-                    ):
+                    if name is None and decorator.args and isinstance(decorator.args[0], ast.Constant):
                         name = decorator.args[0].value
 
                 task_names.append(str(name) if name else node.name.title().replace("_", " "))
@@ -6339,8 +6333,9 @@ class KaggleApi:
         if models:
             model_set = set(models)
             runs = [
-                r for r in runs if r.model_version_slug in model_set
-                or r.model_version_slug.split("/")[-1] in model_set
+                r
+                for r in runs
+                if r.model_version_slug in model_set or r.model_version_slug.split("/")[-1] in model_set
                 # TODO(dolaameng): Remove this fallback once the server returns
                 # BenchmarkModelVersion.Slug (e.g. "claude-sonnet-4-6-default")
                 # instead of ModelProxySlug (e.g. "anthropic/claude-sonnet-4-6@default")

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -3321,7 +3321,8 @@ class KaggleApi:
             os.makedirs(outpath)
 
         # Get file metadata
-        size = int(response.headers["Content-Length"])
+        content_length = response.headers.get("Content-Length")
+        size = int(content_length) if content_length is not None else None
         last_modified = response.headers.get("Last-Modified")
         if last_modified is None:
             remote_date = datetime.now()
@@ -3352,18 +3353,22 @@ class KaggleApi:
                     size_read = os.path.getsize(outfile) if file_exists else 0
                     open_mode = "ab"
 
-                    if size_read >= size:
+                    if size is not None and size_read >= size:
                         if not quiet:
                             print("File already downloaded completely.")
                         return
 
                     if not quiet:
+                        if size is not None:
+                            remaining = f" ({size - size_read} bytes left)"
+                        else:
+                            remaining = ""
                         if retry_count > 0:
                             print(
-                                f"Retry {retry_count}/{max_retries}: Resuming from {size_read} bytes ({size - size_read} bytes left)..."
+                                f"Retry {retry_count}/{max_retries}: Resuming from {size_read} bytes{remaining}..."
                             )
                         else:
-                            print(f"Resuming from {size_read} bytes ({size - size_read} bytes left)...")
+                            print(f"Resuming from {size_read} bytes{remaining}...")
 
                     # Request with Range header for resume, preserving authentication
                     retry_headers = original_headers.copy()
@@ -3412,13 +3417,14 @@ class KaggleApi:
 
                 os.utime(outfile, times=(remote_date_timestamp, remote_date_timestamp))
 
-                # Verify file size
-                final_size = os.path.getsize(outfile)
-                if final_size != size:
-                    error_msg = f"Downloaded file size ({final_size}) does not match expected size ({size})"
-                    if not quiet:
-                        print(f"\n{error_msg}")
-                    raise ValueError(error_msg)
+                # Verify file size (only when Content-Length was provided)
+                if size is not None:
+                    final_size = os.path.getsize(outfile)
+                    if final_size != size:
+                        error_msg = f"Downloaded file size ({final_size}) does not match expected size ({size})"
+                        if not quiet:
+                            print(f"\n{error_msg}")
+                        raise ValueError(error_msg)
 
                 # Success - exit retry loop
                 break
@@ -6680,9 +6686,14 @@ class KaggleApi:
                 slug = self._short_model_slug(r.model_version_slug)
                 print(f"Downloading output for run {r.id} ({slug})...")
                 response = kaggle.benchmarks.benchmark_tasks_api_client.download_benchmark_task_run_output(dl_request)
-                outfile = os.path.join(output, f"{slug}_{r.id}")
-                self.download_file(response, outfile, kaggle.http_client(), quiet=False)
-                print(f"Downloaded output for {slug} to {outfile}")
+                outdir = os.path.join(output, f"{slug}_{r.id}")
+                zipfile_path = outdir + ".zip"
+                self.download_file(response, zipfile_path, kaggle.http_client(), quiet=False)
+                # Extract the zip archive into the output directory
+                with zipfile.ZipFile(zipfile_path, "r") as zf:
+                    zf.extractall(outdir)
+                os.remove(zipfile_path)
+                print(f"Downloaded output for {slug} to {outdir}")
 
     def benchmarks_tasks_models_cli(self):
         """List all available benchmark models."""

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -6234,13 +6234,44 @@ class KaggleApi:
             )
 
     @staticmethod
+    def _strip_ipython_magics(source: str) -> str:
+        """Remove IPython/Jupyter magic lines so ast.parse() can handle them.
+
+        Replaces magic lines with blank lines to preserve line numbers for
+        accurate AST node positions.  Handles cell magics (%%cmd), line
+        magics (%cmd), and shell escapes (!cmd).
+        """
+        import re
+
+        def _to_blank_lines(m: re.Match) -> str:
+            """Replace matched content with the same number of newlines."""
+            return "\n" * m.group().count("\n")
+
+        # Cell magics: %%magic ... spanning to the next blank line or EOF.
+        source = re.sub(
+            r"^[ \t]*%%\w[^\n]*\n(?:[ \t]*\S[^\n]*\n)*",
+            _to_blank_lines,
+            source,
+            flags=re.MULTILINE,
+        )
+        # Line magics (%cmd ...) and shell escapes (!cmd ...).
+        source = re.sub(
+            r"^[ \t]*(?:%(?!%)|!)\w[^\n]*$",
+            "",
+            source,
+            flags=re.MULTILINE,
+        )
+        return source
+
+    @staticmethod
     def _get_task_names_from_file(file_content: str) -> List[str]:
         """Extract task names from a Python file."""
         import ast
 
         task_names: list[str] = []
+        cleaned = KaggleApi._strip_ipython_magics(file_content)
         try:
-            tree = ast.parse(file_content)
+            tree = ast.parse(cleaned)
         except SyntaxError:
             return []
 
@@ -6290,6 +6321,24 @@ class KaggleApi:
         slugified_names = {slugify(n): n for n in task_names}
         if task_slug not in slugified_names:
             raise ValueError(f"Task '{task}' not found in file {file}. Found tasks: {', '.join(task_names)}")
+
+    @staticmethod
+    def _convert_py_to_notebook(source: str) -> str:
+        """Convert a percent-format .py file to .ipynb JSON string."""
+        import jupytext
+
+        notebook = jupytext.reads(source, fmt="py:percent")
+        notebook.metadata["kernelspec"] = {
+            "display_name": "Python 3",
+            "language": "python",
+            "name": "python3",
+        }
+        return jupytext.writes(notebook, fmt="ipynb")
+
+    @staticmethod
+    def _full_task_url(url: str) -> str:
+        """Ensure a task URL is absolute."""
+        return f"https://www.kaggle.com{url}" if url.startswith("/") else url
 
     # -- Instance helpers (API calls) --
 
@@ -6526,12 +6575,9 @@ class KaggleApi:
         if not file.endswith(".py"):
             raise ValueError(f"File {file} must be a .py file")
 
-        with open(file) as f:
-            content = f.read()
-
+        content = open(file).read()
         self._validate_task_in_file(task, file, content)
 
-        # Normalize the user-supplied task name into a URL-safe slug.
         task_slug = slugify(task)
         if task_slug != task:
             print(
@@ -6540,22 +6586,20 @@ class KaggleApi:
                 file=sys.stderr,
             )
 
-        # Convert .py file with percent delimiters to .ipynb
-        import jupytext
-
-        notebook = jupytext.reads(content, fmt="py:percent")
-        # Add kernelspec metadata so papermill can execute it on the server
-        notebook.metadata["kernelspec"] = {
-            "display_name": "Python 3",
-            "language": "python",
-            "name": "python3",
-        }
-        notebook_content = jupytext.writes(notebook, fmt="ipynb")
+        notebook_content = self._convert_py_to_notebook(content)
 
         with self.build_kaggle_client() as kaggle:
+            # If a previous push is still being created, wait or error.
             task_info = self._get_benchmark_task(task_slug, kaggle, allow_not_found=True)
             if task_info and task_info.creation_state in self._PENDING_CREATION_STATES:
-                raise ValueError(f"Task '{task_slug}' is currently being created (pending). Cannot push now.")
+                if wait is None:
+                    raise ValueError(
+                        f"Task '{task_slug}' is currently being created (pending). Cannot push now. "
+                        f"Use --wait to monitor the existing creation."
+                    )
+                print(f"Task '{task_slug}' is already being created. Waiting for it to finish...")
+                self._poll_task_creation(kaggle, task_slug, wait, poll_interval)
+                print(f"Pushing new version of '{task_slug}'...")
 
             request = ApiCreateBenchmarkTaskRequest()
             request.slug = task_slug
@@ -6565,10 +6609,9 @@ class KaggleApi:
             error = getattr(response, "error_message", None) or getattr(response, "errorMessage", None)
             if error:
                 raise ValueError(f"Failed to push task: {error}")
+
+            url = self._full_task_url(response.url)
             print(f"Task '{task_slug}' pushed.")
-            url = response.url
-            if url.startswith("/"):
-                url = "https://www.kaggle.com" + url
             print(f"\033[1mTask URL: {url}\033[0m")
             print(f"To run this task against models, use: kaggle b t run {task_slug}")
 
@@ -6654,9 +6697,7 @@ class KaggleApi:
             print(f"Created:  {self._format_time(task_info.create_time)}")
             url = getattr(task_info, "url", None)
             if url:
-                if url.startswith("/"):
-                    url = "https://www.kaggle.com" + url
-                print(f"\033[1mTask URL: {url}\033[0m")
+                print(f"\033[1mTask URL: {self._full_task_url(url)}\033[0m")
 
             runs = self._fetch_task_runs(kaggle, task, model)
 

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -6148,6 +6148,9 @@ class KaggleApi:
         BenchmarkTaskVersionCreationState.BENCHMARK_TASK_VERSION_CREATION_STATE_RUNNING,
     }
 
+    _TASK_CREATION_COMPLETED = BenchmarkTaskVersionCreationState.BENCHMARK_TASK_VERSION_CREATION_STATE_COMPLETED
+    _TASK_CREATION_ERRORED = BenchmarkTaskVersionCreationState.BENCHMARK_TASK_VERSION_CREATION_STATE_ERRORED
+
     # -- Static helpers --
 
     @staticmethod
@@ -6180,7 +6183,7 @@ class KaggleApi:
         while True:
             response = fetch_page(page_token)
             items.extend(get_items(response))
-            page_token = response.next_page_token or ""
+            page_token = getattr(response, "next_page_token", None) or ""
             if not page_token:
                 break
         return items
@@ -6251,7 +6254,6 @@ class KaggleApi:
         Note: jupytext's ``comment_magics`` only comments the magic line, not
         the cell body, so non-Python content still breaks ``ast.parse()``.
         """
-        import re
 
         def _to_blank_lines(m: re.Match) -> str:
             """Replace matched content with the same number of newlines."""
@@ -6267,7 +6269,7 @@ class KaggleApi:
         # Line magics (%cmd ...) and shell escapes (!cmd ...).
         source = re.sub(
             r"^[ \t]*(?:%(?!%)|!)\w[^\n]*$",
-            "",
+            _to_blank_lines,
             source,
             flags=re.MULTILINE,
         )
@@ -6386,7 +6388,7 @@ class KaggleApi:
             request.page_token = page_token
             return kaggle.benchmarks.benchmark_tasks_api_client.list_benchmark_task_runs(request)
 
-        runs = self._paginate(_fetch, lambda r: r.runs)
+        runs = self._paginate(_fetch, lambda r: r.runs or [])
 
         # Client-side filter as fallback since the server may ignore model_version_slugs.
         if models:
@@ -6589,7 +6591,8 @@ class KaggleApi:
         if not file.endswith(".py"):
             raise ValueError(f"File {file} must be a .py file")
 
-        content = open(file).read()
+        with open(file) as f:
+            content = f.read()
         self._validate_task_in_file(task, file, content)
 
         task_slug = slugify(task)
@@ -6641,12 +6644,10 @@ class KaggleApi:
         with self.build_kaggle_client() as kaggle:
             # Verify the task exists and is ready to run
             task_info = self._get_benchmark_task(task, kaggle)
-            COMPLETED = BenchmarkTaskVersionCreationState.BENCHMARK_TASK_VERSION_CREATION_STATE_COMPLETED
-            ERRORED = BenchmarkTaskVersionCreationState.BENCHMARK_TASK_VERSION_CREATION_STATE_ERRORED
             state = task_info.creation_state
-            if state != COMPLETED:
+            if state != self._TASK_CREATION_COMPLETED:
                 error_msg = f"Task '{task}' is not ready to run (status: {self._clean_enum_str(state)})."
-                if state == ERRORED:
+                if state == self._TASK_CREATION_ERRORED:
                     error_msg += f" Task Info: {task_info}."
                 error_msg += " Only completed tasks can be run."
                 raise ValueError(error_msg)
@@ -6724,9 +6725,12 @@ class KaggleApi:
             runs = self._fetch_task_runs(kaggle, task, model)
 
             if not runs:
-                model_hint = f" for model '{model}'" if isinstance(model, str) else ""
-                if model_hint == "" and model:
-                    model_hint = f" for models {model}"
+                if isinstance(model, str):
+                    model_hint = f" for model '{model}'"
+                elif model:
+                    model_hint = f" for models {', '.join(model)}"
+                else:
+                    model_hint = ""
                 print(f"No runs found for task '{task}'{model_hint}.")
                 print(f"Use 'kaggle b t run {task}' to start one.")
                 return

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -6240,6 +6240,9 @@ class KaggleApi:
         Replaces magic lines with blank lines to preserve line numbers for
         accurate AST node positions.  Handles cell magics (%%cmd), line
         magics (%cmd), and shell escapes (!cmd).
+
+        Note: jupytext's ``comment_magics`` only comments the magic line, not
+        the cell body, so non-Python content still breaks ``ast.parse()``.
         """
         import re
 
@@ -6457,8 +6460,8 @@ class KaggleApi:
                 return
             elif state not in self._PENDING_CREATION_STATES:
                 error_msg = f"Task '{task}' creation failed with status: {self._clean_enum_str(state)}"
-                if hasattr(task_info, "error_message") and task_info.error_message:
-                    error_msg += f" Error: {task_info.error_message}"
+                if error := getattr(task_info, "error_message", None):
+                    error_msg += f" Error: {error}"
                 raise ValueError(error_msg)
 
             print(f"  Task status: {self._clean_enum_str(state)}...")
@@ -6479,12 +6482,7 @@ class KaggleApi:
             if all_runs and all(r.state in self._TERMINAL_RUN_STATES for r in all_runs):
                 print("All runs completed:")
                 for r in all_runs:
-                    label = (
-                        "COMPLETED"
-                        if r.state == BenchmarkTaskRunState.BENCHMARK_TASK_RUN_STATE_COMPLETED
-                        else "ERRORED"
-                    )
-                    print(f"  {self._short_model_slug(r.model_version_slug)}: {label}")
+                    print(f"  {self._short_model_slug(r.model_version_slug)}: {self._clean_enum_str(r.state)}")
                 return
 
             pending = sum(1 for r in all_runs if r.state not in self._TERMINAL_RUN_STATES)
@@ -6581,8 +6579,8 @@ class KaggleApi:
         task_slug = slugify(task)
         if task_slug != task:
             print(
-                f"\033[1mWarning: task name '{task}' was normalized to slug '{task_slug}'. "
-                f"Use '{task_slug}' in future commands.\033[0m\n",
+                f"\n\033[1;33m⚠ Warning: task name '{task}' was normalized to slug '{task_slug}'.\033[0m\n"
+                f"\033[33m  Use '{task_slug}' in future commands.\033[0m\n",
                 file=sys.stderr,
             )
 
@@ -6627,15 +6625,12 @@ class KaggleApi:
         with self.build_kaggle_client() as kaggle:
             # Verify the task exists and is ready to run
             task_info = self._get_benchmark_task(task, kaggle)
-            if (
-                task_info.creation_state
-                != BenchmarkTaskVersionCreationState.BENCHMARK_TASK_VERSION_CREATION_STATE_COMPLETED
-            ):
-                error_msg = f"Task '{task}' is not ready to run (status: {task_info.creation_state})."
-                if (
-                    task_info.creation_state
-                    == BenchmarkTaskVersionCreationState.BENCHMARK_TASK_VERSION_CREATION_STATE_ERRORED
-                ):
+            COMPLETED = BenchmarkTaskVersionCreationState.BENCHMARK_TASK_VERSION_CREATION_STATE_COMPLETED
+            ERRORED = BenchmarkTaskVersionCreationState.BENCHMARK_TASK_VERSION_CREATION_STATE_ERRORED
+            state = task_info.creation_state
+            if state != COMPLETED:
+                error_msg = f"Task '{task}' is not ready to run (status: {self._clean_enum_str(state)})."
+                if state == ERRORED:
                     error_msg += f" Task Info: {task_info}."
                 error_msg += " Only completed tasks can be run."
                 raise ValueError(error_msg)
@@ -6676,16 +6671,13 @@ class KaggleApi:
         if status:
             request.status_filter = status
 
-        all_tasks = []
         with self.build_kaggle_client() as kaggle:
-            while True:
-                response = kaggle.benchmarks.benchmark_tasks_api_client.list_benchmark_tasks(request)
-                if response.tasks:
-                    all_tasks.extend(response.tasks)
-                if not getattr(response, "next_page_token", None):
-                    break
-                request.page_token = response.next_page_token
 
+            def _fetch(page_token):
+                request.page_token = page_token
+                return kaggle.benchmarks.benchmark_tasks_api_client.list_benchmark_tasks(request)
+
+            all_tasks = self._paginate(_fetch, lambda r: r.tasks or [])
             self._print_task_table(all_tasks)
 
     def benchmarks_tasks_status_cli(self, task, model=None):
@@ -6709,20 +6701,40 @@ class KaggleApi:
 
     def benchmarks_tasks_download_cli(self, task, model=None, output=None):
         task = slugify(task)
-        output = output or os.path.join(".", task, "output")
+        output = output or "."
 
         with self.build_kaggle_client() as kaggle:
+            self._get_benchmark_task(task, kaggle)
             runs = self._fetch_task_runs(kaggle, task, model)
 
-            for r in runs:
-                if r.state not in self._TERMINAL_RUN_STATES:
-                    continue
+            if not runs:
+                model_hint = f" for model '{model}'" if isinstance(model, str) else ""
+                if model_hint == "" and model:
+                    model_hint = f" for models {model}"
+                print(f"No runs found for task '{task}'{model_hint}.")
+                print(f"Use 'kaggle b t run {task}' to start one.")
+                return
+
+            downloadable = [r for r in runs if r.state in self._TERMINAL_RUN_STATES]
+            if not downloadable:
+                pending = len(runs)
+                print(f"No downloadable runs yet — {pending} run(s) still in progress.")
+                print(f"Use 'kaggle b t status {task}' to check progress.")
+                return
+
+            for r in downloadable:
                 dl_request = ApiDownloadBenchmarkTaskRunOutputRequest()
                 dl_request.run_id = r.id
                 slug = self._short_model_slug(r.model_version_slug)
+                # Hierarchical layout: {output}/{task}/{model}/{run_id}/
+                outdir = os.path.join(output, task, slug, str(r.id))
+
+                if os.path.isdir(outdir):
+                    print(f"Skipping {slug} (run {r.id}) — already downloaded to {outdir}")
+                    continue
+
                 print(f"Downloading output for run {r.id} ({slug})...")
                 response = kaggle.benchmarks.benchmark_tasks_api_client.download_benchmark_task_run_output(dl_request)
-                outdir = os.path.join(output, f"{slug}_{r.id}")
                 zipfile_path = outdir + ".zip"
                 self.download_file(response, zipfile_path, kaggle.http_client(), quiet=False)
                 # Extract the zip archive into the output directory.

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -6491,19 +6491,14 @@ class KaggleApi:
                 for r in all_runs:
                     print(f"  {self._short_model_slug(r.model_version_slug)}: {self._clean_enum_str(r.state)}")
 
-                errored = [
-                    r for r in all_runs
-                    if r.state == BenchmarkTaskRunState.BENCHMARK_TASK_RUN_STATE_ERRORED
-                ]
+                errored = [r for r in all_runs if r.state == BenchmarkTaskRunState.BENCHMARK_TASK_RUN_STATE_ERRORED]
                 if errored:
                     details = []
                     for r in errored:
                         slug = self._short_model_slug(r.model_version_slug)
                         msg = r.error_message.strip() if r.error_message else "No error message"
                         details.append(f"  [{slug}]\n    {msg}")
-                    raise ValueError(
-                        f"{len(errored)} run(s) failed:\n" + "\n".join(details)
-                    )
+                    raise ValueError(f"{len(errored)} run(s) failed:\n" + "\n".join(details))
                 return
 
             pending = sum(1 for r in all_runs if r.state not in self._TERMINAL_RUN_STATES)

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -6222,16 +6222,23 @@ class KaggleApi:
         sep = model_col + 15 + time_col + time_col
         print(f"{'Model':<{model_col}} {'Status':<15} {'Started':<{time_col}} {'Ended':<{time_col}}")
         print("-" * sep)
+        errors = []
         for r in runs:
-            error_suffix = ""
-            if r.state == BenchmarkTaskRunState.BENCHMARK_TASK_RUN_STATE_ERRORED and r.error_message:
-                error_suffix = f" | Error: {r.error_message}"
             slug = KaggleApi._short_model_slug(r.model_version_slug)
             print(
                 f"{slug:<{model_col}} {KaggleApi._clean_enum_str(r.state):<15} "
                 f"{KaggleApi._format_time(r.start_time):<{time_col}} {KaggleApi._format_time(r.end_time):<{time_col}}"
-                f"{error_suffix}"
             )
+            if r.state == BenchmarkTaskRunState.BENCHMARK_TASK_RUN_STATE_ERRORED and r.error_message:
+                errors.append((slug, r.error_message))
+
+        if errors:
+            print()
+            print(f"\033[1;31mErrors:\033[0m")
+            for slug, msg in errors:
+                print(f"\033[1;31m  [{slug}]\033[0m")
+                for line in msg.strip().splitlines():
+                    print(f"\033[31m    {line}\033[0m")
 
     @staticmethod
     def _strip_ipython_magics(source: str) -> str:
@@ -6323,7 +6330,7 @@ class KaggleApi:
         task_slug = slugify(task)
         slugified_names = {slugify(n): n for n in task_names}
         if task_slug not in slugified_names:
-            raise ValueError(f"Task '{task}' not found in file {file}. Found tasks: {', '.join(task_names)}")
+            raise ValueError(f"Task '{task}' not found in file {file}. Found tasks: {', '.join(slugified_names)}")
 
     @staticmethod
     def _convert_py_to_notebook(source: str) -> str:
@@ -6483,6 +6490,20 @@ class KaggleApi:
                 print("All runs completed:")
                 for r in all_runs:
                     print(f"  {self._short_model_slug(r.model_version_slug)}: {self._clean_enum_str(r.state)}")
+
+                errored = [
+                    r for r in all_runs
+                    if r.state == BenchmarkTaskRunState.BENCHMARK_TASK_RUN_STATE_ERRORED
+                ]
+                if errored:
+                    details = []
+                    for r in errored:
+                        slug = self._short_model_slug(r.model_version_slug)
+                        msg = r.error_message.strip() if r.error_message else "No error message"
+                        details.append(f"  [{slug}]\n    {msg}")
+                    raise ValueError(
+                        f"{len(errored)} run(s) failed:\n" + "\n".join(details)
+                    )
                 return
 
             pending = sum(1 for r in all_runs if r.state not in self._TERMINAL_RUN_STATES)

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -3322,7 +3322,7 @@ class KaggleApi:
 
         # Get file metadata
         content_length = response.headers.get("Content-Length")
-        size = int(content_length) if content_length is not None else None
+        size = int(content_length) if content_length else None
         last_modified = response.headers.get("Last-Modified")
         if last_modified is None:
             remote_date = datetime.now()

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -6255,6 +6255,7 @@ class KaggleApi:
 
                 name = None
                 if isinstance(decorator, ast.Call):
+                    # Check keyword: @task(name="...")
                     name = next(
                         (
                             k.value.value
@@ -6263,6 +6264,13 @@ class KaggleApi:
                         ),
                         None,
                     )
+                    # Check first positional arg: @task("...")
+                    if (
+                        name is None
+                        and decorator.args
+                        and isinstance(decorator.args[0], ast.Constant)
+                    ):
+                        name = decorator.args[0].value
 
                 task_names.append(str(name) if name else node.name.title().replace("_", " "))
 
@@ -6325,7 +6333,13 @@ class KaggleApi:
         if models:
             model_set = set(models)
             runs = [
-                r for r in runs if r.model_version_slug in model_set or r.model_version_slug.split("/")[-1] in model_set
+                r for r in runs if r.model_version_slug in model_set
+                or r.model_version_slug.split("/")[-1] in model_set
+                # TODO(dolaameng): Remove this fallback once the server returns
+                # BenchmarkModelVersion.Slug (e.g. "claude-sonnet-4-6-default")
+                # instead of ModelProxySlug (e.g. "anthropic/claude-sonnet-4-6@default")
+                # in ApiBenchmarkTaskRun.model_version_slug.
+                or r.model_version_slug.split("/")[-1].replace("@", "-") in model_set
             ]
 
         return runs
@@ -6557,7 +6571,9 @@ class KaggleApi:
             print(f"\033[1mTask URL: {url}\033[0m")
             print(f"To run this task against models, use: kaggle b t run {task_slug}")
 
-            if wait is not None:
+            if wait is None:
+                print(f"To check creation status, use: kaggle b t status {task_slug}")
+            else:
                 self._poll_task_creation(kaggle, task_slug, wait, poll_interval)
 
     def benchmarks_tasks_run_cli(self, task, model=None, wait=None, poll_interval=10):

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -1209,11 +1209,15 @@ def parse_benchmark_tasks(subparsers) -> None:
 
     # push
     parser_push = subparsers_tasks.add_parser(
-        "push", formatter_class=argparse.RawTextHelpFormatter, help=Help.command_benchmarks_tasks_push
+        "push",
+        formatter_class=argparse.RawTextHelpFormatter,
+        help=Help.command_benchmarks_tasks_push,
+        usage="%(prog)s [-h] task -f FILE [--wait [WAIT]] [--poll-interval POLL_INTERVAL]",
     )
     parser_push_optional = parser_push._action_groups.pop()
-    parser_push_optional.add_argument("task", help=Help.param_benchmarks_task)
-    parser_push_optional.add_argument("-f", "--file", dest="file", required=True, help=Help.param_benchmarks_file)
+    parser_push_required = parser_push.add_argument_group("required arguments")
+    parser_push_required.add_argument("task", help=Help.param_benchmarks_task)
+    parser_push_required.add_argument("-f", "--file", dest="file", required=True, help=Help.param_benchmarks_file)
     parser_push_optional.add_argument(
         "--wait",
         dest="wait",
@@ -1237,10 +1241,14 @@ def parse_benchmark_tasks(subparsers) -> None:
 
     # run
     parser_run = subparsers_tasks.add_parser(
-        "run", formatter_class=argparse.RawTextHelpFormatter, help=Help.command_benchmarks_tasks_run
+        "run",
+        formatter_class=argparse.RawTextHelpFormatter,
+        help=Help.command_benchmarks_tasks_run,
+        usage="%(prog)s [-h] task [-m MODEL [MODEL ...]] [--wait [WAIT]] [--poll-interval POLL_INTERVAL]",
     )
     parser_run_optional = parser_run._action_groups.pop()
-    parser_run_optional.add_argument("task", help=Help.param_benchmarks_task)
+    parser_run_required = parser_run.add_argument_group("required arguments")
+    parser_run_required.add_argument("task", help=Help.param_benchmarks_task)
     parser_run_optional.add_argument(
         "-m", "--model", dest="model", nargs="+", required=False, help=Help.param_benchmarks_model
     )

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -57,6 +57,14 @@ def api():
     return a
 
 
+@pytest.fixture
+def mock_token(api):
+    """Pre-wire the model proxy token response for auth/init tests."""
+    api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.return_value = (
+        _make_token_response()
+    )
+
+
 def _write_task_file(tmp_path, content=DEFAULT_TASK_CONTENT, name="task.py"):
     """Write *content* to a .py file under *tmp_path* and return its path str."""
     p = tmp_path / name
@@ -154,48 +162,34 @@ def _setup_available_models(api, slugs):
     api._mock_client.benchmarks.benchmarks_api_client.list_benchmark_models.return_value = resp
 
 
-def _setup_list_response(api, tasks, paginated_responses=None):
-    """Set up list tasks response.
+def _setup_paginated_response(mock, attr_name, items, paginated_responses=None):
+    """Wire up a paginated API mock.
 
     If *paginated_responses* is provided, it should be a list of
-    (tasks_list, next_page_token) tuples for multi-page scenarios.
-    Otherwise a single-page response is created from *tasks*.
+    (items_list, next_page_token) tuples for multi-page scenarios.
+    Otherwise a single-page response is created from *items*.
     """
     if paginated_responses:
         side_effects = []
-        for page_tasks, token in paginated_responses:
+        for page_items, token in paginated_responses:
             resp = MagicMock()
-            resp.tasks = page_tasks
+            setattr(resp, attr_name, page_items)
             resp.next_page_token = token
             side_effects.append(resp)
-        api._mock_benchmarks.list_benchmark_tasks.side_effect = side_effects
+        mock.side_effect = side_effects
     else:
         resp = MagicMock()
-        resp.tasks = tasks
+        setattr(resp, attr_name, items)
         resp.next_page_token = ""
-        api._mock_benchmarks.list_benchmark_tasks.return_value = resp
+        mock.return_value = resp
 
 
-def _setup_runs_response(api, runs, paginated_responses=None):
-    """Set up runs response.
+def _setup_list_response(api, tasks, **kwargs):
+    _setup_paginated_response(api._mock_benchmarks.list_benchmark_tasks, "tasks", tasks, **kwargs)
 
-    If *paginated_responses* is provided, it should be a list of
-    (runs_list, next_page_token) tuples for multi-page scenarios.
-    Otherwise a single-page response is created from *runs*.
-    """
-    if paginated_responses:
-        side_effects = []
-        for page_runs, token in paginated_responses:
-            resp = MagicMock()
-            resp.runs = page_runs
-            resp.next_page_token = token
-            side_effects.append(resp)
-        api._mock_benchmarks.list_benchmark_task_runs.side_effect = side_effects
-    else:
-        resp = MagicMock()
-        resp.runs = runs
-        resp.next_page_token = ""
-        api._mock_benchmarks.list_benchmark_task_runs.return_value = resp
+
+def _setup_runs_response(api, runs, **kwargs):
+    _setup_paginated_response(api._mock_benchmarks.list_benchmark_task_runs, "runs", runs, **kwargs)
 
 
 # ============================================================
@@ -580,6 +574,14 @@ class TestList:
         # No task rows
         assert "my-task" not in output
 
+    def test_list_none_tasks_field(self, api, capsys):
+        """Server may return None for the tasks field instead of []."""
+        _setup_list_response(api, None)
+        api.benchmarks_tasks_list_cli()
+        output = capsys.readouterr().out
+        assert "Task" in output
+        assert "my-task" not in output
+
     def test_list_table_format(self, api, capsys):
         """Table uses 40/20/20 column widths and 80-char separator."""
         _setup_list_response(api, [_make_task()])
@@ -684,8 +686,16 @@ class TestDownload:
 
     def _mock_download(self, api):
         """Mock download_file, zipfile.ZipFile, and os.remove for download tests."""
+        _setup_completed_task(api)
         api._mock_benchmarks.download_benchmark_task_run_output.return_value = MagicMock()
         api.download_file = MagicMock()
+
+    @pytest.mark.parametrize("status_code", [403, 404], ids=["forbidden", "not_found"])
+    def test_download_task_not_found(self, api, status_code):
+        """Download gives friendly error when task doesn't exist (403/404)."""
+        api._mock_benchmarks.get_benchmark_task.side_effect = HTTPError(response=MagicMock(status_code=status_code))
+        with pytest.raises(ValueError, match="not found"):
+            api.benchmarks_tasks_download_cli("no-such-task")
 
     def test_download_to_specific_output(self, api, capsys):
         _setup_runs_response(api, [_make_run()])
@@ -698,7 +708,7 @@ class TestDownload:
         assert "my_output_dir" in output
 
     def test_download_default_output_path(self, api, capsys):
-        """Default output directory is ./<task>/output; download_file gets .zip path."""
+        """Default output is ./{task}/{model}/{run_id}.zip."""
         _setup_runs_response(api, [_make_run(run_id=1)])
         self._mock_download(api)
         with patch("zipfile.ZipFile"), patch("os.remove"):
@@ -706,7 +716,7 @@ class TestDownload:
         # download_file receives the .zip path
         call_args = api.download_file.call_args
         zippath = call_args[0][1]
-        expected = os.path.join(".", "my-task", "output", "gemini-pro_1.zip")
+        expected = os.path.join(".", "my-task", "gemini-pro", "1.zip")
         assert zippath == expected
 
     def test_download_with_model_filter(self, api, capsys):
@@ -737,6 +747,48 @@ class TestDownload:
         assert "queued-model" not in output
         assert "running-model" not in output
 
+    def test_download_no_runs_shows_message(self, api, capsys):
+        """No runs at all prints a helpful message with run command hint."""
+        _setup_completed_task(api)
+        _setup_runs_response(api, [])
+        api.benchmarks_tasks_download_cli("my-task", model="nonexistent-model")
+        output = capsys.readouterr().out
+        assert "No runs found for task 'my-task'" in output
+        assert "kaggle b t run my-task" in output
+
+    def test_download_all_pending_shows_message(self, api, capsys):
+        """All runs still in progress prints a status hint."""
+        _setup_completed_task(api)
+        _setup_runs_response(
+            api,
+            [
+                _make_run(state=RUN_QUEUED, run_id=1),
+                _make_run(state=RUN_RUNNING, run_id=2),
+            ],
+        )
+        api.benchmarks_tasks_download_cli("my-task")
+        output = capsys.readouterr().out
+        assert "No downloadable runs yet" in output
+        assert "2 run(s) still in progress" in output
+        assert "kaggle b t status my-task" in output
+
+    def test_download_skips_existing_output(self, api, capsys, tmp_path):
+        """Already-downloaded runs are skipped without making API calls."""
+        _setup_runs_response(api, [_make_run(run_id=42)])
+        self._mock_download(api)
+        outdir = str(tmp_path / "out")
+        # Pre-create the output directory to simulate a previous download
+        existing = os.path.join(outdir, "my-task", "gemini-pro", "42")
+        os.makedirs(existing)
+
+        api.benchmarks_tasks_download_cli("my-task", output=outdir)
+
+        output = capsys.readouterr().out
+        assert "Skipping gemini-pro (run 42)" in output
+        assert "already downloaded" in output
+        # No download API call should have been made
+        api._mock_benchmarks.download_benchmark_task_run_output.assert_not_called()
+
     def test_download_includes_errored_runs(self, api, capsys):
         """ERRORED runs are also downloadable per spec."""
         _setup_runs_response(api, [_make_run(state=RUN_ERRORED)])
@@ -762,11 +814,12 @@ class TestDownload:
 
     def test_download_extracts_zip_and_cleans_up(self, api, capsys, tmp_path):
         """Download extracts zip into a directory and removes the zip file."""
+        _setup_completed_task(api)
         _setup_runs_response(api, [_make_run(run_id=42)])
         api._mock_benchmarks.download_benchmark_task_run_output.return_value = MagicMock()
 
         outdir = str(tmp_path / "out")
-        zip_path = os.path.join(outdir, "gemini-pro_42.zip")
+        zip_path = os.path.join(outdir, "my-task", "gemini-pro", "42.zip")
 
         # Make download_file create a real zip so extraction works
         def fake_download(response, outfile, http_client, quiet=False):
@@ -781,8 +834,8 @@ class TestDownload:
 
         api.benchmarks_tasks_download_cli("my-task", output=outdir)
 
-        # Verify extraction happened
-        extracted_dir = os.path.join(outdir, "gemini-pro_42")
+        # Verify extraction happened: {output}/{task}/{model}/{run_id}/
+        extracted_dir = os.path.join(outdir, "my-task", "gemini-pro", "42")
         assert os.path.isdir(extracted_dir)
         assert os.path.isfile(os.path.join(extracted_dir, "output.txt"))
         with open(os.path.join(extracted_dir, "output.txt")) as f:
@@ -810,6 +863,7 @@ class TestDownload:
 
     def test_download_bad_zip_keeps_file_and_continues(self, api, capsys, tmp_path):
         """Corrupt zip prints a warning, keeps the raw file, and continues."""
+        _setup_completed_task(api)
         _setup_runs_response(
             api,
             [
@@ -846,10 +900,10 @@ class TestDownload:
         output = capsys.readouterr().out
         # Bad zip: warning printed, raw file kept
         assert "not a valid zip archive" in output
-        bad_zip_path = os.path.join(outdir, "bad-model_10.zip")
+        bad_zip_path = os.path.join(outdir, "my-task", "bad-model", "10.zip")
         assert os.path.isfile(bad_zip_path)
         # Good zip: extracted successfully
-        good_dir = os.path.join(outdir, "good-model_11")
+        good_dir = os.path.join(outdir, "my-task", "good-model", "11")
         assert os.path.isdir(good_dir)
         assert os.path.isfile(os.path.join(good_dir, "result.txt"))
         assert "Downloaded output for good-model to" in output
@@ -913,6 +967,30 @@ class TestDownloadFile:
         api.download_file(resp, outfile, MagicMock(), quiet=True)
         # Should succeed without ValueError about size mismatch
         assert os.path.isfile(outfile)
+
+
+# ============================================================
+# Models
+# ============================================================
+
+
+class TestModels:
+    """``kaggle benchmarks tasks models``"""
+
+    def test_models_lists_available(self, api, capsys):
+        _setup_available_models(api, ["gemini-pro", "gemma-2b"])
+        api.benchmarks_tasks_models_cli()
+        output = capsys.readouterr().out
+        assert "Slug" in output
+        assert "Display Name" in output
+        assert "gemini-pro" in output
+        assert "gemma-2b" in output
+
+    def test_models_empty(self, api, capsys):
+        _setup_available_models(api, [])
+        api.benchmarks_tasks_models_cli()
+        output = capsys.readouterr().out
+        assert "No benchmark models available" in output
 
 
 # ============================================================
@@ -1087,10 +1165,7 @@ def _make_token_response(
 class TestBenchmarksAuth:
     """Tests for ``kaggle benchmarks auth``."""
 
-    def test_writes_env_file_with_yes_flag(self, api, capsys, tmp_path):
-        api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.return_value = (
-            _make_token_response()
-        )
+    def test_writes_env_file_with_yes_flag(self, api, mock_token, capsys, tmp_path):
         env_file = str(tmp_path / ".env")
         api.benchmarks_auth_cli(no_confirm=True, env_file=env_file)
         content = (tmp_path / ".env").read_text()
@@ -1102,10 +1177,7 @@ class TestBenchmarksAuth:
         assert "kaggle-benchmarks:cool-token" not in out
         assert "have been written to" in out
 
-    def test_aborted_on_no_confirm(self, api, capsys, tmp_path):
-        api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.return_value = (
-            _make_token_response()
-        )
+    def test_aborted_on_no_confirm(self, api, mock_token, capsys, tmp_path):
         env_file = str(tmp_path / ".env")
         with patch("builtins.input", return_value="no"):
             api.benchmarks_auth_cli(no_confirm=False, env_file=env_file)
@@ -1114,10 +1186,7 @@ class TestBenchmarksAuth:
         assert "MODEL_PROXY_URL" in out
         assert "have been written to" not in out
 
-    def test_confirmed_on_yes(self, api, capsys, tmp_path):
-        api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.return_value = (
-            _make_token_response()
-        )
+    def test_confirmed_on_yes(self, api, mock_token, capsys, tmp_path):
         env_file = str(tmp_path / ".env")
         with patch("builtins.input", return_value="yes"):
             api.benchmarks_auth_cli(no_confirm=False, env_file=env_file)
@@ -1125,10 +1194,7 @@ class TestBenchmarksAuth:
         out = capsys.readouterr().out
         assert "have been written to" in out
 
-    def test_appends_to_existing_file(self, api, capsys, tmp_path):
-        api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.return_value = (
-            _make_token_response()
-        )
+    def test_appends_to_existing_file(self, api, mock_token, capsys, tmp_path):
         env_file = tmp_path / ".env"
         env_file.write_text("EXISTING_VAR=hello\n")
         api.benchmarks_auth_cli(no_confirm=True, env_file=str(env_file))
@@ -1136,10 +1202,7 @@ class TestBenchmarksAuth:
         assert content.startswith("EXISTING_VAR=hello\n")
         assert "MODEL_PROXY_URL=https://mp-staging.kaggle.net/models/openapi\n" in content
 
-    def test_custom_env_file(self, api, capsys, tmp_path):
-        api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.return_value = (
-            _make_token_response()
-        )
+    def test_custom_env_file(self, api, mock_token, capsys, tmp_path):
         env_file = str(tmp_path / "custom.env")
         api.benchmarks_auth_cli(no_confirm=True, env_file=env_file)
         assert (tmp_path / "custom.env").exists()
@@ -1155,10 +1218,7 @@ class TestBenchmarksAuth:
 class TestBenchmarksInit:
     """Tests for ``kaggle benchmarks init``."""
 
-    def test_writes_all_vars(self, api, capsys, tmp_path):
-        api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.return_value = (
-            _make_token_response()
-        )
+    def test_writes_all_vars(self, api, mock_token, capsys, tmp_path):
         env_file = str(tmp_path / ".env")
         example_file = str(tmp_path / "example_task.py")
         api.benchmarks_init_cli(no_confirm=True, env_file=env_file, example_file=example_file)
@@ -1174,10 +1234,7 @@ class TestBenchmarksInit:
         assert "LLM_DEFAULT=google/gemini-3-flash-preview" in out
         assert "have been written to" in out
 
-    def test_writes_example_file(self, api, capsys, tmp_path):
-        api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.return_value = (
-            _make_token_response()
-        )
+    def test_writes_example_file(self, api, mock_token, capsys, tmp_path):
         env_file = str(tmp_path / ".env")
         example_file = str(tmp_path / "example_task.py")
         api.benchmarks_init_cli(no_confirm=True, env_file=env_file, example_file=example_file)
@@ -1187,10 +1244,7 @@ class TestBenchmarksInit:
         out = capsys.readouterr().out
         assert "Example benchmark task file has been written to" in out
 
-    def test_writes_reference_file(self, api, capsys, tmp_path):
-        api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.return_value = (
-            _make_token_response()
-        )
+    def test_writes_reference_file(self, api, mock_token, capsys, tmp_path):
         env_file = str(tmp_path / ".env")
         example_file = str(tmp_path / "example_task.py")
         api.benchmarks_init_cli(no_confirm=True, env_file=env_file, example_file=example_file)
@@ -1202,10 +1256,7 @@ class TestBenchmarksInit:
         assert "Syntax reference has been written to" in out
         assert "@kaggle_benchmarks_reference.md" in out
 
-    def test_skips_reference_file_if_exists(self, api, capsys, tmp_path):
-        api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.return_value = (
-            _make_token_response()
-        )
+    def test_skips_reference_file_if_exists(self, api, mock_token, capsys, tmp_path):
         ref_file = tmp_path / "kaggle_benchmarks_reference.md"
         ref_file.write_text("existing content\n")
         env_file = str(tmp_path / ".env")
@@ -1215,10 +1266,7 @@ class TestBenchmarksInit:
         out = capsys.readouterr().out
         assert "Reference file already exists" in out
 
-    def test_skips_example_file_if_exists(self, api, capsys, tmp_path):
-        api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.return_value = (
-            _make_token_response()
-        )
+    def test_skips_example_file_if_exists(self, api, mock_token, capsys, tmp_path):
         example_file = tmp_path / "example_task.py"
         example_file.write_text("existing content\n")
         env_file = str(tmp_path / ".env")
@@ -1227,30 +1275,21 @@ class TestBenchmarksInit:
         out = capsys.readouterr().out
         assert "already exists" in out
 
-    def test_custom_example_file(self, api, capsys, tmp_path):
-        api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.return_value = (
-            _make_token_response()
-        )
+    def test_custom_example_file(self, api, mock_token, capsys, tmp_path):
         env_file = str(tmp_path / ".env")
         example_file = str(tmp_path / "my_task.py")
         api.benchmarks_init_cli(no_confirm=True, env_file=env_file, example_file=example_file)
         content = (tmp_path / "my_task.py").read_text()
         assert "import kaggle_benchmarks as kbench" in content
 
-    def test_aborted_on_no_confirm(self, api, capsys, tmp_path):
-        api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.return_value = (
-            _make_token_response()
-        )
+    def test_aborted_on_no_confirm(self, api, mock_token, capsys, tmp_path):
         env_file = str(tmp_path / ".env")
         example_file = str(tmp_path / "example_task.py")
         with patch("builtins.input", return_value="no"):
             api.benchmarks_init_cli(no_confirm=False, env_file=env_file, example_file=example_file)
         assert not (tmp_path / ".env").exists()
 
-    def test_appends_to_existing_file(self, api, capsys, tmp_path):
-        api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.return_value = (
-            _make_token_response()
-        )
+    def test_appends_to_existing_file(self, api, mock_token, capsys, tmp_path):
         env_file = tmp_path / ".env"
         env_file.write_text("EXISTING_VAR=hello\n")
         example_file = str(tmp_path / "example_task.py")

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -291,12 +291,38 @@ class TestPush:
     # -- Server edge cases --
 
     @pytest.mark.parametrize("state", [QUEUED, RUNNING], ids=["queued", "running"])
-    def test_push_rejects_pending_task(self, api, tmp_path, state):
-        """Push rejects when the task version is still being created."""
+    def test_push_rejects_pending_task_without_wait(self, api, tmp_path, state):
+        """Push without --wait rejects when task is pending, with a --wait hint."""
         filepath = _write_task_file(tmp_path)
         api._mock_benchmarks.get_benchmark_task.return_value = _make_task(state=state)
-        with pytest.raises(ValueError, match="currently being created"):
+        with pytest.raises(ValueError, match="currently being created") as exc_info:
             _push(api, "my-task", filepath)
+        assert "--wait" in str(exc_info.value)
+
+    @pytest.mark.parametrize("state", [QUEUED, RUNNING], ids=["queued", "running"])
+    def test_push_wait_monitors_pending_then_pushes(self, api, capsys, tmp_path, state):
+        """Push --wait with a pending task waits for existing creation, then pushes new version."""
+        filepath = _write_task_file(tmp_path)
+        _setup_create_response(api, "my-task")
+
+        # Call 1: initial check → pending; Call 2: poll existing → completed;
+        # Call 3: poll new version after push → completed
+        api._mock_benchmarks.get_benchmark_task.side_effect = [
+            _make_task(state=state),
+            _make_task(state=COMPLETED),
+            _make_task(state=COMPLETED),
+        ]
+
+        jt, ctx = _mock_jupytext()
+        with ctx, patch("time.sleep"):
+            api.benchmarks_tasks_push_cli("my-task", filepath, wait=0)
+
+        output = capsys.readouterr().out
+        assert "already being created" in output
+        assert "Pushing new version of 'my-task'" in output
+        assert "Task 'my-task' pushed." in output
+        # Verify the create API was still called (new version pushed)
+        api._mock_benchmarks.create_benchmark_task.assert_called_once()
 
     def test_push_propagates_server_error(self, api, tmp_path):
         """Non-403/404 HTTP errors (e.g. 500) are re-raised, not swallowed."""
@@ -1277,6 +1303,18 @@ class TestGetTaskNamesFromFile:
             # keyword takes priority when both name= and positional could exist
             # (not valid Python for task(), but tests the keyword-first logic)
             ('@task("Pos", name="Kw")\ndef f(): pass\n', ["Kw"]),
+            # file with IPython line magic
+            ('!pip install numpy\n@task("t1")\ndef f(): pass\n', ["t1"]),
+            # file with cell magic and body
+            (
+                '%%writefile out.csv\n1,2,3\n4,5,6\n\n@task("t2")\ndef g(): pass\n',
+                ["t2"],
+            ),
+            # file with Jupytext cell markers (# %%) should NOT be stripped
+            (
+                '# %%\nimport os\n\n# %%\n@task("t3")\ndef h(): pass\n',
+                ["t3"],
+            ),
         ],
         ids=[
             "keyword_name",
@@ -1293,7 +1331,89 @@ class TestGetTaskNamesFromFile:
             "no_decorators",
             "unrelated_decorator",
             "keyword_over_positional",
+            "with_line_magic",
+            "with_cell_magic",
+            "with_jupytext_markers",
         ],
     )
     def test_task_name_detection(self, source, expected):
         assert KaggleApi._get_task_names_from_file(source) == expected
+
+
+# ============================================================
+# IPython Magic Stripping
+# ============================================================
+
+
+class TestStripIpythonMagics:
+    """Tests for ``_strip_ipython_magics`` static method."""
+
+    def test_strips_line_magic(self):
+        source = "%matplotlib inline\nimport os\n"
+        result = KaggleApi._strip_ipython_magics(source)
+        assert "%matplotlib" not in result
+        assert "import os" in result
+
+    def test_strips_shell_escape(self):
+        source = "!pip install numpy\nimport numpy\n"
+        result = KaggleApi._strip_ipython_magics(source)
+        assert "!pip" not in result
+        assert "import numpy" in result
+
+    def test_strips_cell_magic_with_body(self):
+        source = "%%writefile out.csv\n1,2,3\n4,5,6\n\nimport os\n"
+        result = KaggleApi._strip_ipython_magics(source)
+        assert "%%writefile" not in result
+        assert "1,2,3" not in result
+        assert "import os" in result
+
+    def test_preserves_jupytext_cell_markers(self):
+        """``# %%`` markers are NOT magics and must be preserved."""
+        source = "# %%\nimport os\n\n# %%\nx = 1\n"
+        result = KaggleApi._strip_ipython_magics(source)
+        assert result == source
+
+    def test_preserves_line_count(self):
+        """Stripped lines are replaced with blanks to keep line numbers stable."""
+        source = "!pip install foo\nimport os\n%%writefile a.txt\nhello\n\nx = 1\n"
+        assert source.count("\n") == KaggleApi._strip_ipython_magics(source).count("\n")
+
+    def test_mixed_magics_and_code(self):
+        """A realistic Jupytext percent-format file."""
+        source = (
+            "# %%\n"
+            "!pip install kaggle_benchmarks\n"
+            "\n"
+            "# %%\n"
+            "import kaggle_benchmarks as kb\n"
+            "\n"
+            "# %%\n"
+            '@kb.task("ask")\n'
+            "def my_task(llm):\n"
+            "    pass\n"
+            "\n"
+            "my_task.run(kb.llm)\n"
+            "\n"
+            "# %%\n"
+            "%%writefile a.csv\n"
+            "1,2,3\n"
+            "4,5,6\n"
+        )
+        result = KaggleApi._strip_ipython_magics(source)
+        # Code is preserved
+        assert "import kaggle_benchmarks" in result
+        assert '@kb.task("ask")' in result
+        assert "my_task.run" in result
+        # Magics are gone
+        assert "!pip" not in result
+        assert "%%writefile" not in result
+        assert "1,2,3" not in result
+        # Line count preserved
+        assert source.count("\n") == result.count("\n")
+
+    def test_empty_source(self):
+        assert KaggleApi._strip_ipython_magics("") == ""
+
+    def test_no_magics(self):
+        source = "import os\nx = 1\n"
+        assert KaggleApi._strip_ipython_magics(source) == source

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -502,13 +502,13 @@ class TestRun:
         assert "Timed out waiting for runs after 30 seconds" in output
 
     def test_run_wait_shows_errored_runs(self, api, capsys):
-        """ERRORED runs display with ERRORED label."""
+        """ERRORED runs display with ERRORED label and raise ValueError."""
         _setup_completed_task(api)
         _setup_batch_schedule(api, [_make_run_result()])
         api._mock_benchmarks.list_benchmark_task_runs.return_value = MagicMock(
             runs=[_make_run(state=RUN_ERRORED)], next_page_token=""
         )
-        with patch("time.sleep"):
+        with patch("time.sleep"), pytest.raises(ValueError, match="run\(s\) failed"):
             api.benchmarks_tasks_run_cli("my-task", ["gemini-pro"], wait=0)
         assert "gemini-pro: ERRORED" in capsys.readouterr().out
 
@@ -649,7 +649,7 @@ class TestStatus:
         assert "https://www.kaggle.com/benchmarks/runs/42" not in output
 
     def test_status_errored_run_shows_error_message(self, api, capsys):
-        """ERRORED runs with error_message append ' | Error: ...'."""
+        """ERRORED runs show error in a dedicated section below the table."""
         api._mock_benchmarks.get_benchmark_task.return_value = _make_task()
         _setup_runs_response(
             api,
@@ -657,7 +657,9 @@ class TestStatus:
         )
         api.benchmarks_tasks_status_cli("my-task")
         output = capsys.readouterr().out
-        assert "| Error: OOM" in output
+        assert "Errors:" in output
+        assert "[gemma-2b]" in output
+        assert "OOM" in output
 
     def test_status_pagination(self, api, capsys):
         """Status fetches all pages of runs."""

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -764,6 +764,70 @@ class TestDownload:
         # Verify zip was cleaned up
         assert not os.path.exists(zip_path)
 
+    def test_download_model_slug_at_sign_fallback(self, api, capsys):
+        """Model filter matches proxy-style slugs via @→- replacement.
+
+        The server may return ``model_version_slug`` in the proxy format
+        (e.g. ``anthropic/claude-sonnet-4-6@default``) while the user filters
+        by the display slug (``claude-sonnet-4-6-default``).  The client-side
+        fallback in ``_fetch_task_runs`` should still include such runs.
+        """
+        _setup_runs_response(
+            api,
+            [_make_run(model="anthropic/claude-sonnet-4-6@default", run_id=10)],
+        )
+        self._mock_download(api)
+        with patch("zipfile.ZipFile"), patch("os.remove"):
+            api.benchmarks_tasks_download_cli("my-task", model="claude-sonnet-4-6-default")
+        # The run should NOT have been filtered out
+        assert api._mock_benchmarks.download_benchmark_task_run_output.call_count == 1
+
+    def test_download_bad_zip_keeps_file_and_continues(self, api, capsys, tmp_path):
+        """Corrupt zip prints a warning, keeps the raw file, and continues."""
+        _setup_runs_response(
+            api,
+            [
+                _make_run(model="bad-model", run_id=10),
+                _make_run(model="good-model", run_id=11),
+            ],
+        )
+        api._mock_benchmarks.download_benchmark_task_run_output.return_value = MagicMock()
+
+        outdir = str(tmp_path / "out")
+
+        call_count = 0
+
+        def fake_download(response, outfile, http_client, quiet=False):
+            nonlocal call_count
+            os.makedirs(os.path.dirname(outfile), exist_ok=True)
+            call_count += 1
+            if call_count == 1:
+                # First download: write garbage (not a valid zip)
+                with open(outfile, "wb") as f:
+                    f.write(b"this is not a zip")
+            else:
+                # Second download: write a valid zip
+                buf = io.BytesIO()
+                with zipfile.ZipFile(buf, "w") as zf:
+                    zf.writestr("result.txt", "ok")
+                with open(outfile, "wb") as f:
+                    f.write(buf.getvalue())
+
+        api.download_file = MagicMock(side_effect=fake_download)
+
+        api.benchmarks_tasks_download_cli("my-task", output=outdir)
+
+        output = capsys.readouterr().out
+        # Bad zip: warning printed, raw file kept
+        assert "not a valid zip archive" in output
+        bad_zip_path = os.path.join(outdir, "bad-model_10.zip")
+        assert os.path.isfile(bad_zip_path)
+        # Good zip: extracted successfully
+        good_dir = os.path.join(outdir, "good-model_11")
+        assert os.path.isdir(good_dir)
+        assert os.path.isfile(os.path.join(good_dir, "result.txt"))
+        assert "Downloaded output for good-model to" in output
+
 
 # ============================================================
 # download_file (Content-Length handling)

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -11,7 +11,9 @@ Organized by command (matching the spec):
 """
 
 import argparse
+import io
 import os
+import zipfile
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -654,33 +656,38 @@ class TestStatus:
 class TestDownload:
     """``kaggle benchmarks tasks download <task> [-m <model> ...] [-o <dir>]``"""
 
-    def test_download_to_specific_output(self, api, capsys):
-        _setup_runs_response(api, [_make_run()])
+    def _mock_download(self, api):
+        """Mock download_file, zipfile.ZipFile, and os.remove for download tests."""
         api._mock_benchmarks.download_benchmark_task_run_output.return_value = MagicMock()
         api.download_file = MagicMock()
-        api.benchmarks_tasks_download_cli("my-task", output="my_output_dir")
+
+    def test_download_to_specific_output(self, api, capsys):
+        _setup_runs_response(api, [_make_run()])
+        self._mock_download(api)
+        with patch("zipfile.ZipFile"), patch("os.remove"):
+            api.benchmarks_tasks_download_cli("my-task", output="my_output_dir")
         output = capsys.readouterr().out
         assert "Downloading output for run" in output
         assert "Downloaded output for gemini-pro to" in output
         assert "my_output_dir" in output
 
     def test_download_default_output_path(self, api, capsys):
-        """Default output directory is ./<task>/output."""
+        """Default output directory is ./<task>/output; download_file gets .zip path."""
         _setup_runs_response(api, [_make_run(run_id=1)])
-        api._mock_benchmarks.download_benchmark_task_run_output.return_value = MagicMock()
-        api.download_file = MagicMock()
-        api.benchmarks_tasks_download_cli("my-task")
-        # Check the outfile passed to download_file
+        self._mock_download(api)
+        with patch("zipfile.ZipFile"), patch("os.remove"):
+            api.benchmarks_tasks_download_cli("my-task")
+        # download_file receives the .zip path
         call_args = api.download_file.call_args
-        outfile = call_args[0][1]
-        expected = os.path.join(".", "my-task", "output", "gemini-pro_1")
-        assert outfile == expected
+        zippath = call_args[0][1]
+        expected = os.path.join(".", "my-task", "output", "gemini-pro_1.zip")
+        assert zippath == expected
 
     def test_download_with_model_filter(self, api, capsys):
         _setup_runs_response(api, [_make_run()])
-        api._mock_benchmarks.download_benchmark_task_run_output.return_value = MagicMock()
-        api.download_file = MagicMock()
-        api.benchmarks_tasks_download_cli("my-task", model="gemini-pro")
+        self._mock_download(api)
+        with patch("zipfile.ZipFile"), patch("os.remove"):
+            api.benchmarks_tasks_download_cli("my-task", model="gemini-pro")
         request = api._mock_benchmarks.list_benchmark_task_runs.call_args[0][0]
         assert request.model_version_slugs == ["gemini-pro"]
 
@@ -694,9 +701,9 @@ class TestDownload:
                 _make_run(model="done-model", state=RUN_COMPLETED, run_id=3),
             ],
         )
-        api._mock_benchmarks.download_benchmark_task_run_output.return_value = MagicMock()
-        api.download_file = MagicMock()
-        api.benchmarks_tasks_download_cli("my-task")
+        self._mock_download(api)
+        with patch("zipfile.ZipFile"), patch("os.remove"):
+            api.benchmarks_tasks_download_cli("my-task")
         # Only the completed run should be downloaded
         assert api._mock_benchmarks.download_benchmark_task_run_output.call_count == 1
         output = capsys.readouterr().out
@@ -707,9 +714,9 @@ class TestDownload:
     def test_download_includes_errored_runs(self, api, capsys):
         """ERRORED runs are also downloadable per spec."""
         _setup_runs_response(api, [_make_run(state=RUN_ERRORED)])
-        api._mock_benchmarks.download_benchmark_task_run_output.return_value = MagicMock()
-        api.download_file = MagicMock()
-        api.benchmarks_tasks_download_cli("my-task")
+        self._mock_download(api)
+        with patch("zipfile.ZipFile"), patch("os.remove"):
+            api.benchmarks_tasks_download_cli("my-task")
         assert api._mock_benchmarks.download_benchmark_task_run_output.call_count == 1
 
     def test_download_pagination(self, api, capsys):
@@ -722,10 +729,100 @@ class TestDownload:
                 ([_make_run(model="gemini-2", run_id=2)], ""),
             ],
         )
-        api._mock_benchmarks.download_benchmark_task_run_output.return_value = MagicMock()
-        api.download_file = MagicMock()
-        api.benchmarks_tasks_download_cli("my-task")
+        self._mock_download(api)
+        with patch("zipfile.ZipFile"), patch("os.remove"):
+            api.benchmarks_tasks_download_cli("my-task")
         assert api._mock_benchmarks.download_benchmark_task_run_output.call_count == 2
+
+    def test_download_extracts_zip_and_cleans_up(self, api, capsys, tmp_path):
+        """Download extracts zip into a directory and removes the zip file."""
+        _setup_runs_response(api, [_make_run(run_id=42)])
+        api._mock_benchmarks.download_benchmark_task_run_output.return_value = MagicMock()
+
+        outdir = str(tmp_path / "out")
+        zip_path = os.path.join(outdir, "gemini-pro_42.zip")
+
+        # Make download_file create a real zip so extraction works
+        def fake_download(response, outfile, http_client, quiet=False):
+            os.makedirs(os.path.dirname(outfile), exist_ok=True)
+            buf = io.BytesIO()
+            with zipfile.ZipFile(buf, "w") as zf:
+                zf.writestr("output.txt", "hello world")
+            with open(outfile, "wb") as f:
+                f.write(buf.getvalue())
+
+        api.download_file = MagicMock(side_effect=fake_download)
+
+        api.benchmarks_tasks_download_cli("my-task", output=outdir)
+
+        # Verify extraction happened
+        extracted_dir = os.path.join(outdir, "gemini-pro_42")
+        assert os.path.isdir(extracted_dir)
+        assert os.path.isfile(os.path.join(extracted_dir, "output.txt"))
+        with open(os.path.join(extracted_dir, "output.txt")) as f:
+            assert f.read() == "hello world"
+        # Verify zip was cleaned up
+        assert not os.path.exists(zip_path)
+
+
+# ============================================================
+# download_file (Content-Length handling)
+# ============================================================
+
+
+class TestDownloadFile:
+    """Tests for ``download_file`` handling of Content-Length header."""
+
+    def _make_response(self, content=b"test data", headers=None, url="http://example.com/file"):
+        """Build a mock requests.Response-like object."""
+        resp = MagicMock()
+        default_headers = {"Last-Modified": "Mon, 01 Jan 2024 00:00:00 GMT"}
+        if headers:
+            default_headers.update(headers)
+        resp.headers = default_headers
+        resp.url = url
+        resp.request.method = "GET"
+        resp.request.headers = {}
+        resp.iter_content = MagicMock(return_value=iter([content]))
+        # Make type().__name__ return something other than "HTTPResponse"
+        type(resp).__name__ = "Response"
+        return resp
+
+    def test_download_file_with_content_length(self, api, tmp_path):
+        """Normal download with Content-Length header works and verifies size."""
+        content = b"hello world"
+        resp = self._make_response(
+            content=content,
+            headers={"Content-Length": str(len(content))},
+        )
+        outfile = str(tmp_path / "out" / "test.txt")
+        api.download_file(resp, outfile, MagicMock(), quiet=True)
+        assert os.path.isfile(outfile)
+        with open(outfile, "rb") as f:
+            assert f.read() == content
+
+    def test_download_file_missing_content_length(self, api, tmp_path):
+        """Chunked response (no Content-Length) downloads without crashing."""
+        content = b"chunked data"
+        resp = self._make_response(
+            content=content,
+            headers={"Transfer-Encoding": "chunked"},
+        )
+        outfile = str(tmp_path / "out" / "chunked.bin")
+        api.download_file(resp, outfile, MagicMock(), quiet=True)
+        assert os.path.isfile(outfile)
+        with open(outfile, "rb") as f:
+            assert f.read() == content
+
+    def test_download_file_missing_content_length_skips_size_check(self, api, tmp_path):
+        """When Content-Length is absent, size verification is skipped (no ValueError)."""
+        content = b"data"
+        resp = self._make_response(content=content)
+        # No Content-Length in headers at all
+        outfile = str(tmp_path / "out" / "nosize.bin")
+        api.download_file(resp, outfile, MagicMock(), quiet=True)
+        # Should succeed without ValueError about size mismatch
+        assert os.path.isfile(outfile)
 
 
 # ============================================================

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -1071,3 +1071,68 @@ class TestBenchmarksInit:
         content = env_file.read_text()
         assert content.startswith("EXISTING_VAR=hello\n")
         assert "LLM_DEFAULT=google/gemini-3-flash-preview\n" in content
+
+
+# ============================================================
+# Task Name Detection
+# ============================================================
+
+
+class TestGetTaskNamesFromFile:
+    """Tests for ``_get_task_names_from_file`` static method."""
+
+    @pytest.mark.parametrize(
+        "source, expected",
+        [
+            # keyword arg
+            ('@task(name="My Task")\ndef evaluate(): pass\n', ["My Task"]),
+            # positional arg
+            ('@task("My Task")\ndef evaluate(): pass\n', ["My Task"]),
+            # no name — falls back to function name
+            ("@task()\ndef my_eval(): pass\n", ["My Eval"]),
+            # bare decorator (no parens)
+            ("@task\ndef my_eval(): pass\n", ["My Eval"]),
+            # module-qualified: benchmarks.task
+            ('@benchmarks.task(name="Qualified")\ndef f(): pass\n', ["Qualified"]),
+            # module-qualified positional
+            ('@benchmarks.task("Qualified")\ndef f(): pass\n', ["Qualified"]),
+            # async function
+            ('@task(name="Async")\nasync def evaluate(): pass\n', ["Async"]),
+            # non-constant name expression — falls back to function name
+            ("@task(name=TASK_NAME)\ndef my_task(): pass\n", ["My Task"]),
+            # non-constant positional arg — falls back to function name
+            ("@task(TASK_NAME)\ndef my_task(): pass\n", ["My Task"]),
+            # multiple tasks in one file
+            (
+                '@task("First")\ndef a(): pass\n\n@task(name="Second")\ndef b(): pass\n',
+                ["First", "Second"],
+            ),
+            # syntax error → empty list
+            ("def broken(\n", []),
+            # no decorators at all
+            ("def plain(): pass\n", []),
+            # unrelated decorator
+            ("@other_decorator\ndef f(): pass\n", []),
+            # keyword takes priority when both name= and positional could exist
+            # (not valid Python for task(), but tests the keyword-first logic)
+            ('@task("Pos", name="Kw")\ndef f(): pass\n', ["Kw"]),
+        ],
+        ids=[
+            "keyword_name",
+            "positional_name",
+            "no_name_parens",
+            "bare_decorator",
+            "module_qualified_keyword",
+            "module_qualified_positional",
+            "async_function",
+            "non_constant_keyword",
+            "non_constant_positional",
+            "multiple_tasks",
+            "syntax_error",
+            "no_decorators",
+            "unrelated_decorator",
+            "keyword_over_positional",
+        ],
+    )
+    def test_task_name_detection(self, source, expected):
+        assert KaggleApi._get_task_names_from_file(source) == expected

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -1135,6 +1135,7 @@ class TestCliArgParsing:
         args = self._parse("benchmarks init")
         assert args.no_confirm is False
         assert args.env_file == ".env"
+        assert args.example_file == "example_task.py"
 
     def test_parse_benchmarks_init_yes(self):
         args = self._parse("benchmarks init -y")
@@ -1143,6 +1144,10 @@ class TestCliArgParsing:
     def test_parse_benchmarks_init_env_file(self):
         args = self._parse("benchmarks init --env-file custom.env")
         assert args.env_file == "custom.env"
+
+    def test_parse_benchmarks_init_example_file(self):
+        args = self._parse("benchmarks init --example-file my_task.py")
+        assert args.example_file == "my_task.py"
 
 
 # ============================================================
@@ -1256,7 +1261,7 @@ class TestBenchmarksInit:
         assert "kaggle-benchmarks Task Syntax Reference" in content
         out = capsys.readouterr().out
         assert "Syntax reference has been written to" in out
-        assert "@kaggle_benchmarks_reference.md" in out
+        assert "kaggle_benchmarks_reference.md" in out
 
     def test_skips_reference_file_if_exists(self, api, mock_token, capsys, tmp_path):
         ref_file = tmp_path / "kaggle_benchmarks_reference.md"


### PR DESCRIPTION
Fixes and improves the benchmarks CLI:

1. **Fix `download_file` crash on chunked responses** (fixes #984): `Content-Length` is now read via `.get()`; size verification and resume logic gracefully handle `None`.

2. **Overhaul `download` command**: Outputs are auto-extracted from zip into a hierarchical `{task}/{model}/{run_id}/` layout. The command now validates the task exists, skips already-downloaded outputs, handles corrupt zips, and prints helpful hints when no runs are available.

3. **Robust task name parsing**: `_get_task_names_from_file` now supports positional `@task("name")` syntax and strips IPython/Jupyter magics (`%`, `!`, `%%`) before AST parsing so Jupytext percent-format files work correctly.

4. **Model slug `@`-fallback**: Client-side model filtering also matches `anthropic/claude-sonnet-4-6@default` → `claude-sonnet-4-6-default` as a workaround until the server returns the correct slug format.

5. **Better `push` behavior**: Pending tasks are now waited on (with `--wait`) instead of always erroring; a status-check hint is printed when `--wait` is omitted. Slug normalization warnings are shown when the task name differs from its slug.

6. **Improved output formatting**: Run errors are displayed in a dedicated section below the status table instead of inline. Enum values and task names are cleaned up in error messages.

7. **CLI polish & refactors**: `push`/`run` use proper "required arguments" groups with explicit usage strings. Pagination, URL construction, and notebook conversion are extracted into reusable helpers.

8. **More tests**: ~new/updated tests covering task name detection, IPython magic stripping, download edge cases, model slug fallback, and the `models` CLI.