### PR TITLE
fix(benchmarks): normalize provider-prefixed and @-containing model s…

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -301,6 +301,19 @@ Downloads and extracts the output zip archive for each completed run. Files are 
 
 Already-downloaded runs (where the output directory exists) are automatically skipped.
 
+### Model Slug Normalization
+
+Benchmark model names are automatically normalized on both input and output. This makes it easy to pass various formats interchangeably while keeping displays and directories clean.
+
+*   **Flexible Inputs**: The CLI accepts prefixed and proxy-style model names:
+    *   **With Provider Prefix**: `google/gemini-2.5-pro` or `anthropic/claude-sonnet-4`
+    *   **With Version/Proxy `@` symbols**: `anthropic/claude-haiku-4-5@20251001` or `claude-sonnet-4-6@default`
+    *   **Canonical Slugs**: `gemini-2.5-pro` or `claude-haiku-4-5-20251001`
+*   **Unified Normalization**: The client automatically strips any provider prefix (e.g., `google/` or `anthropic/`) and replaces `@` characters with `-` to match the server's canonical database slug format.
+*   **Clean Outputs**:
+    *   **Status Display**: Tables and error logs display the canonical, hyphenated slugs (e.g., `claude-haiku-4-5-20251001` and `gemini-2.0-flash-lite-001`) for readability.
+    *   **Hierarchical Downloads**: Run outputs are extracted into clean folders using the canonical slugs (e.g., `./<task>/<version>/claude-haiku-4-5-20251001/<run_id>/`), with no `@` or `/` symbols in folder names.
+
 ---
 
 ### `kaggle benchmarks tasks models`

--- a/skills/references/benchmarks.md
+++ b/skills/references/benchmarks.md
@@ -298,16 +298,18 @@ When the CLI normalizes a name, it prints a yellow warning:
 
 The slug must match between the `@task(name=...)` decorator in the file and the CLI command. Comparison is done on slugified names, so `@task(name="My Task")` matches `kaggle b t push my-task -f file.py`.
 
-## Model Slug Format
+## Model Slug Normalization
 
-Models use an `owner/model-name` format:
-- `google/gemini-2.5-pro`
-- `anthropic/claude-sonnet-4`
-- `openai/gpt-oss-120b`
+Benchmark model names are automatically normalized on both input and output. This makes it easy to pass various formats interchangeably while keeping displays and directories clean.
 
-When displaying model names, the owner prefix is stripped for readability (e.g. `gemini-2.5-pro`).
-
-The server may sometimes return model slugs in different formats (e.g. `anthropic/claude-sonnet-4-6@default`). The CLI handles this with client-side normalization, replacing `@` with `-` for matching.
+- **Flexible Inputs**: The CLI accepts prefixed and proxy-style model names:
+  - **With Provider Prefix**: `google/gemini-2.5-pro` or `anthropic/claude-sonnet-4`
+  - **With Version/Proxy `@` symbols**: `anthropic/claude-haiku-4-5@20251001` or `claude-sonnet-4-6@default`
+  - **Canonical Slugs**: `gemini-2.5-pro` or `claude-haiku-4-5-20251001`
+- **Unified Normalization**: The client automatically strips any provider prefix (e.g., `google/` or `anthropic/`) and replaces `@` characters with `-` to match the server's canonical database slug format.
+- **Clean Outputs**:
+  - **Status Display**: Tables and error logs display the canonical, hyphenated slugs (e.g., `claude-haiku-4-5-20251001` and `gemini-2.0-flash-lite-001`) for readability.
+  - **Hierarchical Downloads**: Run outputs are extracted into clean folders using the canonical slugs (e.g., `./<task>/<version>/claude-haiku-4-5-20251001/<run_id>/`), with no `@` or `/` symbols in folder names.
 
 ## Common Workflows
 

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -6789,11 +6789,7 @@ class KaggleApi:
         # Client-side filter as fallback since the server may ignore model_version_slugs.
         if models:
             model_set = set(models)
-            runs = [
-                r
-                for r in runs
-                if self._normalize_model_slug(r.model_version_slug) in model_set
-            ]
+            runs = [r for r in runs if self._normalize_model_slug(r.model_version_slug) in model_set]
 
         return runs
 

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -6551,19 +6551,23 @@ class KaggleApi:
         return slug
 
     @staticmethod
