### PR TITLE
fix(benchmarks): handle EOF when selecting models without -m

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -6798,7 +6798,6 @@ class KaggleApi:
 
     def _select_models_interactively(self, kaggle, page_size=20):
         """Prompt the user to pick benchmark models from a paginated list."""
-        # TODO: Check if sys.stdin.isatty() to prevent hanging in non-interactive environments.
 
         def _fetch_models(page_token):
             req = ApiListBenchmarkModelsRequest()
@@ -6831,7 +6830,14 @@ class KaggleApi:
             prompt_parts = ["Enter model numbers (comma-separated)", "'all'"]
             if nav_hints:
                 prompt_parts.extend(nav_hints)
-            selection = input(", ".join(prompt_parts) + ": ").strip().lower()
+            try:
+                selection = input(", ".join(prompt_parts) + ": ").strip().lower()
+            except EOFError:
+                raise ValueError(
+                    "No model specified and no input received. "
+                    "Pass one or more models with -m/--model, or use "
+                    "'kaggle b t models' to list available models."
+                ) from None
 
             if selection == "n" and current_page < total_pages - 1:
                 current_page += 1

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -487,6 +487,23 @@ class TestRun:
             with pytest.raises(ValueError, match="Invalid selection"):
                 api.benchmarks_tasks_run_cli("my-task")
 
+    def test_run_eof_without_models_raises(self, api):
+        """Closed stdin (EOF) -> clear error instead of hanging on input()."""
+        _setup_completed_task(api)
+        _setup_available_models(api, ["gemini-pro"])
+        with patch("builtins.input", side_effect=EOFError), pytest.raises(ValueError, match="-m/--model"):
+            api.benchmarks_tasks_run_cli("my-task")
+
+    def test_run_accepts_piped_model_selection(self, api):
+        """Piped stdin with a selection still schedules the chosen model."""
+        _setup_completed_task(api)
+        _setup_available_models(api, ["gemini-pro", "gemma-2b"])
+        _setup_batch_schedule(api, [_make_run_result()])
+        with patch("builtins.input", return_value="2"):
+            api.benchmarks_tasks_run_cli("my-task")
+        request = api._mock_benchmarks.batch_schedule_benchmark_task_runs.call_args[0][0]
+        assert request.model_version_slugs == ["gemma-2b"]
+
     # -- Wait / polling --
 
     def test_run_wait_polls_until_completion(self, api, capsys):


### PR DESCRIPTION
## Summary

Handle `EOFError` during interactive benchmark model selection to improve behavior in non-interactive environments.

Previously, running:

```bash
kaggle benchmarks tasks run <task>
```

without `-m/--model` could fail ambiguously or hang when stdin was unavailable (for example in CI or other non-interactive environments).

This change:

* wraps the interactive `input()` call in `try/except EOFError`
* raises a clear `ValueError` instructing users to pass `-m/--model`
* preserves existing piped stdin behavior (e.g. `echo 1 | ...`)

## Changes

* Updated `_select_models_interactively` in `kaggle_api_extended.py`
* Added tests for:

  * EOF/non-interactive stdin behavior
  * piped stdin compatibility

## Test Plan

```bash
pytest src/kaggle/test/test_benchmarks_cli.py::TestRun
```
