### PR TITLE
feat: add forums commands for browsing Kaggle discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Some of the key features are:
 * List, create, update, download or delete datasets.
 * List, create, update, download or delete models & model variations.
 * List, update & run, download code & output or delete kernels (notebooks).
+* Browse and read discussion forums.
 
 ## Installation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,7 @@ The Kaggle CLI is organized into several command groups:
 
 *   [Competitions](./competitions.md): Manage and participate in Kaggle competitions.
 *   [Datasets](./datasets.md): Search, download, and manage Kaggle datasets.
+*   [Forums](./forums.md): Browse and read Kaggle discussion forums.
 *   [Kernels](./kernels.md): Interact with Kaggle Kernels (notebooks and scripts).
 *   [Models](./models.md): Manage your Kaggle Models.
 *   [Model Variations](./model_variations.md): Manage variations of your Kaggle Models.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -362,7 +362,7 @@ kaggle benchmarks topics <BENCHMARK> [options]
 
 **Arguments:**
 
-*   `<BENCHMARK>`: Benchmark slug (e.g., `game-arena-chess`).
+*   `<BENCHMARK>`: Benchmark slug (e.g., `kaggle/chess`).
 
 **Options:**
 
@@ -376,7 +376,7 @@ kaggle benchmarks topics <BENCHMARK> [options]
 **Example:**
 
 ```bash
-kaggle benchmarks topics game-arena-chess
+kaggle benchmarks topics kaggle/chess
 ```
 
 **Purpose:**
@@ -396,7 +396,7 @@ kaggle benchmarks topics show <BENCHMARK>/<TOPIC_ID> [options]
 **Arguments:**
 
 *   `<TOPIC_REF>`: A topic reference, which can be:
-    *   `<benchmark>/<topic-id>` (e.g., `game-arena-chess/12345`)
+    *   `<benchmark>/<topic-id>` (e.g., `kaggle/chess/614080`)
     *   `<benchmark> <topic-id>` (two separate arguments)
     *   `<topic-id>` (bare numeric ID)
 
@@ -410,7 +410,7 @@ kaggle benchmarks topics show <BENCHMARK>/<TOPIC_ID> [options]
 **Example:**
 
 ```bash
-kaggle benchmarks topics show game-arena-chess/12345
+kaggle benchmarks topics show kaggle/chess/614080
 ```
 
 **Purpose:**

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -349,3 +349,70 @@ kaggle b t delete my-task -y
 **Purpose:**
 
 Deletes a benchmark task and all associated runs. **Note:** This command is not yet supported by the server.
+
+## `kaggle benchmarks topics`
+
+Lists discussion topics for a benchmark.
+
+**Usage:**
+
+```bash
+kaggle benchmarks topics <BENCHMARK> [options]
+```
+
+**Arguments:**
+
+*   `<BENCHMARK>`: Benchmark slug (e.g., `game-arena-chess`).
+
+**Options:**
+
+*   `--sort-by <SORT_BY>`: Sort order. Valid options: `hot`, `top`, `new`, `recent`, `active`, `relevance`.
+*   `--page-size <PAGE_SIZE>`: Number of items per page.
+*   `--page-token <PAGE_TOKEN>`: Page token for pagination.
+*   `-s, --search <SEARCH_TERM>`: Search query.
+*   `-v, --csv`: Print results in CSV format.
+*   `-q, --quiet`: Suppress verbose output.
+
+**Example:**
+
+```bash
+kaggle benchmarks topics game-arena-chess
+```
+
+**Purpose:**
+
+This command lets you browse discussion topics for a specific benchmark.
+
+## `kaggle benchmarks topics show`
+
+Displays a benchmark discussion topic with all comments in tree form.
+
+**Usage:**
+
+```bash
+kaggle benchmarks topics show <BENCHMARK>/<TOPIC_ID> [options]
+```
+
+**Arguments:**
+
+*   `<TOPIC_REF>`: A topic reference, which can be:
+    *   `<benchmark>/<topic-id>` (e.g., `game-arena-chess/12345`)
+    *   `<benchmark> <topic-id>` (two separate arguments)
+    *   `<topic-id>` (bare numeric ID)
+
+**Options:**
+
+*   `-v, --csv`: Print results in CSV format.
+*   `-q, --quiet`: Suppress verbose output.
+*   `--page-size <PAGE_SIZE>`: Number of comments to show per page.
+*   `--page-token <PAGE_TOKEN>`: Page token for comment pagination.
+
+**Example:**
+
+```bash
+kaggle benchmarks topics show game-arena-chess/12345
+```
+
+**Purpose:**
+
+This command displays a full discussion topic along with all of its comments rendered in an indented tree structure.

--- a/docs/competitions.md
+++ b/docs/competitions.md
@@ -223,3 +223,108 @@ kaggle competitions leaderboard <COMPETITION> [options]
 **Purpose:**
 
 This command lets you view your ranking and the scores of other participants in a competition.
+
+## `kaggle competitions topics`
+
+Lists discussion topics for a competition.
+
+**Usage:**
+
+```bash
+kaggle competitions topics <COMPETITION> [options]
+```
+
+**Arguments:**
+
+*   `<COMPETITION>`: Competition URL suffix (e.g., `titanic`).
+
+**Options:**
+
+*   `--sort-by <SORT_BY>`: Sort order. Valid options: `hot`, `top`, `new`, `recent`, `active`, `relevance`.
+*   `-p, --page <PAGE>`: Page number (1-based).
+*   `-v, --csv`: Print results in CSV format.
+*   `-q, --quiet`: Suppress verbose output.
+
+**Example:**
+
+List discussion topics for the "titanic" competition sorted by most recent:
+
+```bash
+kaggle competitions topics titanic --sort-by recent
+```
+
+**Purpose:**
+
+This command lets you browse discussion topics for a specific competition.
+
+## `kaggle competitions topics show`
+
+Displays a competition discussion topic with all comments in tree form.
+
+**Usage:**
+
+```bash
+kaggle competitions topics show <COMPETITION>/<TOPIC_ID> [options]
+```
+
+**Arguments:**
+
+*   `<TOPIC_REF>`: A topic reference, which can be:
+    *   `<competition>/<topic-id>` (e.g., `titanic/12345`)
+    *   `<competition> <topic-id>` (two separate arguments)
+    *   `<topic-id>` (bare numeric ID)
+
+**Options:**
+
+*   `-v, --csv`: Print results in CSV format.
+*   `-q, --quiet`: Suppress verbose output.
+*   `--page-size <PAGE_SIZE>`: Number of comments to show per page.
+*   `--page-token <PAGE_TOKEN>`: Page token for comment pagination.
+
+**Example:**
+
+Show topic 12345 from the "titanic" competition:
+
+```bash
+kaggle competitions topics show titanic/12345
+```
+
+**Purpose:**
+
+This command displays a full discussion topic along with all of its comments rendered in an indented tree structure. This replaces the older `topic-messages` command.
+
+## `kaggle competitions topic-messages`
+
+Lists messages within a competition discussion topic.
+
+> **Deprecated:** This command is deprecated in favor of `kaggle competitions topics show`. It will be removed in a future release.
+
+**Usage:**
+
+```bash
+kaggle competitions topic-messages <COMPETITION> <TOPIC_ID> [options]
+```
+
+**Arguments:**
+
+*   `<COMPETITION>`: Competition URL suffix (e.g., `titanic`).
+*   `<TOPIC_ID>`: The discussion topic id.
+
+**Options:**
+
+*   `-s, --sort-by <SORT_BY>`: Sort order. Valid options: `best`, `new`, `old`.
+*   `-n, --page-size <PAGE_SIZE>`: Max top-level messages to return; `-1` for all.
+*   `-v, --csv`: Print results in CSV format.
+*   `-q, --quiet`: Suppress verbose output.
+
+**Example:**
+
+List all messages for topic 12345 in the "titanic" competition, sorted by newest first:
+
+```bash
+kaggle competitions topic-messages titanic 12345 -s new -n -1
+```
+
+**Purpose:**
+
+This command displays the messages within a specific competition discussion topic.

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -307,3 +307,72 @@ kaggle datasets delete username/dataset-slug --yes
 **Purpose:**
 
 This command permanently removes one of your datasets from Kaggle. Use with caution.
