### PR TITLE
Update `kaggle b init` to include example and reference

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -190,6 +190,158 @@ from typing import Callable, cast, Dict, List, Mapping, Optional, Tuple, Union, 
 
 T = TypeVar("T")
 
+BENCHMARKS_SYNTAX_REF = """\
+# kaggle-benchmarks Task Syntax Reference
+
+- Installation: `pip install kaggle-benchmarks`
+- [Quick Start](https://github.com/Kaggle/kaggle-benchmarks/blob/ci/quick_start.md)
+- [Cookbook](https://github.com/Kaggle/kaggle-benchmarks/blob/ci/cookbook.md)
+
+## Decorator & Signature
+
+```python
+@kbench.task(name="task_name", description="...", version=1)
+def my_task(llm, param1: str, param2: int) -> ReturnType:
+    ...
+```
+
+- First param is always `llm` (model under test).
+- Additional params passed via `.run()` or `.evaluate()`.
+- `name` defaults to function name; `description` defaults to docstring.
+- **Important:** The `name` is normalized to a URL-safe slug (e.g. `"My Task"` becomes `my-task`).
+  This slug must match the task name used with `kaggle b t push <task-slug> -f <file>`.
+
+## Return Type Annotations (controls leaderboard rendering)
+
+| Annotation | Meaning |
+|---|---|
+| `None` / omitted | Pass/Fail — graded solely by assertions |
+| `-> bool` | Binary pass/fail |
+| `-> int` / `-> float` | Numerical score |
+| `-> tuple[int, int]` | (passed, total) count |
+| `-> tuple[float, float]` | (value, confidence_interval) |
+| `-> dict` | Structured result dict |
+
+## LLM Interaction
+
+```python
+response = llm.prompt("question")                            # returns str
+obj = llm.prompt("question", schema=MyDataclass)             # structured output
+response = llm.prompt("q", image=images.from_url(url))       # with image
+response = llm.prompt("q", video=videos.from_url(yt_url))    # with video
+response = llm.prompt("q", audio=audios.from_path(path))     # with audio
+response = llm.prompt("q", tools=[my_func])                  # tool calling (needs api="genai")
+llm.send(msg)        # adds message without triggering response
+llm.respond()         # gets response continuing existing conversation
+kbench.user.send(x)   # adds user message (text/image/etc.) to chat history
+```
+
+## Chat Context Management
+
+```python
+with kbench.chats.new("name"):     # isolated chat context
+    response = llm.prompt("...")    # only this chat's history is sent
+```
+
+Use `kbench.chats.new()` in loops to avoid growing context.
+For multi-agent: `contexts.enter(chat=agent_chat)`
+
+## Accessing Models
+
+```python
+kbench.llm                              # default model placeholder
+kbench.judge_llm                        # judge model
+kbench.llms["google/gemini-2.5-flash"]  # specific model by name
+```
+
+## Assertions (always include `expectation=` for leaderboard display)
+
+```python
+kbench.assertions.assert_equal(expected, actual, expectation="...")
+kbench.assertions.assert_true(value, expectation="...")
+kbench.assertions.assert_false(value, expectation="...")
+kbench.assertions.assert_in(member, container, expectation="...")
+kbench.assertions.assert_not_in(member, container, expectation="...")
+kbench.assertions.assert_contains_regex(pattern, text, expectation="...")
+kbench.assertions.assert_not_contains_regex(pattern, text, expectation="...", flags=0)
+kbench.assertions.assert_empty(container, expectation="...")
+kbench.assertions.assert_not_empty(container, expectation="...")
+kbench.assertions.assert_fail(expectation="...")  # unconditional fail
+```
+
+## Custom Assertions
+
+```python
+from kaggle_benchmarks.assertions import assertion_handler, AssertionResult
+
+@assertion_handler()
+def assert_is_positive(value: float, expectation: str) -> AssertionResult:
+    return AssertionResult(passed=value > 0, expectation=expectation)
+```
+
+## Judge-Based Assessment
+
+```python
+report = kbench.assertions.assess_response_with_judge(
+    criteria=("criterion 1", "criterion 2"),
+    response_text=response,
+    judge_llm=kbench.judge_llm,
+    prompt_fn=optional_custom_fn,       # (criteria, response_text) -> str
+    output_schema=OptionalDataclass,
+)
+for r in report.results:
+    kbench.assertions.assert_true(r.passed, expectation=f"{r.criterion}: {r.reason}")
+```
+
+## Running Tasks
+
+`.run()` or `.evaluate()` MUST be called to generate a run file.
+Without invoking one of these, no `.run.json` is produced and nothing is recorded.
+
+```python
+# Single run:
+run = my_task.run(llm=kbench.llm, param1="val1", param2=42)
+
+# Dataset evaluation (runs task once per row in a DataFrame):
+runs = my_task.evaluate(
+    llm=[kbench.llm], evaluation_data=df,  # df columns map to task params
+    n_jobs=2, timeout=120,
+    stop_condition=lambda r: len(r) == df.shape[0],
+    max_attempts=50, retry_delay=15, remove_run_files=True,
+)
+results_df = runs.as_dataframe()
+```
+
+## Multimodal Content Factories
+
+```python
+from kaggle_benchmarks.content_types import images, videos, audios
+images.from_url(url) | images.from_path(p) | images.from_base64(b64, format="png")
+videos.from_url(youtube_url)
+audios.from_path(p) | audios.from_url(url) | audios.from_base64(b64, format="mp3")
+```
+
+## Token Usage Tracking
+
+```python
+with kbench.chats.new("chat") as chat:
+    llm.prompt("...")
+    chat.usage.input_tokens / .output_tokens / .input_tokens_cost_nanodollars
+```
+"""
+
+BENCHMARKS_EXAMPLE_TASK = """\
+# Syntax reference: kaggle_benchmarks_reference.md
+import kaggle_benchmarks as kbench
+
+@kbench.task(name="What is Kaggle?", description="Does the LLM know what Kaggle is?")
+def what_is_kaggle(llm) -> None:
+    response = llm.prompt("What is Kaggle?")
+    kbench.assertions.assert_in("platform", response.lower())
+
+what_is_kaggle.run(kbench.llm)
+"""
+
 
 class AuthMethod(Enum):
     LEGACY_API_KEY = 0
