### PR TITLE
fix(benchmarks cli): bugs and additional features

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -290,10 +290,10 @@ kaggle benchmarks tasks download <TASK> [options]
 
 **Purpose:**
 
-Downloads and extracts the output zip archive for each completed run. Files are organized in a hierarchical layout:
+Downloads and extracts the output zip archive for each completed run. Files are organized in a hierarchical layout that includes the task's version number:
 
 ```
-<output>/<task>/<model>/<run_id>/
+<output>/<task>/<version>/<model>/<run_id>/
 ```
 
 Already-downloaded runs (where the output directory exists) are automatically skipped.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -213,7 +213,7 @@ kaggle benchmarks tasks list [options]
 
 **Purpose:**
 
-Displays a table of your benchmark tasks showing the task slug, creation status, and creation timestamp.
+Displays a table of your benchmark tasks showing the task slug, current version, creation status, and creation timestamp.
 
 ---
 
@@ -294,6 +294,7 @@ Downloads and extracts the output zip archive for each completed run. Files are 
 
 ```
 <output>/<task>/<version>/<model>/<run_id>/
+   ├── output files...
 ```
 
 Already-downloaded runs (where the output directory exists) are automatically skipped.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -213,7 +213,7 @@ kaggle benchmarks tasks list [options]
 
 **Purpose:**
 
-Displays a table of your benchmark tasks showing the task slug, current version, creation status, and creation timestamp.
+Displays a table of your benchmark tasks showing the task slug, current version (or `unset` if unavailable), creation status, and creation timestamp.
 
 ---
 
@@ -290,7 +290,7 @@ kaggle benchmarks tasks download <TASK> [options]
 
 **Purpose:**
 
-Downloads and extracts the output zip archive for each completed run. Files are organized in a hierarchical layout that includes the task's version number:
+Downloads and extracts the output zip archive for each completed run. Files are organized in a hierarchical layout that includes the task's version number (or `unset` if unavailable):
 
 ```
 <output>/<task>/<version>/<model>/<run_id>/

--- a/skills/references/benchmarks.md
+++ b/skills/references/benchmarks.md
@@ -230,14 +230,14 @@ kaggle b t download my-task -o ./results
 
 **Output directory structure:**
 ```
-<output>/<task>/<model>/<run_id>/
+<output>/<task>/<version>/<model>/<run_id>/
    ├── output files...
 ```
 
 **Behavior details:**
 - Downloads outputs for all runs in a **terminal state** — this includes both `COMPLETED` and `ERRORED` runs (errored runs may still have partial output)
 - Downloads zip archives and extracts them automatically
-- Already-downloaded runs are skipped: `Skipping gemini-2.5-pro (run 123) — already downloaded to ./my-task/gemini-2.5-pro/123`
+- Already-downloaded runs are skipped: `Skipping gemini-2.5-pro (run 123) — already downloaded to ./my-task/1/gemini-2.5-pro/123`
 - Corrupt zips: Warning printed, raw `.zip` file kept, continues with other models
 - No downloadable runs (all still in progress): `No downloadable runs yet — N run(s) still in progress. Use 'kaggle b t status my-task' to check progress.`
 - No runs at all: `No runs found for task 'my-task'. Use 'kaggle b t run my-task' to start one.`

--- a/skills/references/benchmarks.md
+++ b/skills/references/benchmarks.md
@@ -262,7 +262,7 @@ kaggle b t list --name-regex "^math" --status errored
 
 **Status filter values:** `queued`, `running`, `completed`, `errored`
 
-**Output:** Aligned table with columns: Task, Status, Created
+**Output:** Aligned table with columns: Task, Version, Status, Created
 
 ### List Available Models
 

--- a/skills/references/benchmarks.md
+++ b/skills/references/benchmarks.md
@@ -230,7 +230,7 @@ kaggle b t download my-task -o ./results
 
 **Output directory structure:**
 ```