+
+## `kaggle datasets topics`
+
+Lists discussion topics for a dataset.
+
+**Usage:**
+
+```bash
+kaggle datasets topics <DATASET> [options]
+```
+
+**Arguments:**
+
+*   `<DATASET>`: Dataset ref in format `<owner>/<dataset-slug>` (e.g., `zillow/zecon`).
+
+**Options:**
+
+*   `--sort-by <SORT_BY>`: Sort order. Valid options: `hot`, `top`, `new`, `recent`, `active`, `relevance`.
+*   `--page-size <PAGE_SIZE>`: Number of items per page.
+*   `--page-token <PAGE_TOKEN>`: Page token for pagination.
+*   `-s, --search <SEARCH_TERM>`: Search query.
+*   `-v, --csv`: Print results in CSV format.
+*   `-q, --quiet`: Suppress verbose output.
+
+**Example:**
+
+List recent topics for the zillow/zecon dataset:
+
+```bash
+kaggle datasets topics zillow/zecon --sort-by recent
+```
+
+**Purpose:**
+
+This command lets you browse discussion topics for a specific dataset.
+
+## `kaggle datasets topics show`
+
+Displays a dataset discussion topic with all comments in tree form.
+
+**Usage:**
+
+```bash
+kaggle datasets topics show <DATASET>/<TOPIC_ID> [options]
+```
+
+**Arguments:**
+
+*   `<TOPIC_REF>`: A topic reference, which can be:
+    *   `<dataset>/<topic-id>` (e.g., `zillow/zecon/12345`)
+    *   `<dataset> <topic-id>` (two separate arguments)
+    *   `<topic-id>` (bare numeric ID)
+
+**Options:**
+
+*   `-v, --csv`: Print results in CSV format.
+*   `-q, --quiet`: Suppress verbose output.
+*   `--page-size <PAGE_SIZE>`: Number of comments to show per page.
+*   `--page-token <PAGE_TOKEN>`: Page token for comment pagination.
+
+**Example:**
+
+```bash
+kaggle datasets topics show zillow/zecon/12345
+```
+
+**Purpose:**
+
+This command displays a full discussion topic along with all of its comments rendered in an indented tree structure.

--- a/docs/forums.md
+++ b/docs/forums.md
@@ -1,0 +1,115 @@
+# Forums Commands
+
+Commands for browsing and reading Kaggle discussion forums.
+
+## `kaggle forums`
+
+Lists all discussion forums. Also available as `kaggle forums list`.
+
+**Alias:** `fo`
+
+**Usage:**
+
+```bash
+kaggle forums [options]
+```
+
+**Options:**
+
+*   `-v, --csv`: Print results in CSV format.
+*   `-q, --quiet`: Suppress verbose output.
+
+**Example:**
+
+List all forums in CSV format:
+
+```bash
+kaggle forums -v
+```
+
+**Purpose:**
+
+This command helps you discover all available discussion forums on Kaggle.
+
+## `kaggle forums topics`
+
+Lists discussion topics in a forum.
+
+**Usage:**
+
+```bash
+kaggle forums topics <FORUM> [options]
+```
+
+**Arguments:**
+
+*   `<FORUM>`: Forum slug (e.g., `getting-started`, `product-feedback`).
+
+**Options:**
+
+*   `--sort-by <SORT_BY>`: Sort order. Valid options: `hot`, `top`, `new`, `recent`, `active`, `relevance`.
+*   `--page-size <PAGE_SIZE>`: Number of items per page.
+*   `--page-token <PAGE_TOKEN>`: Page token for pagination.
+*   `-s, --search <SEARCH_TERM>`: Search query.
+*   `--category <CATEGORY>`: Filter by category. Valid options: `all`, `forums`, `competitions`, `datasets`, `competition_write_ups`, `models`, `benchmarks`.
+*   `--group <GROUP>`: Filter by group. Valid options: `all`, `owned`, `upvoted`, `bookmarked`, `my_activity`, `drafts`.
+*   `-v, --csv`: Print results in CSV format.
+*   `-q, --quiet`: Suppress verbose output.
+
+**Example:**
+
+List topics in the "getting-started" forum sorted by most recent, showing 5 per page:
+
+```bash
+kaggle forums topics getting-started --sort-by recent --page-size 5
+```
+
+**Purpose:**
+
+This command lets you browse discussion topics within a specific forum, with filtering and sorting options.
+
+## `kaggle forums topics show`
+
+Displays a topic with all comments in tree form (indented).
+
+**Usage:**
+
+```bash
+kaggle forums topics show <TOPIC_REF> [options]
+```
+
+**Arguments:**
+
+*   `<TOPIC_REF>`: A topic reference, which can be:
+    *   `<forum-name>/<topic-id>` (e.g., `getting-started/12345`)
+    *   `<forum-name> <topic-id>` (two separate arguments)
+    *   `<topic-id>` (bare numeric ID)
+
+**Options:**
+
+*   `-v, --csv`: Print results in CSV format.
+*   `-q, --quiet`: Suppress verbose output.
+
+**Example:**
+
+Show topic 12345 from the "getting-started" forum:
+
+```bash
+kaggle forums topics show getting-started/12345
+```
+
+Show the same topic using two separate arguments:
+
+```bash
+kaggle forums topics show getting-started 12345
+```
+
+Show a topic by bare numeric ID:
+
+```bash
+kaggle forums topics show 12345
+```
+
+**Purpose:**
+
+This command displays a full discussion topic along with all of its comments rendered in an indented tree structure.

--- a/docs/forums.md
+++ b/docs/forums.md
@@ -89,6 +89,8 @@ kaggle forums topics show <TOPIC_REF> [options]
 
 *   `-v, --csv`: Print results in CSV format.
 *   `-q, --quiet`: Suppress verbose output.
+*   `--page-size <PAGE_SIZE>`: Number of comments to show per page.
+*   `--page-token <PAGE_TOKEN>`: Page token for comment pagination.
 
 **Example:**
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -182,3 +182,70 @@ kaggle models delete $KAGGLE_DEVELOPER/test-model -y
 **Purpose:**
 
 This command permanently removes one of your models (and all its variations and versions) from Kaggle. Use with caution.
+
+## `kaggle models topics`
+
+Lists discussion topics for a model.
+
+**Usage:**
+
+```bash
+kaggle models topics <MODEL> [options]
+```
+
+**Arguments:**
+
+*   `<MODEL>`: Model ref in format `<owner>/<model-slug>` (e.g., `google/gemma`).
+
+**Options:**
+
+*   `--sort-by <SORT_BY>`: Sort order. Valid options: `hot`, `top`, `new`, `recent`, `active`, `relevance`.
+*   `--page-size <PAGE_SIZE>`: Number of items per page.
+*   `--page-token <PAGE_TOKEN>`: Page token for pagination.
+*   `-s, --search <SEARCH_TERM>`: Search query.
+*   `-v, --csv`: Print results in CSV format.
+*   `-q, --quiet`: Suppress verbose output.
+
+**Example:**
+
+```bash
+kaggle models topics google/gemma --sort-by hot
+```
+
+**Purpose:**
+
+This command lets you browse discussion topics for a specific model.
+
+## `kaggle models topics show`
+
+Displays a model discussion topic with all comments in tree form.
+
+**Usage:**
+
+```bash
+kaggle models topics show <MODEL>/<TOPIC_ID> [options]
+```
+
+**Arguments:**
+
+*   `<TOPIC_REF>`: A topic reference, which can be:
+    *   `<model>/<topic-id>` (e.g., `google/gemma/12345`)
+    *   `<model> <topic-id>` (two separate arguments)
+    *   `<topic-id>` (bare numeric ID)
+
+**Options:**
+
+*   `-v, --csv`: Print results in CSV format.
+*   `-q, --quiet`: Suppress verbose output.
+*   `--page-size <PAGE_SIZE>`: Number of comments to show per page.
+*   `--page-token <PAGE_TOKEN>`: Page token for comment pagination.
+
+**Example:**
+
+```bash
+kaggle models topics show google/gemma/12345
+```
+
+**Purpose:**
+
+This command displays a full discussion topic along with all of its comments rendered in an indented tree structure.

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -98,8 +98,23 @@ from kagglesdk.competitions.types.competition_api_service import (
     ApiListTopicMessagesRequest,
     ApiListTopicMessagesResponse,
 )
