### PR TITLE
fix (cli): print friendly auth instructions on 401 / missing creds

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -673,6 +673,31 @@ class FileList(object):
         return ""
 
 
+def print_auth_help() -> None:
+    """Print friendly instructions for setting up Kaggle authentication."""
+    print(
+        "Authentication required to call the Kaggle API.\n"
+        "\n"
+        "First, you will need a Kaggle account. You can sign up at\n"
+        "  https://www.kaggle.com/account/login\n"
+        "\n"
+        "After login, generate an API token at\n"
+        '  https://www.kaggle.com/settings/api  (click "Generate New Token" under "API")\n'
+        "\n"
+        "Then authenticate using one of the following options:\n"
+        "\n"
+        "Option 1: OAuth (recommended)\n"
+        "  Obtains access credentials via a web-based authorization flow.\n"
+        "    kaggle auth login\n"
+        "\n"
+        "Option 2: Environment variable\n"
+        "    export KAGGLE_API_TOKEN=xxxxxxxxxxxxxx  # token copied from the settings UI\n"
+        "\n"
+        "Option 3: API token file\n"
+        "  Save the token to ~/.kaggle/access_token"
+    )
+
+
 class KaggleApi:
     """
     KaggleApi provides methods for interacting with Kaggle's public API.
@@ -958,11 +983,7 @@ class KaggleApi:
             return
         if self._authenticate_with_oauth_creds():
             return
-        print("You must authenticate before you can call the Kaggle API.")
-        print('Please run "kaggle auth login" to log in via OAuth')
-        print(
-            "Or use one of the alternate ways to authenticate: https://github.com/Kaggle/kaggle-cli/blob/main/docs/README.md#authentication"
-        )
+        print_auth_help()
         exit(1)
 
     def _authenticate_with_legacy_apikey(self) -> bool:

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -681,20 +681,19 @@ def print_auth_help() -> None:
         "First, you will need a Kaggle account. You can sign up at\n"
         "  https://www.kaggle.com/account/login\n"
         "\n"
-        "After login, generate an API token at\n"
-        '  https://www.kaggle.com/settings/api  (click "Generate New Token" under "API")\n'
-        "\n"
-        "Then authenticate using one of the following options:\n"
-        "\n"
-        "Option 1: OAuth (recommended)\n"
-        "  Obtains access credentials via a web-based authorization flow.\n"
+        "Recommended: log in with OAuth via a web-based authorization flow.\n"
+        "No token to manage; credentials are cached locally for you.\n"
         "    kaggle auth login\n"
         "\n"
-        "Option 2: Environment variable\n"
+        "If you'd rather not use OAuth, generate an API token at\n"
+        '  https://www.kaggle.com/settings/api  (click "Generate New Token" under "API")\n'
+        "and supply it to the CLI in one of these ways:\n"
+        "\n"
+        "  Option A: Environment variable\n"
         "    export KAGGLE_API_TOKEN=xxxxxxxxxxxxxx  # token copied from the settings UI\n"
         "\n"
-        "Option 3: API token file\n"
-        "  Save the token to ~/.kaggle/access_token"
+        "  Option B: API token file\n"
+        "    Save the token to ~/.kaggle/access_token"
     )
 
 

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -20,9 +20,12 @@ from __future__ import print_function
 import argparse
 import json
 
+from requests.exceptions import HTTPError
+
 import kaggle
 from kaggle import KaggleApi
 from kaggle import api
+from kaggle.api.kaggle_api_extended import print_auth_help
 
 # from rest import ApiException
 ApiException = IOError
@@ -69,6 +72,13 @@ def main() -> None:
     error = False
     try:
         out = args.func(**command_args)
+    except HTTPError as e:
+        if e.response is not None and e.response.status_code == 401:
+            print_auth_help()
+        else:
+            print(e)
+        out = None
+        error = True
     except ApiException as e:
         print(e)
         out = None


### PR DESCRIPTION
Replaces the terse "you must authenticate" message and the bare HTTPError traceback on a 401 with a single helper that lists the three ways to authenticate (OAuth via `kaggle auth login`, KAGGLE_API_TOKEN env var, or ~/.kaggle/access_token file).