-    def _normalize_model_list(model) -> list:
-        """Normalize a model argument (str, list, or None) into a list."""
-        if isinstance(model, list):
-            return model
-        return [model] if model else []
+    def _normalize_model_slug(slug: str) -> str:
+        """Normalize a model slug (possibly in proxy/provider format) to the database format.
+
+        e.g. 'xai/grok-4.3' -> 'grok-4.3'
+             'anthropic/claude-sonnet-4-6@default' -> 'claude-sonnet-4-6-default'
+        """
+        slug = slug.split("/")[-1] if "/" in slug else slug
+        return slug.replace("@", "-")
 
     @staticmethod
-    def _short_model_slug(slug: str) -> str:
-        """Strip the owner prefix from a model slug for display.
-
-        e.g. 'google/gemini-2.5-pro' -> 'gemini-2.5-pro'
-        """
-        return slug.split("/")[-1] if "/" in slug else slug
+    def _normalize_model_list(model) -> list:
+        """Normalize a model argument (str, list, or None) into a list of normalized slugs."""
+        if isinstance(model, list):
+            raw_list = model
+        else:
+            raw_list = [model] if model else []
+        return [KaggleApi._normalize_model_slug(m) for m in raw_list]
 
     @staticmethod
     def _paginate(fetch_page, get_items):
@@ -6611,7 +6615,7 @@ class KaggleApi:
     @staticmethod
     def _print_run_table(runs):
         """Print a list of benchmark task runs in an aligned table."""
-        model_col = max((len(KaggleApi._short_model_slug(r.model_version_slug)) for r in runs), default=20)
+        model_col = max((len(KaggleApi._normalize_model_slug(r.model_version_slug)) for r in runs), default=20)
         model_col = max(model_col, 20)
         time_col = 21
         sep = model_col + 15 + time_col + time_col
@@ -6619,7 +6623,7 @@ class KaggleApi:
         print("-" * sep)
         errors = []
         for r in runs:
-            slug = KaggleApi._short_model_slug(r.model_version_slug)
+            slug = KaggleApi._normalize_model_slug(r.model_version_slug)
             print(
                 f"{slug:<{model_col}} {KaggleApi._clean_enum_str(r.state):<15} "
                 f"{KaggleApi._format_time(r.start_time):<{time_col}} {KaggleApi._format_time(r.end_time):<{time_col}}"
@@ -6788,26 +6792,25 @@ class KaggleApi:
             runs = [
                 r
                 for r in runs
-                if r.model_version_slug in model_set or r.model_version_slug.split("/")[-1] in model_set
-                # TODO(dolaameng): Remove this fallback once the server returns
-                # BenchmarkModelVersion.Slug (e.g. "claude-sonnet-4-6-default")
-                # instead of ModelProxySlug (e.g. "anthropic/claude-sonnet-4-6@default")
-                # in ApiBenchmarkTaskRun.model_version_slug.
-                or r.model_version_slug.split("/")[-1].replace("@", "-") in model_set
+                if self._normalize_model_slug(r.model_version_slug) in model_set
             ]
 
         return runs
 
-    def _select_models_interactively(self, kaggle, page_size=20):
-        """Prompt the user to pick benchmark models from a paginated list."""
+    def _fetch_all_benchmark_models(self, kaggle):
+        """Fetch all available benchmark models from the server."""
 
-        def _fetch_models(page_token):
+        def _fetch_page(page_token):
             req = ApiListBenchmarkModelsRequest()
             if page_token:
                 req.page_token = page_token
             return self.with_retry(kaggle.benchmarks.benchmarks_api_client.list_benchmark_models)(req)
 
-        available = self._paginate(_fetch_models, lambda r: r.benchmark_models)
+        return self._paginate(_fetch_page, lambda r: r.benchmark_models)
+
+    def _select_models_interactively(self, kaggle, page_size=20):
+        """Prompt the user to pick benchmark models from a paginated list."""
+        available = self._fetch_all_benchmark_models(kaggle)
         if not available:
             raise ValueError("No benchmark models available. Cannot schedule runs.")
 
@@ -6905,13 +6908,13 @@ class KaggleApi:
             if all_runs and all(r.state in self._TERMINAL_RUN_STATES for r in all_runs):
                 print("All runs completed:")
                 for r in all_runs:
-                    print(f"  {self._short_model_slug(r.model_version_slug)}: {self._clean_enum_str(r.state)}")
+                    print(f"  {self._normalize_model_slug(r.model_version_slug)}: {self._clean_enum_str(r.state)}")
 
                 errored = [r for r in all_runs if r.state == BenchmarkTaskRunState.BENCHMARK_TASK_RUN_STATE_ERRORED]
                 if errored:
                     details = []
                     for r in errored:
-                        slug = self._short_model_slug(r.model_version_slug)
+                        slug = self._normalize_model_slug(r.model_version_slug)
                         msg = (getattr(r, "error_message", None) or "").strip() or "No error message"
                         details.append(f"  [{slug}]\n    {msg}")
                     raise ValueError(f"{len(errored)} run(s) failed:\n" + "\n".join(details))
@@ -7168,7 +7171,7 @@ class KaggleApi:
             for r in downloadable:
                 dl_request = ApiDownloadBenchmarkTaskRunOutputRequest()
                 dl_request.run_id = r.id
-                slug = self._short_model_slug(r.model_version_slug)
+                slug = self._normalize_model_slug(r.model_version_slug)
                 # Hierarchical layout: {output}/{task}/{version}/{model}/{run_id}/
                 outdir = os.path.join(output, task, version, slug, str(r.id))
 
@@ -7200,14 +7203,7 @@ class KaggleApi:
     def benchmarks_tasks_models_cli(self):
         """List all available benchmark models."""
         with self.build_kaggle_client() as kaggle:
-
-            def _fetch_models(page_token):
-                req = ApiListBenchmarkModelsRequest()
-                if page_token:
-                    req.page_token = page_token
-                return self.with_retry(kaggle.benchmarks.benchmarks_api_client.list_benchmark_models)(req)
-
-            models = self._paginate(_fetch_models, lambda r: r.benchmark_models)
+            models = self._fetch_all_benchmark_models(kaggle)
             if not models:
                 print("No benchmark models available.")
                 return

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -1199,11 +1199,8 @@ class TestModelSlugNormalization:
         assert KaggleApi._normalize_model_list("xai/grok-4.3") == ["grok-4.3"]
 
     def test_normalize_model_list_list_of_strings(self):
-        result = KaggleApi._normalize_model_list(
-            ["xai/grok-4.3", "anthropic/claude-sonnet-4-6@default", "gemini-pro"]
-        )
+        result = KaggleApi._normalize_model_list(["xai/grok-4.3", "anthropic/claude-sonnet-4-6@default", "gemini-pro"])
         assert result == ["grok-4.3", "claude-sonnet-4-6-default", "gemini-pro"]
-
 
     # -- End-to-end: run sends normalized slugs to the API --
 

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -1155,6 +1155,95 @@ class TestDownloadFile:
 
 
 # ============================================================
+# Model Slug Normalization
+# ============================================================
+
+
+class TestModelSlugNormalization:
+    """Tests for model slug normalization helpers."""
+
+    # -- _normalize_model_slug --
+
+    @pytest.mark.parametrize(
+        "input_slug, expected",
+        [
+            # Already canonical — no change
+            ("gemini-pro", "gemini-pro"),
+            ("grok-4.3", "grok-4.3"),
+            # Provider prefix stripped
+            ("xai/grok-4.3", "grok-4.3"),
+            ("google/gemini-2.5-pro", "gemini-2.5-pro"),
+            # @ replaced with -
+            ("claude-sonnet-4-6@default", "claude-sonnet-4-6-default"),
+            # Both prefix and @
+            ("anthropic/claude-sonnet-4-6@default", "claude-sonnet-4-6-default"),
+        ],
+        ids=[
+            "canonical_plain",
+            "canonical_with_dot",
+            "strip_xai_prefix",
+            "strip_google_prefix",
+            "at_to_dash",
+            "prefix_and_at",
+        ],
+    )
+    def test_normalize_model_slug(self, input_slug, expected):
+        assert KaggleApi._normalize_model_slug(input_slug) == expected
+
+    # -- _normalize_model_list --
+
+    def test_normalize_model_list_none(self):
+        assert KaggleApi._normalize_model_list(None) == []
+
+    def test_normalize_model_list_single_string(self):
+        assert KaggleApi._normalize_model_list("xai/grok-4.3") == ["grok-4.3"]
+
+    def test_normalize_model_list_list_of_strings(self):
+        result = KaggleApi._normalize_model_list(
+            ["xai/grok-4.3", "anthropic/claude-sonnet-4-6@default", "gemini-pro"]
+        )
+        assert result == ["grok-4.3", "claude-sonnet-4-6-default", "gemini-pro"]
+
+
+    # -- End-to-end: run sends normalized slugs to the API --
+
+    def test_run_normalizes_prefixed_model_for_api(self, api, capsys):
+        """Running with 'xai/grok-4.3' should send 'grok-4.3' to the server."""
+        _setup_completed_task(api)
+        _setup_batch_schedule(api, [_make_run_result()])
+        api.benchmarks_tasks_run_cli("my-task", ["xai/grok-4.3"])
+        request = api._mock_benchmarks.batch_schedule_benchmark_task_runs.call_args[0][0]
+        assert request.model_version_slugs == ["grok-4.3"]
+
+    def test_run_normalizes_at_sign_model_for_api(self, api, capsys):
+        """Running with 'anthropic/claude-sonnet-4-6@default' normalizes to 'claude-sonnet-4-6-default'."""
+        _setup_completed_task(api)
+        _setup_batch_schedule(api, [_make_run_result()])
+        api.benchmarks_tasks_run_cli("my-task", ["anthropic/claude-sonnet-4-6@default"])
+        request = api._mock_benchmarks.batch_schedule_benchmark_task_runs.call_args[0][0]
+        assert request.model_version_slugs == ["claude-sonnet-4-6-default"]
+
+    def test_status_normalizes_model_filter(self, api, capsys):
+        """Status with prefixed model filter normalizes slugs for the API request."""
+        api._mock_benchmarks.get_benchmark_task.return_value = _make_task()
+        _setup_runs_response(api, [])
+        api.benchmarks_tasks_status_cli("my-task", model="google/gemini-2.5-pro")
+        request = api._mock_benchmarks.list_benchmark_task_runs.call_args[0][0]
+        assert request.model_version_slugs == ["gemini-2.5-pro"]
+
+    def test_download_normalizes_model_filter(self, api, capsys):
+        """Download with prefixed model filter normalizes slugs for the API request."""
+        _setup_completed_task(api)
+        _setup_runs_response(api, [_make_run()])
+        api._mock_benchmarks.download_benchmark_task_run_output.return_value = MagicMock()
+        api.download_file = MagicMock()
+        with patch("zipfile.ZipFile"), patch("os.remove"):
+            api.benchmarks_tasks_download_cli("my-task", model="xai/grok-4.3")
+        request = api._mock_benchmarks.list_benchmark_task_runs.call_args[0][0]
+        assert request.model_version_slugs == ["grok-4.3"]
+
+
+# ============================================================
 # Models
 # ============================================================
 


### PR DESCRIPTION
# PR: Consolidate and Normalize Benchmark Model Slugs

## Rationale & Root Cause
The server-side benchmark runner strictly requires canonical model slugs (no owner prefixes, no `@` characters) to schedule runs, causing `404 Not Found` errors when users passed intuitive names like `google/gemini-2.5-pro` or `claude@default`. Additionally, raw `@` characters were inconsistently exposed in status tables and file download directory structures.

## Key Changes
*   **Unified Client-Side Normalization**: Consolidated all model slug cleaning into a new helper `_normalize_model_slug(slug)` that automatically strips provider prefixes (e.g. `google/`) and converts `@` signs to hyphens (`-`) to align with the database format.
*   **Deduplicated Code**: Extracted paginated model-fetching logic into a shared helper `_fetch_all_benchmark_models(kaggle)` to remove code duplication.
*   **Updated Tests and Docs**: Added 11 unit/integration tests validating flexible input support and formatting.


## Usage
Commands (`run`, `status`, `download`) now accept all format styles interchangeably. Output tables and downloaded directories are consistently named using the canonical database slug (no `/` or `@` characters).
```bash
# You can schedule runs using any of these model slug formats interchangeably:
kaggle b t run my-task -m anthropic/claude-haiku-4-5@20251001     # Prefixed + '@' sign
kaggle b t run my-task -m google/gemini-2.0-flash-lite-001      # Prefixed only
kaggle b t run my-task -m claude-haiku-4-5-20251001              # Canonical database format

# All inputs above automatically map to clean canonical names in status and downloads:

# Check Status (displays clean canonical names, removing provider prefixes and '@' signs):
#
# Model                       Status      Started               Ended
# -------------------------------------------------------------------------
# claude-haiku-4-5-20251001   COMPLETED   2026-05-19 15:28:38   2026-05-19 15:28:38
# gemini-2.0-flash-lite-001   COMPLETED   2026-05-19 15:28:00   2026-05-19 15:28:00
kaggle b t status my-task

# Download Outputs (creates folders using clean canonical names):
#
# Downloads to: ./my-task/1/claude-haiku-4-5-20251001/283124/
# Downloads to: ./my-task/1/gemini-2.0-flash-lite-001/283123/
kaggle b t download my-task
```