+from kagglesdk.discussions.types.discussions_api_service import (
+    ApiDiscussionComment,
+    ApiDiscussionForum,
+    ApiDiscussionTopic,
+    ApiGetTopicRequest,
+    ApiGetTopicResponse,
+    ApiListCommentsRequest,
+    ApiListCommentsResponse,
+    ApiListForumsRequest,
+    ApiListForumsResponse,
+    ApiListTopicsRequest,
+    ApiListTopicsResponse,
+)
 from kagglesdk.discussions.types.discussions_enums import (
     CommentListSortBy,
+    TopicListCategory,
+    TopicListGroup,
     TopicListSortBy,
 )
 from kagglesdk.competitions.types.competition_enums import (
@@ -804,6 +819,14 @@ class KaggleApi:
     competition_topic_message_fields = ["id", "authorName", "postDate", "votes", "content"]
     valid_topic_sort_by = ["hot", "top", "new", "recent", "active", "relevance"]
     valid_comment_sort_by = ["hot", "new", "old", "top"]
+
+    # Forums / Discussions
+    forum_fields = ["id", "name", "subtitle"]
+    forum_topic_fields = ["id", "title", "authorName", "commentCount", "votes", "postDate"]
+    forum_comment_fields = ["id", "authorName", "postDate", "votes", "content"]
+    valid_forum_topic_sort_by = ["hot", "top", "new", "recent", "active", "relevance"]
+    valid_forum_topic_categories = ["all", "forums", "competitions", "datasets", "competition_write_ups", "models", "benchmarks"]
+    valid_forum_topic_groups = ["all", "owned", "upvoted", "bookmarked", "my_activity", "drafts"]
 
     def _is_retriable(self, e: HTTPError) -> bool:
         if self._is_rate_limited(e):
@@ -2269,6 +2292,242 @@ class KaggleApi:
             flat.append(m)
             if getattr(m, "replies", None):
                 flat.extend(self._flatten_topic_messages(m.replies, depth + 1))
+        return flat
+
+    # ── Forums / Discussions ─────────────────────────────────────────────
+
+    def forums_list(self):
+        """List all top-level discussion forums on Kaggle.
+
+        Returns:
+            ApiListForumsResponse: response with a list of forums.
+        """
+        with self.build_kaggle_client() as kaggle:
+            request = ApiListForumsRequest()
+            return kaggle.discussions.discussion_api_client.list_forums(request)
+
+    def forums_list_cli(self, csv_display=False, quiet=False):
+        """CLI wrapper for forums_list."""
+        response = self.forums_list()
+        forums = response.forums
+        if forums:
+            fields = self.forum_fields
+            if csv_display:
+                self.print_csv(forums, fields)
+            else:
+                self.print_table(forums, fields)
+        else:
+            print("No forums found")
+
+    def forums_list_topics(
+        self,
+        forum_slug: Optional[str] = None,
+        sort_by: Optional[str] = None,
+        page_size: Optional[int] = None,
+        page_token: Optional[str] = None,
+        search: Optional[str] = None,
+        category: Optional[str] = None,
+        group: Optional[str] = None,
+    ):
+        """List discussion topics, optionally filtered by forum.
+
+        Args:
+            forum_slug (Optional[str]): Forum slug to filter by (e.g. 'getting-started').
+            sort_by (Optional[str]): Sort order; one of valid_forum_topic_sort_by.
+            page_size (Optional[int]): Number of results per page.
+            page_token (Optional[str]): Page token for pagination.
+            search (Optional[str]): Search query to filter topics.
+            category (Optional[str]): Topic category filter; one of valid_forum_topic_categories.
+            group (Optional[str]): Topic group filter; one of valid_forum_topic_groups.
+
+        Returns:
+            ApiListTopicsResponse: response with topics, total_count, and next_page_token.
+        """
+        with self.build_kaggle_client() as kaggle:
+            request = ApiListTopicsRequest()
+            if forum_slug:
+                request.forum_slug = forum_slug
+            if sort_by:
+                if sort_by not in self.valid_forum_topic_sort_by:
+                    raise ValueError(
+                        "Invalid sort_by specified. Valid options are " + str(self.valid_forum_topic_sort_by)
+                    )
+                request.sort_by = TopicListSortBy["TOPIC_LIST_SORT_BY_" + sort_by.upper()]
+            if page_size is not None:
+                request.page_size = page_size
+            if page_token:
+                request.page_token = page_token
+            if search:
+                request.search_query = search
+            if category:
+                if category not in self.valid_forum_topic_categories:
+                    raise ValueError(
+                        "Invalid category specified. Valid options are " + str(self.valid_forum_topic_categories)
+                    )
+                request.category = TopicListCategory["TOPIC_LIST_CATEGORY_" + category.upper()]
+            if group:
+                if group not in self.valid_forum_topic_groups:
+                    raise ValueError(
+                        "Invalid group specified. Valid options are " + str(self.valid_forum_topic_groups)
+                    )
+                request.group = TopicListGroup["TOPIC_LIST_GROUP_" + group.upper()]
+            return kaggle.discussions.discussion_api_client.list_topics(request)
+
+    def forums_list_topics_cli(
+        self,
+        forum=None,
+        sort_by=None,
+        page_size=None,
+        page_token=None,
+        search=None,
+        category=None,
+        group=None,
+        csv_display=False,
+        quiet=False,
+    ):
+        """CLI wrapper for forums_list_topics."""
+        response = self.forums_list_topics(
+            forum_slug=forum,
+            sort_by=sort_by,
+            page_size=page_size,
+            page_token=page_token,
+            search=search,
+            category=category,
+            group=group,
+        )
+        topics = response.topics
+        if topics:
+            fields = self.forum_topic_fields
+            if csv_display:
+                self.print_csv(topics, fields)
+            else:
+                self.print_table(topics, fields)
+            if not quiet and response.next_page_token:
+                print(f"Next page token: {response.next_page_token}")
+        else:
+            print("No topics found")
+
+    def forums_topic_show(self, topic_id: int):
+        """Get a single discussion topic by ID, including its comments.
+
+        Args:
+            topic_id (int): The topic ID.
+
+        Returns:
+            tuple: (ApiDiscussionTopic, list[ApiDiscussionComment]) — the topic and its comments.
+        """
+        with self.build_kaggle_client() as kaggle:
+            # Fetch the topic
+            get_request = ApiGetTopicRequest()
+            get_request.id = topic_id
+            topic_response = kaggle.discussions.discussion_api_client.get_topic(get_request)
+            topic = topic_response.topic
+
+            # Fetch comments (paginate to get all)
+            all_comments: list = []
+            page_token: Optional[str] = None
+            while True:
+                comments_request = ApiListCommentsRequest()
+                comments_request.topic_id = topic_id
+                if page_token:
+                    comments_request.page_token = page_token
+                comments_response = kaggle.discussions.discussion_api_client.list_comments(comments_request)
+                if comments_response.comments:
+                    all_comments.extend(comments_response.comments)
+                next_token = comments_response.next_page_token
+                if not next_token:
+                    break
+                page_token = next_token
+
+            return topic, all_comments
+
+    def forums_topic_show_cli(
+        self,
+        topic_ref=None,
+        topic_id_arg=None,
+        csv_display=False,
+        quiet=False,
+    ):
+        """CLI wrapper for forums_topic_show.
+
+        topic_ref can be either 'forum-slug/topic-id' or just 'topic-id'.
+        topic_id_arg is the second positional arg when using 'forum-slug topic-id' form.
+        """
+        # Support both 'forum-slug/topic-id' and 'forum-slug topic-id' forms
+        if topic_id_arg is not None:
+            # Two separate positional args: forum-slug topic-id
+            topic_id = int(topic_id_arg)
+        elif topic_ref and "/" in topic_ref:
+            # Single arg with slash: forum-slug/topic-id
+            parts = topic_ref.rsplit("/", 1)
+            topic_id = int(parts[1])
+        else:
+            # Just a bare topic-id
+            if topic_ref is None:
+                raise ValueError("No topic specified. Usage: kaggle forums topics show <forum>/<topic-id>")
+            topic_id = int(topic_ref)
+
+        topic, comments = self.forums_topic_show(topic_id)
+
+        if topic is None:
+            print("Topic not found")
+            return
+
+        if csv_display:
+            # In CSV mode, print the topic then flat comments
+            self.print_csv([topic], self.forum_topic_fields)
+            flat = self._flatten_discussion_comments(comments)
+            if flat:
+                self.print_csv(flat, self.forum_comment_fields)
+        else:
+            # Pretty-print the topic header
+            print(f"Topic #{topic.id}: {topic.title}")
+            print(f"  Author: {topic.author_name}")
+            print(f"  Posted: {topic.post_date}")
+            print(f"  Votes: {topic.votes}  Comments: {topic.comment_count}")
+            if topic.content:
+                content = bleach.clean(topic.content, tags=[], strip=True).strip()
+                print(f"\n{content}")
+            print()
+
+            # Print comment tree
+            if comments:
+                print("Comments:")
+                self._print_comment_tree(comments)
+            elif not quiet:
+                print("No comments")
+
+    def _print_comment_tree(self, comments, depth=0):
+        """Recursively print comments with indentation to show tree structure."""
+        indent = "  " * depth
+        for comment in comments or []:
+            author = getattr(comment, "author_name", "Unknown")
+            date = getattr(comment, "post_date", "")
+            votes = getattr(comment, "votes", 0)
+            content = getattr(comment, "content", "")
+            if content:
+                content = bleach.clean(content, tags=[], strip=True).strip()
+                # Truncate long content for display
+                if len(content) > 200:
+                    content = content[:197] + "..."
+
+            print(f"{indent}├─ {author} ({date}) [+{votes}]")
+            if content:
+                # Indent content lines
+                for line in content.split("\n"):
+                    print(f"{indent}│  {line}")
+
+            replies = getattr(comment, "replies", None)
+            if replies:
+                self._print_comment_tree(replies, depth + 1)
+
+    def _flatten_discussion_comments(self, comments, depth=0):
+        """Flatten nested discussion comments into a single list."""
+        flat = []
+        for c in comments or []:
+            flat.append(c)
+            if getattr(c, "replies", None):
+                flat.extend(self._flatten_discussion_comments(c.replies, depth + 1))
         return flat
 
     def dataset_list(

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -825,7 +825,15 @@ class KaggleApi:
     forum_topic_fields = ["id", "title", "authorName", "commentCount", "votes", "postDate"]
     forum_comment_fields = ["id", "authorName", "postDate", "votes", "content"]
     valid_forum_topic_sort_by = ["hot", "top", "new", "recent", "active", "relevance"]
-    valid_forum_topic_categories = ["all", "forums", "competitions", "datasets", "competition_write_ups", "models", "benchmarks"]
+    valid_forum_topic_categories = [
+        "all",
+        "forums",
+        "competitions",
+        "datasets",
+        "competition_write_ups",
+        "models",
+        "benchmarks",
+    ]
     valid_forum_topic_groups = ["all", "owned", "upvoted", "bookmarked", "my_activity", "drafts"]
 
     def _is_retriable(self, e: HTTPError) -> bool:
@@ -2367,9 +2375,7 @@ class KaggleApi:
                 request.category = TopicListCategory["TOPIC_LIST_CATEGORY_" + category.upper()]
             if group:
                 if group not in self.valid_forum_topic_groups:
-                    raise ValueError(
-                        "Invalid group specified. Valid options are " + str(self.valid_forum_topic_groups)
-                    )
+                    raise ValueError("Invalid group specified. Valid options are " + str(self.valid_forum_topic_groups))
                 request.group = TopicListGroup["TOPIC_LIST_GROUP_" + group.upper()]
             return kaggle.discussions.discussion_api_client.list_topics(request)
 
@@ -2407,14 +2413,22 @@ class KaggleApi:
         else:
             print("No topics found")
 
-    def forums_topic_show(self, topic_id: int):
+    def forums_topic_show(
+        self,
+        topic_id: int,
+        page_size: Optional[int] = None,
+        page_token: Optional[str] = None,
+    ):
         """Get a single discussion topic by ID, including its comments.
 
         Args:
             topic_id (int): The topic ID.
+            page_size (Optional[int]): Number of comments per page. If None, fetches all.
+            page_token (Optional[str]): Page token for comment pagination.
 
         Returns:
-            tuple: (ApiDiscussionTopic, list[ApiDiscussionComment]) — the topic and its comments.
+            tuple: (ApiDiscussionTopic, list[ApiDiscussionComment], str) — the topic,
+                comments, and next_page_token (empty string if no more pages).
         """
         with self.build_kaggle_client() as kaggle:
             # Fetch the topic
@@ -2423,28 +2437,41 @@ class KaggleApi:
             topic_response = kaggle.discussions.discussion_api_client.get_topic(get_request)
             topic = topic_response.topic
 
-            # Fetch comments (paginate to get all)
-            all_comments: list = []
-            page_token: Optional[str] = None
-            while True:
+            # Fetch comments
+            if page_size is not None:
+                # Single page requested
                 comments_request = ApiListCommentsRequest()
                 comments_request.topic_id = topic_id
+                comments_request.page_size = page_size
                 if page_token:
                     comments_request.page_token = page_token
                 comments_response = kaggle.discussions.discussion_api_client.list_comments(comments_request)
-                if comments_response.comments:
-                    all_comments.extend(comments_response.comments)
-                next_token = comments_response.next_page_token
-                if not next_token:
-                    break
-                page_token = next_token
+                return topic, comments_response.comments or [], comments_response.next_page_token or ""
+            else:
+                # Fetch all pages
+                all_comments: list = []
+                current_token: Optional[str] = page_token
+                while True:
+                    comments_request = ApiListCommentsRequest()
+                    comments_request.topic_id = topic_id
+                    if current_token:
+                        comments_request.page_token = current_token
+                    comments_response = kaggle.discussions.discussion_api_client.list_comments(comments_request)
+                    if comments_response.comments:
+                        all_comments.extend(comments_response.comments)
+                    next_token = comments_response.next_page_token
+                    if not next_token:
+                        break
+                    current_token = next_token
 
-            return topic, all_comments
+                return topic, all_comments, ""
 
     def forums_topic_show_cli(
         self,
         topic_ref=None,
         topic_id_arg=None,
+        page_size=None,
+        page_token=None,
         csv_display=False,
         quiet=False,
     ):
@@ -2467,7 +2494,7 @@ class KaggleApi:
                 raise ValueError("No topic specified. Usage: kaggle forums topics show <forum>/<topic-id>")
             topic_id = int(topic_ref)
 
-        topic, comments = self.forums_topic_show(topic_id)
+        topic, comments, next_page_token = self.forums_topic_show(topic_id, page_size=page_size, page_token=page_token)
 
         if topic is None:
             print("Topic not found")
@@ -2496,6 +2523,9 @@ class KaggleApi:
                 self._print_comment_tree(comments)
             elif not quiet:
                 print("No comments")
+
+        if not quiet and next_page_token:
+            print(f"Next page token: {next_page_token}")
 
     def _print_comment_tree(self, comments, depth=0):
         """Recursively print comments with indentation to show tree structure."""

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -2204,6 +2204,9 @@ class KaggleApi:
         competition_opt=None,
         sort_by=None,
         page=None,
+        page_size=None,
+        page_token=None,
+        search=None,
         csv_display=False,
         quiet=False,
     ):
@@ -2217,14 +2220,22 @@ class KaggleApi:
         if competition is None:
             raise ValueError("No competition specified")
 
-        response = self.competition_list_topics(competition, sort_by=sort_by, page=page)
+        response = self.forums_list_topics(
+            forum_slug=competition,
+            sort_by=sort_by,
+            page_size=page_size,
+            page_token=page_token,
+            search=search,
+        )
         topics = response.topics
         if topics:
-            fields = self.competition_topic_fields
+            fields = self.forum_topic_fields
             if csv_display:
                 self.print_csv(topics, fields)
             else:
                 self.print_table(topics, fields)
+            if not quiet and response.next_page_token:
+                print(f"Next page token: {response.next_page_token}")
         else:
             print("No topics found")
 
@@ -2559,6 +2570,73 @@ class KaggleApi:
             if getattr(c, "replies", None):
                 flat.extend(self._flatten_discussion_comments(c.replies, depth + 1))
         return flat
+
+    # ------------------------------------------------------------------
+    # Generic entity topics CLI wrappers
+    #
+    # These allow datasets, models, and benchmarks to reuse the forums
+    # discussion API by passing the entity ref as the forum slug.
+    # ------------------------------------------------------------------
+
+    def entity_list_topics_cli(
+        self,
+        entity_ref=None,
+        sort_by=None,
+        page_size=None,
+        page_token=None,
+        search=None,
+        csv_display=False,
+        quiet=False,
+    ):
+        """Generic CLI wrapper that lists discussion topics for any entity.
+
+        Args:
+            entity_ref (str): The entity identifier used as the forum slug
+                (e.g. 'titanic', 'zillow/zecon', 'google/gemma').
+        """
+        if entity_ref is None:
+            raise ValueError("No entity specified")
+
+        response = self.forums_list_topics(
+            forum_slug=entity_ref,
+            sort_by=sort_by,
+            page_size=page_size,
+            page_token=page_token,
+            search=search,
+        )
+        topics = response.topics
+        if topics:
+            fields = self.forum_topic_fields
+            if csv_display:
+                self.print_csv(topics, fields)
+            else:
+                self.print_table(topics, fields)
+            if not quiet and response.next_page_token:
+                print(f"Next page token: {response.next_page_token}")
+        else:
+            print("No topics found")
+
+    def entity_topic_show_cli(
+        self,
+        topic_ref=None,
+        topic_id_arg=None,
+        page_size=None,
+        page_token=None,
+        csv_display=False,
+        quiet=False,
+    ):
+        """Generic CLI wrapper that displays a discussion topic for any entity.
+
+        Delegates to forums_topic_show_cli with the same arguments.
+        """
+        self.forums_topic_show_cli(
+            topic_ref=topic_ref,
+            topic_id_arg=topic_id_arg,
+            page_size=page_size,
+            page_token=page_token,
+            csv_display=csv_display,
+            quiet=quiet,
+        )
 
     def dataset_list(
         self,

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -359,10 +359,13 @@ def parse_competitions(subparsers) -> None:
     parser_competitions_pages._action_groups.append(parser_competitions_pages_optional)
     parser_competitions_pages.set_defaults(func=api.competition_list_pages_cli)
 
-    # Competitions list discussion topics
+    # Competitions list discussion topics (with 'show' subcommand)
     parser_competitions_topics = subparsers_competitions.add_parser(
         "topics", formatter_class=argparse.RawTextHelpFormatter, help=Help.command_competitions_topics
     )
+    subparsers_competitions_topics = parser_competitions_topics.add_subparsers(title="commands", dest="command")
+    subparsers_competitions_topics.choices = Help.entity_topics_choices
+
     parser_competitions_topics_optional = parser_competitions_topics._action_groups.pop()
     parser_competitions_topics_optional.add_argument(
         "competition", nargs="?", default=None, help=Help.param_competition
@@ -375,11 +378,15 @@ def parse_competitions(subparsers) -> None:
         "--sort-by",
         dest="sort_by",
         required=False,
-        help="Sort order. One of: " + ", ".join(KaggleApi.valid_topic_sort_by),
+        help="Sort order. One of: " + ", ".join(KaggleApi.valid_forum_topic_sort_by),
     )
     parser_competitions_topics_optional.add_argument(
-        "-p", "--page", dest="page", type=int, required=False, help="Page number (1-based)"
+        "--page-size", dest="page_size", type=int, required=False, help=Help.param_page_size
     )
+    parser_competitions_topics_optional.add_argument(
+        "--page-token", dest="page_token", required=False, help=Help.param_page_token
+    )
+    parser_competitions_topics_optional.add_argument("--search", dest="search", required=False, help=Help.param_search)
     parser_competitions_topics_optional.add_argument(
         "-v", "--csv", dest="csv_display", action="store_true", help=Help.param_csv
     )
@@ -389,11 +396,14 @@ def parse_competitions(subparsers) -> None:
     parser_competitions_topics._action_groups.append(parser_competitions_topics_optional)
     parser_competitions_topics.set_defaults(func=api.competition_list_topics_cli)
 
-    # Competitions list messages within a topic
+    # Competitions topics show
+    _add_topics_show_parser(subparsers_competitions_topics)
+
+    # Competitions list messages within a topic (DEPRECATED — hidden alias)
     parser_competitions_topic_messages = subparsers_competitions.add_parser(
         "topic-messages",
         formatter_class=argparse.RawTextHelpFormatter,
-        help=Help.command_competitions_topic_messages,
+        help=argparse.SUPPRESS,
     )
     parser_competitions_topic_messages_optional = parser_competitions_topic_messages._action_groups.pop()
     parser_competitions_topic_messages_optional.add_argument(
@@ -626,6 +636,14 @@ def parse_datasets(subparsers) -> None:
     )
     parser_datasets_status._action_groups.append(parser_datasets_status_optional)
     parser_datasets_status.set_defaults(func=api.dataset_status_cli)
+
+    # Datasets discussion topics
+    _add_entity_topics_parser(
+        subparsers_datasets,
+        entity_name="dataset",
+        entity_help=Help.command_datasets_topics,
+        entity_param_help=Help.param_dataset,
+    )
 
 
 def parse_kernels(subparsers) -> None:
@@ -888,6 +906,14 @@ def parse_models(subparsers) -> None:
     )
     parser_models_update._action_groups.append(parser_models_update_optional)
     parser_models_update.set_defaults(func=api.model_update_cli)
+
+    # Models discussion topics
+    _add_entity_topics_parser(
+        subparsers_models,
+        entity_name="model",
+        entity_help=Help.command_models_topics,
+        entity_param_help=Help.param_model,
+    )
 
 
 def parse_model_instances(subparsers) -> None:
@@ -1170,6 +1196,14 @@ def parse_benchmarks(subparsers) -> None:
     parse_benchmarks_auth(subparsers_benchmarks)
     parse_benchmarks_init(subparsers_benchmarks)
 
+    # Benchmarks discussion topics
+    _add_entity_topics_parser(
+        subparsers_benchmarks,
+        entity_name="benchmark",
+        entity_help=Help.command_benchmarks_topics,
+        entity_param_help=Help.param_benchmarks_task,
+    )
+
 
 def parse_benchmarks_auth(subparsers) -> None:
     parser_auth = subparsers.add_parser(
@@ -1409,6 +1443,73 @@ def parse_auth(subparsers) -> None:
     parser_auth_revoke_token.set_defaults(func=api.auth_revoke_token)
 
 
+# ------------------------------------------------------------------
+# Shared helpers for discussion topics across entity types
+# ------------------------------------------------------------------
+
+
+def _add_topics_show_parser(parent_subparsers) -> None:
+    """Add a 'show' subcommand for displaying a topic with threaded comments.
+
+    This is shared by competitions, datasets, models, benchmarks, and forums.
+    """
+    parser_show = parent_subparsers.add_parser(
+        "show", formatter_class=argparse.RawTextHelpFormatter, help=Help.command_entity_topics_show
+    )
+    parser_show_optional = parser_show._action_groups.pop()
+    parser_show_optional.add_argument("topic_ref", help=Help.param_topic_ref)
+    parser_show_optional.add_argument(
+        "topic_id_arg",
+        nargs="?",
+        default=None,
+        type=int,
+        help="Topic ID (when using two-arg form: <entity-ref> <topic-id>)",
+    )
+    parser_show_optional.add_argument("-v", "--csv", dest="csv_display", action="store_true", help=Help.param_csv)
+    parser_show_optional.add_argument("-q", "--quiet", dest="quiet", action="store_true", help=Help.param_quiet)
+    parser_show_optional.add_argument(
+        "--page-size", dest="page_size", type=int, required=False, help=Help.param_page_size
+    )
+    parser_show_optional.add_argument("--page-token", dest="page_token", required=False, help=Help.param_page_token)
+    parser_show._action_groups.append(parser_show_optional)
+    parser_show.set_defaults(func=api.entity_topic_show_cli)
+
+
+def _add_entity_topics_parser(parent_subparsers, entity_name, entity_help, entity_param_help) -> None:
+    """Add 'topics' and 'topics show' subcommands to an entity type.
+
+    This creates:
+      kaggle <entity> topics <entity_ref> [options]
+      kaggle <entity> topics show <topic_ref> [options]
+    """
+    parser_topics = parent_subparsers.add_parser(
+        "topics", formatter_class=argparse.RawTextHelpFormatter, help=f"List discussion topics for a {entity_name}"
+    )
+    subparsers_topics = parser_topics.add_subparsers(title="commands", dest="command")
+    subparsers_topics.choices = Help.entity_topics_choices
+
+    parser_topics_optional = parser_topics._action_groups.pop()
+    parser_topics_optional.add_argument("entity_ref", nargs="?", default=None, help=entity_param_help)
+    parser_topics_optional.add_argument(
+        "--sort-by",
+        dest="sort_by",
+        required=False,
+        help="Sort order. One of: " + ", ".join(KaggleApi.valid_forum_topic_sort_by),
+    )
+    parser_topics_optional.add_argument(
+        "--page-size", dest="page_size", type=int, required=False, help=Help.param_page_size
+    )
+    parser_topics_optional.add_argument("--page-token", dest="page_token", required=False, help=Help.param_page_token)
+    parser_topics_optional.add_argument("-s", "--search", dest="search", required=False, help=Help.param_search)
+    parser_topics_optional.add_argument("-v", "--csv", dest="csv_display", action="store_true", help=Help.param_csv)
+    parser_topics_optional.add_argument("-q", "--quiet", dest="quiet", action="store_true", help=Help.param_quiet)
+    parser_topics._action_groups.append(parser_topics_optional)
+    parser_topics.set_defaults(func=api.entity_list_topics_cli)
+
+    # Add 'show' subcommand
+    _add_topics_show_parser(subparsers_topics)
+
+
 def parse_forums(subparsers) -> None:
     parser_forums = subparsers.add_parser(
         "forums", formatter_class=argparse.RawTextHelpFormatter, help=Help.group_forums, aliases=["fo"]
@@ -1536,29 +1637,56 @@ class Help(object):
         "topics",
         "topic-messages",
     ]
-    datasets_choices = ["list", "files", "download", "create", "version", "init", "metadata", "status", "delete"]
+    datasets_choices = [
+        "list",
+        "files",
+        "download",
+        "create",
+        "version",
+        "init",
+        "metadata",
+        "status",
+        "delete",
+        "topics",
+    ]
     kernels_choices = ["list", "files", "get", "init", "push", "pull", "output", "status", "logs", "update", "delete"]
-    models_choices = ["instances", "i", "variations", "v", "get", "list", "init", "create", "delete", "update"]
+    models_choices = [
+        "instances",
+        "i",
+        "variations",
+        "v",
+        "get",
+        "list",
+        "init",
+        "create",
+        "delete",
+        "update",
+        "topics",
+    ]
     model_instances_choices = ["versions", "v", "get", "files", "list", "init", "create", "delete", "update"]
     model_instance_versions_choices = ["init", "create", "download", "delete", "files", "list"]
     files_choices = ["upload"]
-    benchmarks_choices = ["tasks", "t", "auth", "init"]
+    benchmarks_choices = ["tasks", "t", "auth", "init", "topics"]
     benchmarks_tasks_choices = ["push", "run", "list", "status", "download", "models", "delete"]
     forums_choices = ["list", "topics"]
     forums_topics_choices = ["show"]
+    entity_topics_choices = ["show"]
     config_choices = ["view", "set", "unset"]
     auth_choices = ["login", "print-access-token", "revoke"]
 
     kaggle = (
         "Use one of:\ncompetitions {"
         + ", ".join(competitions_choices)
-        + "}\ndatasets {"
+        + "}\ncompetitions topics {show}"
+        + "\ndatasets {"
         + ", ".join(datasets_choices)
-        + "}\nkernels {"
+        + "}\ndatasets topics {show}"
+        + "\nkernels {"
         + ", ".join(kernels_choices)
         + "}\nmodels {"
         + ", ".join(models_choices)
-        + "}\nmodels variations {"
+        + "}\nmodels topics {show}"
+        + "\nmodels variations {"
         + ", ".join(model_instances_choices)
         + "}\nmodels variations versions {"
         + ", ".join(model_instance_versions_choices)
@@ -1568,7 +1696,8 @@ class Help(object):
         + ", ".join(forums_topics_choices)
         + "}\nbenchmarks {"
         + ", ".join(benchmarks_choices)
-        + "}\nconfig {"
+        + "}\nbenchmarks topics {show}"
+        + "\nconfig {"
         + ", ".join(config_choices)
         + "}"
     )
@@ -1586,6 +1715,9 @@ class Help(object):
     group_benchmarks_tasks = "Commands related to benchmark tasks"
     group_config = "Configuration settings"
     group_auth = "Commands related to authentication"
+
+    # Entity topics commands (shared across entity types)
+    command_entity_topics_show = "Display a topic with all its comments in tree form"
 
     # Competitions commands
     command_competitions_list = "List available competitions"
@@ -1608,6 +1740,7 @@ class Help(object):
 
     # Datasets commands
     command_datasets_list = "List available datasets"
+    command_datasets_topics = "List discussion topics for a dataset"
     command_datasets_files = "List dataset files"
     command_datasets_download = "Download dataset files"
     command_datasets_new = "Create a new dataset"
@@ -1630,6 +1763,7 @@ class Help(object):
 
     # Models commands
     command_models_files = "List model files"
+    command_models_topics = "List discussion topics for a model"
     command_models_get = "Get a model"
     command_models_list = "List models"
     command_models_init = "Initialize metadata file for model creation"
@@ -1639,6 +1773,7 @@ class Help(object):
 
     # Benchmarks commands
     command_benchmarks_auth = "Fetch and persist Model Proxy credential information"
+    command_benchmarks_topics = "List discussion topics for a benchmark"
     command_benchmarks_init = (
         "Fetch and persist  Model Proxy credentials and other Kaggle Benchmarks environment variables"
     )

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -1427,9 +1427,7 @@ def parse_forums(subparsers) -> None:
     parser_forums_list_optional.add_argument(
         "-v", "--csv", dest="csv_display", action="store_true", help=Help.param_csv
     )
-    parser_forums_list_optional.add_argument(
-        "-q", "--quiet", dest="quiet", action="store_true", help=Help.param_quiet
-    )
+    parser_forums_list_optional.add_argument("-q", "--quiet", dest="quiet", action="store_true", help=Help.param_quiet)
     parser_forums_list._action_groups.append(parser_forums_list_optional)
     parser_forums_list.set_defaults(func=api.forums_list_cli)
 
@@ -1441,11 +1439,11 @@ def parse_forums(subparsers) -> None:
     subparsers_forums_topics.choices = Help.forums_topics_choices
 
     parser_forums_topics_optional = parser_forums_topics._action_groups.pop()
+    parser_forums_topics_optional.add_argument("forum", nargs="?", default=None, help=Help.param_forum)
     parser_forums_topics_optional.add_argument(
-        "forum", nargs="?", default=None, help=Help.param_forum
-    )
-    parser_forums_topics_optional.add_argument(
-        "--sort-by", dest="sort_by", required=False,
+        "--sort-by",
+        dest="sort_by",
+        required=False,
         help="Sort order. One of: " + ", ".join(KaggleApi.valid_forum_topic_sort_by),
     )
     parser_forums_topics_optional.add_argument(
@@ -1454,15 +1452,17 @@ def parse_forums(subparsers) -> None:
     parser_forums_topics_optional.add_argument(
         "--page-token", dest="page_token", required=False, help=Help.param_page_token
     )
+    parser_forums_topics_optional.add_argument("-s", "--search", dest="search", required=False, help=Help.param_search)
     parser_forums_topics_optional.add_argument(
-        "-s", "--search", dest="search", required=False, help=Help.param_search
-    )
-    parser_forums_topics_optional.add_argument(
-        "--category", dest="category", required=False,
+        "--category",
+        dest="category",
+        required=False,
         help="Filter by category. One of: " + ", ".join(KaggleApi.valid_forum_topic_categories),
     )
     parser_forums_topics_optional.add_argument(
-        "--group", dest="group", required=False,
+        "--group",
+        dest="group",
+        required=False,
         help="Filter by group. One of: " + ", ".join(KaggleApi.valid_forum_topic_groups),
     )
     parser_forums_topics_optional.add_argument(
@@ -1479,18 +1479,25 @@ def parse_forums(subparsers) -> None:
         "show", formatter_class=argparse.RawTextHelpFormatter, help=Help.command_forums_topics_show
     )
     parser_forums_topics_show_optional = parser_forums_topics_show._action_groups.pop()
+    parser_forums_topics_show_optional.add_argument("topic_ref", help=Help.param_topic_ref)
     parser_forums_topics_show_optional.add_argument(
-        "topic_ref", help=Help.param_topic_ref
-    )
-    parser_forums_topics_show_optional.add_argument(
-        "topic_id_arg", nargs="?", default=None, type=int,
-        help="Topic ID (when using two-arg form: <forum-name> <topic-id>)"
+        "topic_id_arg",
+        nargs="?",
+        default=None,
+        type=int,
+        help="Topic ID (when using two-arg form: <forum-name> <topic-id>)",
     )
     parser_forums_topics_show_optional.add_argument(
         "-v", "--csv", dest="csv_display", action="store_true", help=Help.param_csv
     )
     parser_forums_topics_show_optional.add_argument(
         "-q", "--quiet", dest="quiet", action="store_true", help=Help.param_quiet
+    )
+    parser_forums_topics_show_optional.add_argument(
+        "--page-size", dest="page_size", type=int, required=False, help=Help.param_page_size
+    )
+    parser_forums_topics_show_optional.add_argument(
+        "--page-token", dest="page_token", required=False, help=Help.param_page_token
     )
     parser_forums_topics_show._action_groups.append(parser_forums_topics_show_optional)
     parser_forums_topics_show.set_defaults(func=api.forums_topic_show_cli)
@@ -1691,8 +1698,7 @@ class Help(object):
 
     # Forums params
     param_forum = (
-        "Forum slug (e.g. 'getting-started', 'product-feedback').\n"
-        'Use "kaggle forums" to list available forums.'
+        "Forum slug (e.g. 'getting-started', 'product-feedback').\n" 'Use "kaggle forums" to list available forums.'
     )
     param_topic_ref = (
         "Topic reference in format <forum-name>/<topic-id> or just <topic-id>.\n"

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -54,6 +54,7 @@ def main() -> None:
     parse_kernels(subparsers)
     parse_models(subparsers)
     parse_files(subparsers)
+    parse_forums(subparsers)
     parse_benchmarks(subparsers)
     parse_config(subparsers)
     parse_auth(subparsers)
@@ -1408,6 +1409,93 @@ def parse_auth(subparsers) -> None:
     parser_auth_revoke_token.set_defaults(func=api.auth_revoke_token)
 
 
+def parse_forums(subparsers) -> None:
+    parser_forums = subparsers.add_parser(
+        "forums", formatter_class=argparse.RawTextHelpFormatter, help=Help.group_forums, aliases=["fo"]
+    )
+    subparsers_forums = parser_forums.add_subparsers(title="commands", dest="command")
+    subparsers_forums.choices = Help.forums_choices
+
+    # Default action: list forums (when no subcommand given)
+    parser_forums.set_defaults(func=api.forums_list_cli)
+
+    # Forums list (explicit)
+    parser_forums_list = subparsers_forums.add_parser(
+        "list", formatter_class=argparse.RawTextHelpFormatter, help=Help.command_forums_list
+    )
+    parser_forums_list_optional = parser_forums_list._action_groups.pop()
+    parser_forums_list_optional.add_argument(
+        "-v", "--csv", dest="csv_display", action="store_true", help=Help.param_csv
+    )
+    parser_forums_list_optional.add_argument(
+        "-q", "--quiet", dest="quiet", action="store_true", help=Help.param_quiet
+    )
+    parser_forums_list._action_groups.append(parser_forums_list_optional)
+    parser_forums_list.set_defaults(func=api.forums_list_cli)
+
+    # Forums topics
+    parser_forums_topics = subparsers_forums.add_parser(
+        "topics", formatter_class=argparse.RawTextHelpFormatter, help=Help.command_forums_topics
+    )
+    subparsers_forums_topics = parser_forums_topics.add_subparsers(title="commands", dest="command")
+    subparsers_forums_topics.choices = Help.forums_topics_choices
+
+    parser_forums_topics_optional = parser_forums_topics._action_groups.pop()
+    parser_forums_topics_optional.add_argument(
+        "forum", nargs="?", default=None, help=Help.param_forum
+    )
+    parser_forums_topics_optional.add_argument(
+        "--sort-by", dest="sort_by", required=False,
+        help="Sort order. One of: " + ", ".join(KaggleApi.valid_forum_topic_sort_by),
+    )
+    parser_forums_topics_optional.add_argument(
+        "--page-size", dest="page_size", type=int, required=False, help=Help.param_page_size
+    )
+    parser_forums_topics_optional.add_argument(
+        "--page-token", dest="page_token", required=False, help=Help.param_page_token
+    )
+    parser_forums_topics_optional.add_argument(
+        "-s", "--search", dest="search", required=False, help=Help.param_search
+    )
+    parser_forums_topics_optional.add_argument(
+        "--category", dest="category", required=False,
+        help="Filter by category. One of: " + ", ".join(KaggleApi.valid_forum_topic_categories),
+    )
+    parser_forums_topics_optional.add_argument(
+        "--group", dest="group", required=False,
+        help="Filter by group. One of: " + ", ".join(KaggleApi.valid_forum_topic_groups),
+    )
+    parser_forums_topics_optional.add_argument(
+        "-v", "--csv", dest="csv_display", action="store_true", help=Help.param_csv
+    )
+    parser_forums_topics_optional.add_argument(
+        "-q", "--quiet", dest="quiet", action="store_true", help=Help.param_quiet
+    )
+    parser_forums_topics._action_groups.append(parser_forums_topics_optional)
+    parser_forums_topics.set_defaults(func=api.forums_list_topics_cli)
+
+    # Forums topics show
+    parser_forums_topics_show = subparsers_forums_topics.add_parser(
+        "show", formatter_class=argparse.RawTextHelpFormatter, help=Help.command_forums_topics_show
+    )
+    parser_forums_topics_show_optional = parser_forums_topics_show._action_groups.pop()
+    parser_forums_topics_show_optional.add_argument(
+        "topic_ref", help=Help.param_topic_ref
+    )
+    parser_forums_topics_show_optional.add_argument(
+        "topic_id_arg", nargs="?", default=None, type=int,
+        help="Topic ID (when using two-arg form: <forum-name> <topic-id>)"
+    )
+    parser_forums_topics_show_optional.add_argument(
+        "-v", "--csv", dest="csv_display", action="store_true", help=Help.param_csv
+    )
+    parser_forums_topics_show_optional.add_argument(
+        "-q", "--quiet", dest="quiet", action="store_true", help=Help.param_quiet
+    )
+    parser_forums_topics_show._action_groups.append(parser_forums_topics_show_optional)
+    parser_forums_topics_show.set_defaults(func=api.forums_topic_show_cli)
+
+
 class Help(object):
     kaggle_choices = [
         "competitions",
@@ -1420,6 +1508,8 @@ class Help(object):
         "m",
         "files",
         "f",
+        "forums",
+        "fo",
         "benchmarks",
         "b",
         "config",
@@ -1447,6 +1537,8 @@ class Help(object):
     files_choices = ["upload"]
     benchmarks_choices = ["tasks", "t", "auth", "init"]
     benchmarks_tasks_choices = ["push", "run", "list", "status", "download", "models", "delete"]
+    forums_choices = ["list", "topics"]
+    forums_topics_choices = ["show"]
     config_choices = ["view", "set", "unset"]
     auth_choices = ["login", "print-access-token", "revoke"]
 
@@ -1463,6 +1555,10 @@ class Help(object):
         + ", ".join(model_instances_choices)
         + "}\nmodels variations versions {"
         + ", ".join(model_instance_versions_choices)
+        + "}\nforums {"
+        + ", ".join(forums_choices)
+        + "}\nforums topics {"
+        + ", ".join(forums_topics_choices)
         + "}\nbenchmarks {"
         + ", ".join(benchmarks_choices)
         + "}\nconfig {"
@@ -1477,6 +1573,7 @@ class Help(object):
     group_models = "Commands related to Kaggle models"
     group_model_instances = "Commands related to Kaggle model variations"
     group_model_instance_versions = "Commands related to Kaggle model variations versions"
+    group_forums = "Commands related to Kaggle discussion forums"
     group_files = "Commands related files"
     group_benchmarks = "Commands related to Kaggle benchmarks"
     group_benchmarks_tasks = "Commands related to benchmark tasks"
@@ -1496,6 +1593,11 @@ class Help(object):
     command_competitions_pages = "List pages for a competition"
     command_competitions_topics = "List discussion topics for a competition"
     command_competitions_topic_messages = "List messages within a competition discussion topic"
+
+    # Forums commands
+    command_forums_list = "List all discussion forums"
+    command_forums_topics = "List topics in a forum"
+    command_forums_topics_show = "Display a topic with all its comments in tree form"
 
     # Datasets commands
     command_datasets_list = "List available datasets"
@@ -1586,6 +1688,16 @@ class Help(object):
     param_page_token = "Page token for results paging."
     param_search = "Term(s) to search for"
     param_mine = "Display only my items"
+
+    # Forums params
+    param_forum = (
+        "Forum slug (e.g. 'getting-started', 'product-feedback').\n"
+        'Use "kaggle forums" to list available forums.'
+    )
+    param_topic_ref = (
+        "Topic reference in format <forum-name>/<topic-id> or just <topic-id>.\n"
+        "You can also pass <forum-name> and <topic-id> as two separate arguments."
+    )
     param_unzip = "Unzip the downloaded file. Will delete the zip file when completed."
     param_untar = "Untar the downloaded file. Will delete the tar file when completed."
     param_yes = 'Sets any confirmation values to "yes" automatically. Users will not be asked to confirm.'

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -483,10 +483,11 @@ class TestKaggleApi(unittest.TestCase):
         if not getattr(self, "forum_topic_id", None):
             self.skipTest("No topics available to show")
         try:
-            topic, comments = api.forums_topic_show(self.forum_topic_id)
+            topic, comments, next_page_token = api.forums_topic_show(self.forum_topic_id)
             self.assertIsNotNone(topic)
             self.assertEqual(topic.id, self.forum_topic_id)
             self.assertIsInstance(comments, list)
+            self.assertIsInstance(next_page_token, str)
         except ApiException as e:
             self.fail(f"forums_topic_show failed: {e}")
 

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -449,6 +449,20 @@ class TestKaggleApi(unittest.TestCase):
         except ApiException as e:
             self.fail(f"competition_list_topic_messages failed: {e}")
 
+    def test_competition_k_topics_show(self):
+        if not getattr(self, "competition_topic_id", None):
+            self.test_competition_i_topics()
+        if not getattr(self, "competition_topic_id", None):
+            self.skipTest("No topics available to show")
+        try:
+            topic, comments, next_page_token = api.forums_topic_show(self.competition_topic_id)
+            self.assertIsNotNone(topic)
+            self.assertEqual(topic.id, self.competition_topic_id)
+            self.assertIsInstance(comments, list)
+            self.assertIsInstance(next_page_token, str)
+        except ApiException as e:
+            self.fail(f"forums_topic_show (competition) failed: {e}")
+
     # Forums
 
     def test_forums_a_list(self):

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -449,6 +449,47 @@ class TestKaggleApi(unittest.TestCase):
         except ApiException as e:
             self.fail(f"competition_list_topic_messages failed: {e}")
 
+    # Forums
+
+    def test_forums_a_list(self):
+        try:
+            response = api.forums_list()
+            self.assertTrue(hasattr(response, "forums"))
+            forums = response.forums
+            self.assertIsInstance(forums, list)
+            self.assertGreater(len(forums), 0)
+            [self.assertTrue(hasattr(forums[0], api.camel_to_snake(f))) for f in api.forum_fields]
+        except ApiException as e:
+            self.fail(f"forums_list failed: {e}")
+
+    def test_forums_b_list_topics(self):
+        try:
+            response = api.forums_list_topics()
+            self.assertTrue(hasattr(response, "topics"))
+            topics = response.topics
+            self.assertIsInstance(topics, list)
+            self.assertGreater(len(topics), 0)
+            [self.assertTrue(hasattr(topics[0], api.camel_to_snake(f))) for f in api.forum_topic_fields]
+            if topics:
+                self.forum_topic_id = topics[0].id
+            else:
+                self.forum_topic_id = None
+        except ApiException as e:
+            self.fail(f"forums_list_topics failed: {e}")
+
+    def test_forums_c_topic_show(self):
+        if not getattr(self, "forum_topic_id", None):
+            self.test_forums_b_list_topics()
+        if not getattr(self, "forum_topic_id", None):
+            self.skipTest("No topics available to show")
+        try:
+            topic, comments = api.forums_topic_show(self.forum_topic_id)
+            self.assertIsNotNone(topic)
+            self.assertEqual(topic.id, self.forum_topic_id)
+            self.assertIsInstance(comments, list)
+        except ApiException as e:
+            self.fail(f"forums_topic_show failed: {e}")
+
     # Datasets
 
     def test_dataset_a_list(self):


### PR DESCRIPTION
## Summary

Add a new `forums` command group (alias `fo`) that exposes the Discussions API under a user-friendly name.

## New Commands

- **`kaggle forums`** — list all discussion forums
- **`kaggle forums topics <forum>`** — list topics with full filtering (`--sort-by`, `--search`, `--category`, `--group`, `--page-size`, `--page-token`)
- **`kaggle forums topics show <ref>`** — display a topic with all comments rendered in an indented tree structure

## Key Design Decisions

- Supports both `forum/topic-id` and `forum topic-id` argument forms for `show`
- Bare numeric topic IDs also accepted
- Comment tree uses Unicode box-drawing characters for readability
- All commands support `-v/--csv` and `-q/--quiet` flags
- Full `--help` support at every level

## Files Changed

| File | Description |
|------|-------------|
| `src/kaggle/api/kaggle_api_extended.py` | SDK imports, field definitions, 6 API methods, 2 helpers |
| `src/kaggle/cli.py` | `parse_forums()`, main() registration, Help class |
| `docs/forums.md` | **NEW** — full documentation |
| `docs/README.md` | Added Forums link |
| `README.md` | Added to Key Features |
| `tests/unit_tests.py` | 3 new forum tests |

## Testing

- All `--help` screens verified
- Python syntax check passes
- Unit tests added (require running server to execute)