### PR TITLE
Add submission ref to competition submissions output

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -631,7 +631,7 @@ class KaggleApi:
 
     # Attributes
     competition_fields = ["ref", "deadline", "category", "reward", "teamCount", "userHasEntered"]
-    submission_fields = ["fileName", "date", "description", "status", "publicScore", "privateScore"]
+    submission_fields = ["ref", "fileName", "date", "description", "status", "publicScore", "privateScore"]
     competition_file_fields = ["name", "totalBytes", "creationDate"]
     competition_file_labels = ["name", "size", "creationDate"]
     competition_leaderboard_fields = ["teamId", "teamName", "submissionDate", "score"]


### PR DESCRIPTION
The submission ID (ref) is required by 'kaggle competitions episodes' but was not exposed by 'kaggle competitions submissions'. Add ref as the first column so users can discover the ID needed for episodes.