-<output>/<task>/<version>/<model>/<run_id>/
+<output>/<task>/<version>/<model>/<run_id>/    (version is "unset" if unavailable)
    ├── output files...
 ```
 
@@ -262,7 +262,7 @@ kaggle b t list --name-regex "^math" --status errored
 
 **Status filter values:** `queued`, `running`, `completed`, `errored`
 
-**Output:** Aligned table with columns: Task, Version, Status, Created
+**Output:** Aligned table with columns: Task, Version (or `unset`), Status, Created
 
 ### List Available Models
 

--- a/src/kaggle/__init__.py
+++ b/src/kaggle/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 from kaggle.api.kaggle_api_extended import KaggleApi
 
-__version__ = "2.1.0"
+__version__ = "2.1.1"
 
 api = KaggleApi()
 api.authenticate()

--- a/src/kaggle/__init__.py
+++ b/src/kaggle/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 from kaggle.api.kaggle_api_extended import KaggleApi
 
-__version__ = "2.1.1"
+__version__ = "2.1.0"
 
 api = KaggleApi()
 api.authenticate()

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -6957,6 +6957,8 @@ class KaggleApi:
         self._write_benchmarks_reference(os.path.dirname(os.path.abspath(example_file)))
 
     def benchmarks_tasks_push_cli(self, task, file, wait=None, poll_interval=10):
+        if poll_interval is not None and poll_interval <= 0:
+            raise ValueError("--poll-interval must be a positive integer")
         if not os.path.isfile(file):
             raise ValueError(f"File {file} does not exist")
         if not file.endswith(".py"):
@@ -7009,6 +7011,8 @@ class KaggleApi:
                 self._poll_task_creation(kaggle, task_slug, wait, poll_interval)
 
     def benchmarks_tasks_run_cli(self, task, model=None, wait=None, poll_interval=10):
+        if poll_interval is not None and poll_interval <= 0:
+            raise ValueError("--poll-interval must be a positive integer")
         models = self._normalize_model_list(model)
         task = slugify(task)
 

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -6836,7 +6836,11 @@ class KaggleApi:
                 return
             elif state not in self._PENDING_CREATION_STATES:
                 error_msg = f"Task '{task}' creation failed with status: {self._clean_enum_str(state)}"
-                if error := getattr(task_info, "error_message", None):
+                error = (
+                    getattr(task_info, "error", None)
+                    or getattr(task_info, "creation_error_message", None)
+                )
+                if error:
                     error_msg += f" Error: {error}"
                 raise ValueError(error_msg)
 
@@ -6990,7 +6994,7 @@ class KaggleApi:
             request.text = notebook_content
 
             response = kaggle.benchmarks.benchmark_tasks_api_client.create_benchmark_task(request)
-            error = getattr(response, "error_message", None) or getattr(response, "errorMessage", None)
+            error = response.error
             if error:
                 raise ValueError(f"Failed to push task: {error}")
 
@@ -7088,7 +7092,8 @@ class KaggleApi:
         output = output or "."
 
         with self.build_kaggle_client() as kaggle:
-            self._get_benchmark_task(task, kaggle)
+            task_info = self._get_benchmark_task(task, kaggle)
+            version = str(task_info.slug.version_number) if task_info.slug.version_number else "unknown"
             runs = self._fetch_task_runs(kaggle, task, model)
 
             if not runs:
@@ -7113,8 +7118,8 @@ class KaggleApi:
                 dl_request = ApiDownloadBenchmarkTaskRunOutputRequest()
                 dl_request.run_id = r.id
                 slug = self._short_model_slug(r.model_version_slug)
-                # Hierarchical layout: {output}/{task}/{model}/{run_id}/
-                outdir = os.path.join(output, task, slug, str(r.id))
+                # Hierarchical layout: {output}/{task}/{version}/{model}/{run_id}/
+                outdir = os.path.join(output, task, version, slug, str(r.id))
 
                 if os.path.isdir(outdir):
                     print(f"Skipping {slug} (run {r.id}) — already downloaded to {outdir}")

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -6838,10 +6838,7 @@ class KaggleApi:
                 return
             elif state not in self._PENDING_CREATION_STATES:
                 error_msg = f"Task '{task}' creation failed with status: {self._clean_enum_str(state)}"
-                error = (
-                    getattr(task_info, "error", None)
-                    or getattr(task_info, "creation_error_message", None)
-                )
+                error = getattr(task_info, "error", None) or getattr(task_info, "creation_error_message", None)
                 if error:
                     error_msg += f" Error: {error}"
                 raise ValueError(error_msg)

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -6576,13 +6576,13 @@ class KaggleApi:
         max_task_len = max((len(t.slug.task_slug) for t in tasks), default=40)
         max_task_len = max(max_task_len, 40)
 
-        print(f"{'Task':<{max_task_len}} {'Version':<10}{'Status':<20} {'Created':<20}")
-        print("-" * (max_task_len + 50))
+        print(f"{'Task':<{max_task_len}} {'Version':<10} {'Status':<20} {'Created':<20}")
+        print("-" * (max_task_len + 53))
         for t in tasks:
-            version = str(t.slug.version_number) if t.slug.version_number else "-"
+            version = str(t.slug.version_number) if t.slug.version_number else "0"
             print(
                 f"{t.slug.task_slug:<{max_task_len}} {version:<10}"
-                f"{KaggleApi._clean_enum_str(t.creation_state):<20} {KaggleApi._format_time(t.create_time):<20}"
+                f" {KaggleApi._clean_enum_str(t.creation_state):<20} {KaggleApi._format_time(t.create_time):<20}"
             )
 
     @staticmethod
@@ -6995,7 +6995,7 @@ class KaggleApi:
             request.text = notebook_content
 
             response = kaggle.benchmarks.benchmark_tasks_api_client.create_benchmark_task(request)
-            error = response.error
+            error = getattr(response, "error", None)
             if error:
                 raise ValueError(f"Failed to push task: {error}")
 
@@ -7096,7 +7096,7 @@ class KaggleApi:
 
         with self.build_kaggle_client() as kaggle:
             task_info = self._get_benchmark_task(task, kaggle)
-            version = str(task_info.slug.version_number) if task_info.slug.version_number else "unknown"
+            version = str(task_info.slug.version_number) if task_info.slug.version_number else "0"
             runs = self._fetch_task_runs(kaggle, task, model)
 
             if not runs:

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -6579,7 +6579,7 @@ class KaggleApi:
         print(f"{'Task':<{max_task_len}} {'Version':<10} {'Status':<20} {'Created':<20}")
         print("-" * (max_task_len + 53))
         for t in tasks:
-            version = str(t.slug.version_number) if t.slug.version_number else "0"
+            version = str(t.slug.version_number) if t.slug.version_number else "unset"
             print(
                 f"{t.slug.task_slug:<{max_task_len}} {version:<10}"
                 f" {KaggleApi._clean_enum_str(t.creation_state):<20} {KaggleApi._format_time(t.create_time):<20}"
@@ -6868,7 +6868,7 @@ class KaggleApi:
                     details = []
                     for r in errored:
                         slug = self._short_model_slug(r.model_version_slug)
-                        msg = r.error_message.strip() if r.error_message else "No error message"
+                        msg = (getattr(r, "error_message", None) or "").strip() or "No error message"
                         details.append(f"  [{slug}]\n    {msg}")
                     raise ValueError(f"{len(errored)} run(s) failed:\n" + "\n".join(details))
                 return
@@ -7076,6 +7076,8 @@ class KaggleApi:
         with self.build_kaggle_client() as kaggle:
             task_info = self._get_benchmark_task(task, kaggle)
             print(f"Task:     {task_info.slug.task_slug}")
+            version = task_info.slug.version_number or "unset"
+            print(f"Version:  {version}")
             print(f"Status:   {self._clean_enum_str(task_info.creation_state)}")
             print(f"Created:  {self._format_time(task_info.create_time)}")
             url = getattr(task_info, "url", None)
@@ -7096,7 +7098,7 @@ class KaggleApi:
 
         with self.build_kaggle_client() as kaggle:
             task_info = self._get_benchmark_task(task, kaggle)
-            version = str(task_info.slug.version_number) if task_info.slug.version_number else "0"
+            version = str(task_info.slug.version_number) if task_info.slug.version_number else "unset"
             runs = self._fetch_task_runs(kaggle, task, model)
 
             if not runs:

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -6576,11 +6576,13 @@ class KaggleApi:
         max_task_len = max((len(t.slug.task_slug) for t in tasks), default=40)
         max_task_len = max(max_task_len, 40)
 
-        print(f"{'Task':<{max_task_len}} {'Status':<20} {'Created':<20}")
-        print("-" * (max_task_len + 40))
+        print(f"{'Task':<{max_task_len}} {'Version':<10}{'Status':<20} {'Created':<20}")
+        print("-" * (max_task_len + 50))
         for t in tasks:
+            version = str(t.slug.version_number) if t.slug.version_number else "-"
             print(
-                f"{t.slug.task_slug:<{max_task_len}} {KaggleApi._clean_enum_str(t.creation_state):<20} {KaggleApi._format_time(t.create_time):<20}"
+                f"{t.slug.task_slug:<{max_task_len}} {version:<10}"
+                f"{KaggleApi._clean_enum_str(t.creation_state):<20} {KaggleApi._format_time(t.create_time):<20}"
             )
 
     @staticmethod

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -548,6 +548,7 @@ class TestList:
         api.benchmarks_tasks_list_cli()
         output = capsys.readouterr().out
         assert "Task" in output
+        assert "Version" in output
         assert "my-task" in output
 
     def test_list_with_name_regex_filter(self, api, capsys):
@@ -588,11 +589,11 @@ class TestList:
         assert "my-task" not in output
 
     def test_list_table_format(self, api, capsys):
-        """Table uses 40/20/20 column widths and 80-char separator."""
+        """Table uses 40/10/20/20 column widths and 90-char separator."""
         _setup_list_response(api, [_make_task()])
         api.benchmarks_tasks_list_cli()
         output = capsys.readouterr().out
-        assert "-" * 80 in output
+        assert "-" * 90 in output
 
 
 # ============================================================

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -93,15 +93,14 @@ def _push(api, task, filepath):
     return jt
 
 
-def _make_task(slug="my-task", state=COMPLETED, create_time="2026-04-06 10:00:00", url=None, version_number=1, error="", creation_error_message=""):
+def _make_task(slug="my-task", state=COMPLETED, create_time="2026-04-06 10:00:00", url=None, version_number=1):
     t = MagicMock()
     t.slug.task_slug = slug
     t.slug.version_number = version_number
     t.creation_state = state
     t.create_time = create_time
     t.url = url if url is not None else f"/benchmarks/{slug}"
-    t.error = error
-    t.creation_error_message = creation_error_message
+    t.creation_error_message = ""
     return t
 
 
@@ -327,7 +326,7 @@ class TestPush:
             _push(api, "my-task", filepath)
 
     def test_push_handles_api_error(self, api, tmp_path):
-        """Push raises ValueError when response contains error."""
+        """Push raises ValueError when response contains error_message."""
         filepath = _write_task_file(tmp_path)
         _setup_completed_task(api)
 
@@ -337,30 +336,6 @@ class TestPush:
 
         with pytest.raises(ValueError, match="Failed to push task: Some backend error"):
             _push(api, "my-task", filepath)
-
-    @pytest.mark.parametrize(
-        "error_field, error_kwargs",
-        [
-            ("error", {"error": "Notebook execution failed"}),
-            ("creation_error_message", {"creation_error_message": "OOM during creation"}),
-        ],
-        ids=["error_field", "creation_error_message_field"],
-    )
-    def test_push_wait_creation_failed_shows_error(self, api, capsys, tmp_path, error_field, error_kwargs):
-        """When task creation fails, the error from either `error` or `creation_error_message` is shown."""
-        filepath = _write_task_file(tmp_path)
-        _setup_create_response(api, "my-task")
-
-        errored_task = _make_task(state=ERRORED, **error_kwargs)
-        api._mock_benchmarks.get_benchmark_task.side_effect = [
-            _make_task(state=COMPLETED),  # initial check
-            errored_task,                 # poll -> errored
-        ]
-
-        with patch("time.sleep"), pytest.raises(ValueError, match="creation failed") as exc_info:
-            api.benchmarks_tasks_push_cli("my-task", filepath, wait=0)
-
-        assert error_kwargs[error_field] in str(exc_info.value)
 
     def test_push_wait_polls_until_completion(self, api, capsys, tmp_path):
         filepath = _write_task_file(tmp_path)
@@ -395,6 +370,13 @@ class TestPush:
         output = capsys.readouterr().out
         assert "Timed out waiting for task creation after 30 seconds" in output
 
+    @pytest.mark.parametrize("interval", [0, -1], ids=["zero", "negative"])
+    def test_push_rejects_non_positive_poll_interval(self, api, tmp_path, interval):
+        """Push raises ValueError when poll_interval is 0 or negative."""
+        filepath = _write_task_file(tmp_path)
+        with pytest.raises(ValueError, match="--poll-interval must be a positive integer"):
+            api.benchmarks_tasks_push_cli("my-task", filepath, wait=0, poll_interval=interval)
+
 
 # ============================================================
 # Run
@@ -412,6 +394,12 @@ class TestRun:
         with pytest.raises(ValueError, match="not ready to run"):
             api.benchmarks_tasks_run_cli("my-task", ["gemini-pro"])
         api._mock_benchmarks.batch_schedule_benchmark_task_runs.assert_not_called()
+
+    @pytest.mark.parametrize("interval", [0, -1], ids=["zero", "negative"])
+    def test_run_rejects_non_positive_poll_interval(self, api, interval):
+        """Run raises ValueError when poll_interval is 0 or negative."""
+        with pytest.raises(ValueError, match="--poll-interval must be a positive integer"):
+            api.benchmarks_tasks_run_cli("my-task", ["gemini-pro"], poll_interval=interval)
 
     def test_run_errored_task_includes_task_info(self, api):
         """ERRORED task error message includes task info."""
@@ -590,18 +578,10 @@ class TestList:
         assert "task-1" in output
         assert "task-2" in output
 
-    def test_list_empty(self, api, capsys):
-        """Empty task list still prints the header."""
-        _setup_list_response(api, [])
-        api.benchmarks_tasks_list_cli()
-        output = capsys.readouterr().out
-        assert "Task" in output
-        # No task rows
-        assert "my-task" not in output
-
-    def test_list_none_tasks_field(self, api, capsys):
-        """Server may return None for the tasks field instead of []."""
-        _setup_list_response(api, None)
+    @pytest.mark.parametrize("tasks", [[], None], ids=["empty_list", "none"])
+    def test_list_empty(self, api, capsys, tasks):
+        """Empty/None task list still prints the header."""
+        _setup_list_response(api, tasks)
         api.benchmarks_tasks_list_cli()
         output = capsys.readouterr().out
         assert "Task" in output
@@ -650,19 +630,17 @@ class TestStatus:
         assert "No runs yet" in output
         assert "kaggle b t run my-task" in output
 
-    def test_status_with_model_filter(self, api, capsys):
+    @pytest.mark.parametrize(
+        "model_input, expected",
+        [("gemini-3", ["gemini-3"]), (["gemini-3", "gpt-5"], ["gemini-3", "gpt-5"])],
+        ids=["single", "multiple"],
+    )
+    def test_status_with_model_filter(self, api, capsys, model_input, expected):
         api._mock_benchmarks.get_benchmark_task.return_value = _make_task()
         _setup_runs_response(api, [])
-        api.benchmarks_tasks_status_cli("my-task", model="gemini-3")
+        api.benchmarks_tasks_status_cli("my-task", model=model_input)
         request = api._mock_benchmarks.list_benchmark_task_runs.call_args[0][0]
-        assert request.model_version_slugs == ["gemini-3"]
-
-    def test_status_with_multiple_models_filter(self, api, capsys):
-        api._mock_benchmarks.get_benchmark_task.return_value = _make_task()
-        _setup_runs_response(api, [])
-        api.benchmarks_tasks_status_cli("my-task", model=["gemini-3", "gpt-5"])
-        request = api._mock_benchmarks.list_benchmark_task_runs.call_args[0][0]
-        assert request.model_version_slugs == ["gemini-3", "gpt-5"]
+        assert request.model_version_slugs == expected
 
     def test_status_run_table(self, api, capsys):
         """Completed run renders with correct columns."""
@@ -1041,14 +1019,11 @@ class TestModels:
 class TestDelete:
     """``kaggle benchmarks tasks delete <task> [-y]``"""
 
-    def test_delete_prints_stub_message(self, api, capsys):
-        api.benchmarks_tasks_delete_cli("my-task")
+    @pytest.mark.parametrize("no_confirm", [False, True], ids=["default", "yes_flag"])
+    def test_delete_prints_stub_message(self, api, capsys, no_confirm):
+        """Delete always prints stub message; -y flag is accepted but has no effect."""
+        api.benchmarks_tasks_delete_cli("my-task", no_confirm=no_confirm)
         assert "Delete is not supported by the server yet." in capsys.readouterr().out
-
-    def test_delete_accepts_no_confirm_flag(self, api, capsys):
-        """The -y flag is accepted but has no effect (stub)."""
-        api.benchmarks_tasks_delete_cli("my-task", no_confirm=True)
-        assert "Delete is not supported" in capsys.readouterr().out
 
 
 # ============================================================
@@ -1136,6 +1111,18 @@ class TestCliArgParsing:
             ),
             ("benchmarks tasks delete my-task -y", {"no_confirm": True}),
             ("benchmarks tasks delete my-task --yes", {"no_confirm": True}),
+            # auth
+            ("benchmarks auth", {"no_confirm": False, "env_file": ".env"}),
+            ("benchmarks auth -y", {"no_confirm": True}),
+            ("benchmarks auth --env-file custom.env", {"env_file": "custom.env"}),
+            # init
+            (
+                "benchmarks init",
+                {"no_confirm": False, "env_file": ".env", "example_file": "example_task.py"},
+            ),
+            ("benchmarks init -y", {"no_confirm": True}),
+            ("benchmarks init --env-file custom.env", {"env_file": "custom.env"}),
+            ("benchmarks init --example-file my_task.py", {"example_file": "my_task.py"}),
         ],
     )
     def test_parse_success(self, cmd, expected):
@@ -1155,37 +1142,6 @@ class TestCliArgParsing:
     def test_parse_error(self, cmd):
         with pytest.raises(SystemExit):
             self._parse(cmd)
-
-    def test_parse_benchmarks_auth(self):
-        args = self._parse("benchmarks auth")
-        assert args.no_confirm is False
-        assert args.env_file == ".env"
-
-    def test_parse_benchmarks_auth_yes(self):
-        args = self._parse("benchmarks auth -y")
-        assert args.no_confirm is True
-
-    def test_parse_benchmarks_auth_env_file(self):
-        args = self._parse("benchmarks auth --env-file custom.env")
-        assert args.env_file == "custom.env"
-
-    def test_parse_benchmarks_init(self):
-        args = self._parse("benchmarks init")
-        assert args.no_confirm is False
-        assert args.env_file == ".env"
-        assert args.example_file == "example_task.py"
-
-    def test_parse_benchmarks_init_yes(self):
-        args = self._parse("benchmarks init -y")
-        assert args.no_confirm is True
-
-    def test_parse_benchmarks_init_env_file(self):
-        args = self._parse("benchmarks init --env-file custom.env")
-        assert args.env_file == "custom.env"
-
-    def test_parse_benchmarks_init_example_file(self):
-        args = self._parse("benchmarks init --example-file my_task.py")
-        assert args.example_file == "my_task.py"
 
 
 # ============================================================

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -589,11 +589,11 @@ class TestList:
         assert "my-task" not in output
 
     def test_list_table_format(self, api, capsys):
-        """Table uses 40/10/20/20 column widths and 90-char separator."""
+        """Table uses 40/10/20/20 column widths and 93-char separator."""
         _setup_list_response(api, [_make_task()])
         api.benchmarks_tasks_list_cli()
         output = capsys.readouterr().out
-        assert "-" * 90 in output
+        assert "-" * 93 in output
 
 
 # ============================================================
@@ -914,8 +914,8 @@ class TestDownload:
         assert os.path.isfile(os.path.join(good_dir, "result.txt"))
         assert "Downloaded output for good-model to" in output
 
-    def test_download_version_zero_uses_unknown(self, api, capsys):
-        """When version_number is 0 (unset), directory uses 'unknown'."""
+    def test_download_version_zero_uses_zero(self, api, capsys):
+        """When version_number is 0 (unset), directory uses '0'."""
         task = _make_task(version_number=0)
         api._mock_benchmarks.get_benchmark_task.return_value = task
         _setup_runs_response(api, [_make_run(run_id=1)])
@@ -924,7 +924,7 @@ class TestDownload:
         with patch("zipfile.ZipFile"), patch("os.remove"):
             api.benchmarks_tasks_download_cli("my-task")
         zippath = api.download_file.call_args[0][1]
-        expected = os.path.join(".", "my-task", "unknown", "gemini-pro", "1.zip")
+        expected = os.path.join(".", "my-task", "0", "gemini-pro", "1.zip")
         assert zippath == expected
 
 

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -93,12 +93,15 @@ def _push(api, task, filepath):
     return jt
 
 
-def _make_task(slug="my-task", state=COMPLETED, create_time="2026-04-06 10:00:00", url=None):
+def _make_task(slug="my-task", state=COMPLETED, create_time="2026-04-06 10:00:00", url=None, version_number=1, error="", creation_error_message=""):
     t = MagicMock()
     t.slug.task_slug = slug
+    t.slug.version_number = version_number
     t.creation_state = state
     t.create_time = create_time
     t.url = url if url is not None else f"/benchmarks/{slug}"
+    t.error = error
+    t.creation_error_message = creation_error_message
     return t
 
 
@@ -133,8 +136,7 @@ def _setup_create_response(api, task_slug="my-task"):
     resp = MagicMock()
     resp.slug.task_slug = task_slug
     resp.url = f"https://kaggle.com/benchmarks/{task_slug}"
-    resp.error_message = None
-    resp.errorMessage = None
+    resp.error = None
     api._mock_benchmarks.create_benchmark_task.return_value = resp
 
 
@@ -275,8 +277,7 @@ class TestPush:
         filepath = _write_task_file(tmp_path)
         resp = MagicMock()
         resp.url = "/benchmarks/my-task"
-        resp.error_message = None
-        resp.errorMessage = None
+        resp.error = None
         api._mock_benchmarks.create_benchmark_task.return_value = resp
         _setup_completed_task(api)
         _push(api, "my-task", filepath)
@@ -326,16 +327,40 @@ class TestPush:
             _push(api, "my-task", filepath)
 
     def test_push_handles_api_error(self, api, tmp_path):
-        """Push raises ValueError when response contains error_message."""
+        """Push raises ValueError when response contains error."""
         filepath = _write_task_file(tmp_path)
         _setup_completed_task(api)
 
         resp = MagicMock()
-        resp.error_message = "Some backend error"
+        resp.error = "Some backend error"
         api._mock_benchmarks.create_benchmark_task.return_value = resp
 
         with pytest.raises(ValueError, match="Failed to push task: Some backend error"):
             _push(api, "my-task", filepath)
+
+    @pytest.mark.parametrize(
+        "error_field, error_kwargs",
+        [
+            ("error", {"error": "Notebook execution failed"}),
+            ("creation_error_message", {"creation_error_message": "OOM during creation"}),
+        ],
+        ids=["error_field", "creation_error_message_field"],
+    )
+    def test_push_wait_creation_failed_shows_error(self, api, capsys, tmp_path, error_field, error_kwargs):
+        """When task creation fails, the error from either `error` or `creation_error_message` is shown."""
+        filepath = _write_task_file(tmp_path)
+        _setup_create_response(api, "my-task")
+
+        errored_task = _make_task(state=ERRORED, **error_kwargs)
+        api._mock_benchmarks.get_benchmark_task.side_effect = [
+            _make_task(state=COMPLETED),  # initial check
+            errored_task,                 # poll -> errored
+        ]
+
+        with patch("time.sleep"), pytest.raises(ValueError, match="creation failed") as exc_info:
+            api.benchmarks_tasks_push_cli("my-task", filepath, wait=0)
+
+        assert error_kwargs[error_field] in str(exc_info.value)
 
     def test_push_wait_polls_until_completion(self, api, capsys, tmp_path):
         filepath = _write_task_file(tmp_path)
@@ -718,7 +743,7 @@ class TestDownload:
         # download_file receives the .zip path
         call_args = api.download_file.call_args
         zippath = call_args[0][1]
-        expected = os.path.join(".", "my-task", "gemini-pro", "1.zip")
+        expected = os.path.join(".", "my-task", "1", "gemini-pro", "1.zip")
         assert zippath == expected
 
     def test_download_with_model_filter(self, api, capsys):
@@ -780,7 +805,7 @@ class TestDownload:
         self._mock_download(api)
         outdir = str(tmp_path / "out")
         # Pre-create the output directory to simulate a previous download
-        existing = os.path.join(outdir, "my-task", "gemini-pro", "42")
+        existing = os.path.join(outdir, "my-task", "1", "gemini-pro", "42")
         os.makedirs(existing)
 
         api.benchmarks_tasks_download_cli("my-task", output=outdir)
@@ -821,7 +846,7 @@ class TestDownload:
         api._mock_benchmarks.download_benchmark_task_run_output.return_value = MagicMock()
 
         outdir = str(tmp_path / "out")
-        zip_path = os.path.join(outdir, "my-task", "gemini-pro", "42.zip")
+        zip_path = os.path.join(outdir, "my-task", "1", "gemini-pro", "42.zip")
 
         # Make download_file create a real zip so extraction works
         def fake_download(response, outfile, http_client, quiet=False):
@@ -836,8 +861,8 @@ class TestDownload:
 
         api.benchmarks_tasks_download_cli("my-task", output=outdir)
 
-        # Verify extraction happened: {output}/{task}/{model}/{run_id}/
-        extracted_dir = os.path.join(outdir, "my-task", "gemini-pro", "42")
+        # Verify extraction happened: {output}/{task}/{version}/{model}/{run_id}/
+        extracted_dir = os.path.join(outdir, "my-task", "1", "gemini-pro", "42")
         assert os.path.isdir(extracted_dir)
         assert os.path.isfile(os.path.join(extracted_dir, "output.txt"))
         with open(os.path.join(extracted_dir, "output.txt")) as f:
@@ -902,13 +927,26 @@ class TestDownload:
         output = capsys.readouterr().out
         # Bad zip: warning printed, raw file kept
         assert "not a valid zip archive" in output
-        bad_zip_path = os.path.join(outdir, "my-task", "bad-model", "10.zip")
+        bad_zip_path = os.path.join(outdir, "my-task", "1", "bad-model", "10.zip")
         assert os.path.isfile(bad_zip_path)
         # Good zip: extracted successfully
-        good_dir = os.path.join(outdir, "my-task", "good-model", "11")
+        good_dir = os.path.join(outdir, "my-task", "1", "good-model", "11")
         assert os.path.isdir(good_dir)
         assert os.path.isfile(os.path.join(good_dir, "result.txt"))
         assert "Downloaded output for good-model to" in output
+
+    def test_download_version_zero_uses_unknown(self, api, capsys):
+        """When version_number is 0 (unset), directory uses 'unknown'."""
+        task = _make_task(version_number=0)
+        api._mock_benchmarks.get_benchmark_task.return_value = task
+        _setup_runs_response(api, [_make_run(run_id=1)])
+        api._mock_benchmarks.download_benchmark_task_run_output.return_value = MagicMock()
+        api.download_file = MagicMock()
+        with patch("zipfile.ZipFile"), patch("os.remove"):
+            api.benchmarks_tasks_download_cli("my-task")
+        zippath = api.download_file.call_args[0][1]
+        expected = os.path.join(".", "my-task", "unknown", "gemini-pro", "1.zip")
+        assert zippath == expected
 
 
 # ============================================================
@@ -1235,7 +1273,7 @@ class TestBenchmarksInit:
         assert "MODEL_PROXY_EXPIRY_TIME=2026-04-17T12:00:00Z\n" in content
         assert "LLM_DEFAULT=google/gemini-3-flash-preview\n" in content
         assert "LLM_DEFAULT_EVAL=google/gemini-3-flash-preview\n" in content
-        assert "LLMS_AVAILABLE=google/gemini-3-flash-preview,google/gemini-3.1-flash-lite-preview\n" in content
+        assert "LLMS_AVAILABLE=anthropic/claude-haiku-4-5@20251001,deepseek-ai/deepseek-v3.2,google/gemini-3-flash-preview,google/gemini-3.1-flash-lite-preview,openai/gpt-oss-120b,qwen/qwen3-next-80b-a3b-instruct,zai/glm-5\n" in content
         out = capsys.readouterr().out
         assert "MODEL_PROXY_API_KEY=****************oken" in out
         assert "LLM_DEFAULT=google/gemini-3-flash-preview" in out

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -611,7 +611,8 @@ class TestStatus:
         api.benchmarks_tasks_status_cli("my-task")
         output = capsys.readouterr().out
         assert "Task:" in output
-        assert "Status:" in output
+        assert "Version:" in output
+        assert "Status:   COMPLETED" in output
         assert "Created:" in output
         assert "Task URL:" in output
 
@@ -915,7 +916,7 @@ class TestDownload:
         assert "Downloaded output for good-model to" in output
 
     def test_download_version_zero_uses_zero(self, api, capsys):
-        """When version_number is 0 (unset), directory uses '0'."""
+        """When version_number is 0 (unset), directory uses 'unset'."""
         task = _make_task(version_number=0)
         api._mock_benchmarks.get_benchmark_task.return_value = task
         _setup_runs_response(api, [_make_run(run_id=1)])
@@ -924,7 +925,7 @@ class TestDownload:
         with patch("zipfile.ZipFile"), patch("os.remove"):
             api.benchmarks_tasks_download_cli("my-task")
         zippath = api.download_file.call_args[0][1]
-        expected = os.path.join(".", "my-task", "0", "gemini-pro", "1.zip")
+        expected = os.path.join(".", "my-task", "unset", "gemini-pro", "1.zip")
         assert zippath == expected
 
 

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -1230,7 +1230,10 @@ class TestBenchmarksInit:
         assert "MODEL_PROXY_EXPIRY_TIME=2026-04-17T12:00:00Z\n" in content
         assert "LLM_DEFAULT=google/gemini-3-flash-preview\n" in content
         assert "LLM_DEFAULT_EVAL=google/gemini-3-flash-preview\n" in content
-        assert "LLMS_AVAILABLE=anthropic/claude-haiku-4-5@20251001,deepseek-ai/deepseek-v3.2,google/gemini-3-flash-preview,google/gemini-3.1-flash-lite-preview,openai/gpt-oss-120b,qwen/qwen3-next-80b-a3b-instruct,zai/glm-5\n" in content
+        assert (
+            "LLMS_AVAILABLE=anthropic/claude-haiku-4-5@20251001,deepseek-ai/deepseek-v3.2,google/gemini-3-flash-preview,google/gemini-3.1-flash-lite-preview,openai/gpt-oss-120b,qwen/qwen3-next-80b-a3b-instruct,zai/glm-5\n"
+            in content
+        )
         out = capsys.readouterr().out
         assert "MODEL_PROXY_API_KEY=****************oken" in out
         assert "LLM_DEFAULT=google/gemini-3-flash-preview" in out


### PR DESCRIPTION
### PR Summary


#### Changes

1. **Fix error handling for task push/poll** — Replaced deprecated `error_message`/`errorMessage` attributes with the correct SDK fields (`response.error` for sync push, `creation_error_message` for async polling), preventing silent failures when the server returns errors.

2. **Validate `--poll-interval`** — Both `push` and `run` now reject `--poll-interval 0` and negative values with a clear `ValueError`, preventing infinite loops or nonsensical polling.

3. **Add Version column to `kaggle b t list`** — The task list table now shows the current task version number alongside Task, Status, and Created.

4. **Include version in download directory** — Downloads now use `<task>/<version>/<model>/<run_id>/` layout instead of `<task>/<model>/<run_id>/`, preventing output collisions across task versions.

5. **Simplify test suite** 

6. **Updated docs** — `docs/benchmarks.md`, `skills/references/benchmarks.md` updated to reflect new Version column and download directory structure.

**Validation:** 28/28 live bugbash tests passed, 147/147 unit tests passed: https://paste.googleplex.com/6535645993500672