@@ -6314,11 +6466,33 @@ class KaggleApi:
 
         print(f"Environment variables have been written to {env_file}.")
 
+    def _write_benchmarks_example(self, example_file):
+        example_file = os.path.abspath(example_file)
+        if os.path.exists(example_file):
+            print(f"Example file already exists at {example_file}, skipping.")
+            return
+
+        with open(example_file, "w") as f:
+            f.write(BENCHMARKS_EXAMPLE_TASK)
+
+        print(f"Example benchmark task file has been written to {example_file}.")
+
+    def _write_benchmarks_reference(self, directory):
+        ref_file = os.path.join(os.path.abspath(directory), "kaggle_benchmarks_reference.md")
+        if os.path.exists(ref_file):
+            print(f"Reference file already exists at {ref_file}, skipping.")
+            return
+
+        with open(ref_file, "w") as f:
+            f.write(BENCHMARKS_SYNTAX_REF)
+
+        print(f"Syntax reference has been written to {ref_file}.")
+
     def benchmarks_auth_cli(self, no_confirm=False, env_file=".env"):
         env_vars = self._fetch_model_proxy_env()
         self._write_benchmarks_env(env_vars, no_confirm, env_file)
 
-    def benchmarks_init_cli(self, no_confirm=False, env_file=".env"):
+    def benchmarks_init_cli(self, no_confirm=False, env_file=".env", example_file="example_task.py"):
         env_vars = self._fetch_model_proxy_env()
         env_vars.update(
             {
@@ -6328,6 +6502,8 @@ class KaggleApi:
             }
         )
         self._write_benchmarks_env(env_vars, no_confirm, env_file)
+        self._write_benchmarks_example(example_file)
+        self._write_benchmarks_reference(os.path.dirname(os.path.abspath(example_file)))
 
     def benchmarks_tasks_push_cli(self, task, file, wait=None, poll_interval=10):
         if not os.path.isfile(file):

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -1192,6 +1192,9 @@ def parse_benchmarks_init(subparsers) -> None:
     parser_init_optional.add_argument(
         "--env-file", dest="env_file", default=".env", help=Help.param_benchmarks_env_file
     )
+    parser_init_optional.add_argument(
+        "--example-file", dest="example_file", default="example_task.py", help=Help.param_benchmarks_example_file
+    )
     parser_init._action_groups.append(parser_init_optional)
     parser_init.set_defaults(func=api.benchmarks_init_cli)
 
@@ -1750,6 +1753,7 @@ class Help(object):
 
     # Benchmarks params
     param_benchmarks_env_file = "File to write environment variables to (default: .env)"
+    param_benchmarks_example_file = "File to write the example benchmark task to (default: example_task.py)"
     param_benchmarks_task = "Task name (normalized to a URL-safe slug, e.g. 'my_task' or 'My Task' becomes 'my-task')."
     param_benchmarks_file = "Path to the source Python file defining the task"
     param_benchmarks_name_regex = "Filter task names by regular expression"

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -973,7 +973,8 @@ class TestBenchmarksInit:
             _make_token_response()
         )
         env_file = str(tmp_path / ".env")
-        api.benchmarks_init_cli(no_confirm=True, env_file=env_file)
+        example_file = str(tmp_path / "example_task.py")
+        api.benchmarks_init_cli(no_confirm=True, env_file=env_file, example_file=example_file)
         content = (tmp_path / ".env").read_text()
         assert "MODEL_PROXY_URL=https://mp-staging.kaggle.net/models/openapi\n" in content
         assert "MODEL_PROXY_API_KEY=kaggle-benchmarks:cool-token\n" in content
@@ -986,13 +987,77 @@ class TestBenchmarksInit:
         assert "LLM_DEFAULT=google/gemini-3-flash-preview" in out
         assert "have been written to" in out
 
+    def test_writes_example_file(self, api, capsys, tmp_path):
+        api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.return_value = (
+            _make_token_response()
+        )
+        env_file = str(tmp_path / ".env")
+        example_file = str(tmp_path / "example_task.py")
+        api.benchmarks_init_cli(no_confirm=True, env_file=env_file, example_file=example_file)
+        content = (tmp_path / "example_task.py").read_text()
+        assert "import kaggle_benchmarks as kbench" in content
+        assert "kaggle_benchmarks_reference.md" in content
+        out = capsys.readouterr().out
+        assert "Example benchmark task file has been written to" in out
+
+    def test_writes_reference_file(self, api, capsys, tmp_path):
+        api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.return_value = (
+            _make_token_response()
+        )
+        env_file = str(tmp_path / ".env")
+        example_file = str(tmp_path / "example_task.py")
+        api.benchmarks_init_cli(no_confirm=True, env_file=env_file, example_file=example_file)
+        ref_file = tmp_path / "kaggle_benchmarks_reference.md"
+        assert ref_file.exists()
+        content = ref_file.read_text()
+        assert "kaggle-benchmarks Task Syntax Reference" in content
+        out = capsys.readouterr().out
+        assert "Syntax reference has been written to" in out
+        assert "@kaggle_benchmarks_reference.md" in out
+
+    def test_skips_reference_file_if_exists(self, api, capsys, tmp_path):
+        api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.return_value = (
+            _make_token_response()
+        )
+        ref_file = tmp_path / "kaggle_benchmarks_reference.md"
+        ref_file.write_text("existing content\n")
+        env_file = str(tmp_path / ".env")
+        example_file = str(tmp_path / "example_task.py")
+        api.benchmarks_init_cli(no_confirm=True, env_file=env_file, example_file=str(example_file))
+        assert ref_file.read_text() == "existing content\n"
+        out = capsys.readouterr().out
+        assert "Reference file already exists" in out
+
+    def test_skips_example_file_if_exists(self, api, capsys, tmp_path):
+        api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.return_value = (
+            _make_token_response()
+        )
+        example_file = tmp_path / "example_task.py"
+        example_file.write_text("existing content\n")
+        env_file = str(tmp_path / ".env")
+        api.benchmarks_init_cli(no_confirm=True, env_file=env_file, example_file=str(example_file))
+        assert example_file.read_text() == "existing content\n"
+        out = capsys.readouterr().out
+        assert "already exists" in out
+
+    def test_custom_example_file(self, api, capsys, tmp_path):
+        api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.return_value = (
+            _make_token_response()
+        )
+        env_file = str(tmp_path / ".env")
+        example_file = str(tmp_path / "my_task.py")
+        api.benchmarks_init_cli(no_confirm=True, env_file=env_file, example_file=example_file)
+        content = (tmp_path / "my_task.py").read_text()
+        assert "import kaggle_benchmarks as kbench" in content
+
     def test_aborted_on_no_confirm(self, api, capsys, tmp_path):
         api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.return_value = (
             _make_token_response()
         )
         env_file = str(tmp_path / ".env")
+        example_file = str(tmp_path / "example_task.py")
         with patch("builtins.input", return_value="no"):
-            api.benchmarks_init_cli(no_confirm=False, env_file=env_file)
+            api.benchmarks_init_cli(no_confirm=False, env_file=env_file, example_file=example_file)
         assert not (tmp_path / ".env").exists()
 
     def test_appends_to_existing_file(self, api, capsys, tmp_path):
@@ -1001,7 +1066,8 @@ class TestBenchmarksInit:
         )
         env_file = tmp_path / ".env"
         env_file.write_text("EXISTING_VAR=hello\n")
-        api.benchmarks_init_cli(no_confirm=True, env_file=str(env_file))
+        example_file = str(tmp_path / "example_task.py")
+        api.benchmarks_init_cli(no_confirm=True, env_file=str(env_file), example_file=example_file)
         content = env_file.read_text()
         assert content.startswith("EXISTING_VAR=hello\n")
         assert "LLM_DEFAULT=google/gemini-3-flash-preview\n" in content


### PR DESCRIPTION
```
The following environment variables will be written to .../.env:

  MODEL_PROXY_URL=https://mp-staging.kaggle.net/models
  MODEL_PROXY_API_KEY=****************XcxD
  MODEL_PROXY_EXPIRY_TIME=2026-04-28T19:11:54.813000Z
  LLM_DEFAULT=google/gemini-3-flash-preview
  LLM_DEFAULT_EVAL=google/gemini-3-flash-preview
  LLMS_AVAILABLE=google/gemini-3-flash-preview,google/gemini-3.1-flash-lite-preview

Are you sure you want to write these environment variables to ..../.env? [Y/n] 
Environment variables have been written to .../.env.
Example benchmark task file has been written to .../example_task.py.
Syntax reference has been written to .../kaggle_benchmarks_reference.md.
```

[local demo screencast](https://screencast.googleplex.com/cast/NDYyNjg3NDEwNDgwNzQyNHwzODcxZmQ5NC1mYQ)