### PR TITLE
feat(benchmarks): Add log and download source files

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -384,6 +384,14 @@ The command handles two response types from the server:
 *   **Active runs**: Logs are streamed in real-time via Server-Sent Events (SSE).
 *   **Completed runs**: The persisted log file is returned and printed.
 
+### Concurrency & Streaming Order
+
+When viewing logs for multiple concurrent model runs, the CLI processes and outputs them **sequentially** to prevent logs from interleaving and garbling your terminal output:
+1. The CLI prints the header for the first model run in the queue.
+2. If that run is currently active, the CLI blocks and streams its log output in real-time via SSE until it completes.
+3. The log output for the next model run will **only** be printed once the previous model run's log stream finishes and closes.
+4. Any model runs that complete in the background while you are watching the first stream will print instantly as completed persisted logs once their turn in the sequence is reached.
+
 ### Model Slug Normalization
 
 Benchmark model names are automatically normalized on both input and output. This makes it easy to pass various formats interchangeably while keeping displays and directories clean.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -6,7 +6,7 @@ The top-level command is `kaggle benchmarks` (alias: `kaggle b`), which has thre
 
 *   **`auth`** — Fetch Model Proxy credentials.
 *   **`init`** — Fetch credentials and default environment variables for local development.
-*   **`tasks`** (alias: `t`) — Manage benchmark tasks (push, run, list, status, download, models, delete).
+*   **`tasks`** (alias: `t`) — Manage benchmark tasks (push, run, list, status, download, log, models, delete).
 
 ## `kaggle benchmarks auth`
 
@@ -276,6 +276,7 @@ kaggle benchmarks tasks download <TASK> [options]
 *   `-m, --model <MODEL> [MODEL ...]`: Download outputs only for specific model slug(s).
 *   `-o, --output <DIRECTORY>`: Directory to download output files into (defaults to current working directory).
 *   `-s, --include-source`: Also download the kernel session's source notebooks.
+*   `-f, --force`: Force re-download of already completed runs, overwriting local files.
 
 **Examples:**
 
@@ -297,6 +298,12 @@ kaggle benchmarks tasks download <TASK> [options]
     kaggle b t download my-task --include-source
     ```
 
+4.  Force re-download of previously downloaded runs:
+
+    ```bash
+    kaggle b t download my-task --force
+    ```
+
 **Purpose:**
 
 Downloads and extracts the output zip archive for each completed run. Files are organized in a hierarchical layout that includes the task's version number (or `unset` if unavailable):
@@ -306,7 +313,7 @@ Downloads and extracts the output zip archive for each completed run. Files are 
    ├── output files...
 ```
 
-Already-downloaded runs (where the output directory exists) are automatically skipped.
+Already-downloaded runs (where the output directory exists) are automatically skipped unless the `-f` / `--force` flag is used, in which case they are overwritten.
 
 When `--include-source` is used, the downloaded zip also contains the kernel session's source files (e.g., `__notebook__.ipynb` and `__notebook_source__.ipynb`).
 
@@ -354,7 +361,23 @@ kaggle benchmarks tasks log <TASK> [options]
 
 **Purpose:**
 
-Fetches and displays execution logs for benchmark task runs. When multiple runs match, each run's logs are printed with a header showing the model name and run ID. For a single matching run, the header is omitted for clean output.
+Fetches and displays execution logs for benchmark task runs. Each run's logs are printed with a structured header and footer for clear identification:
+
+```
+═══ Logs for gemini-2.5-pro (Run 123) [COMPLETED] ═══
+<log output>
+═══ (42 lines) ═══
+
+═══ Logs for claude-sonnet-4 (Run 456) [ERRORED] ═══
+<log output>
+═══ (18 lines) ═══
+
+Showed logs for 2 run(s) across 2 model(s).
+```
+
+*   **Header**: Shows model name, run ID, and run state (`COMPLETED`, `ERRORED`, `RUNNING`, etc.).
+*   **Footer**: Shows the line count for each run's log output.
+*   **Summary**: Printed at the end with total run and model counts.
 
 The command handles two response types from the server:
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -169,13 +169,13 @@ kaggle benchmarks tasks run <TASK> [options]
 2.  Run a task against specific models:
 
     ```bash
-    kaggle b t run my-task -m google/gemini-2.5-pro anthropic/claude-sonnet-4
+    kaggle b t run my-task -m gemini-2.5-pro claude-sonnet-4
     ```
 
 3.  Run a task and wait for all runs to finish:
 
     ```bash
-    kaggle b t run my-task -m google/gemini-2.5-pro --wait
+    kaggle b t run my-task -m gemini-2.5-pro --wait
     ```
 
 **Purpose:**
@@ -248,7 +248,7 @@ kaggle benchmarks tasks status <TASK> [options]
 2.  Show status for specific models only:
 
     ```bash
-    kaggle b t status my-task -m google/gemini-2.5-pro
+    kaggle b t status my-task -m gemini-2.5-pro
     ```
 
 **Purpose:**
@@ -287,7 +287,7 @@ kaggle benchmarks tasks download <TASK> [options]
 2.  Download outputs for a specific model into a custom directory:
 
     ```bash
-    kaggle b t download my-task -m google/gemini-2.5-pro -o ./results
+    kaggle b t download my-task -m gemini-2.5-pro -o ./results
     ```
 
 **Purpose:**
@@ -305,10 +305,10 @@ Already-downloaded runs (where the output directory exists) are automatically sk
 
 Benchmark model names are automatically normalized on both input and output. This makes it easy to pass various formats interchangeably while keeping displays and directories clean.
 
-*   **Flexible Inputs**: The CLI accepts prefixed and proxy-style model names:
+*   **Flexible Inputs**: The CLI accepts model names in several formats:
+    *   **Canonical Slugs (recommended)**: `gemini-2.5-pro` or `claude-sonnet-4`
     *   **With Provider Prefix**: `google/gemini-2.5-pro` or `anthropic/claude-sonnet-4`
     *   **With Version/Proxy `@` symbols**: `anthropic/claude-haiku-4-5@20251001` or `claude-sonnet-4-6@default`
-    *   **Canonical Slugs**: `gemini-2.5-pro` or `claude-haiku-4-5-20251001`
 *   **Unified Normalization**: The client automatically strips any provider prefix (e.g., `google/` or `anthropic/`) and replaces `@` characters with `-` to match the server's canonical database slug format.
 *   **Clean Outputs**:
     *   **Status Display**: Tables and error logs display the canonical, hyphenated slugs (e.g., `claude-haiku-4-5-20251001` and `gemini-2.0-flash-lite-001`) for readability.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -275,6 +275,7 @@ kaggle benchmarks tasks download <TASK> [options]
 
 *   `-m, --model <MODEL> [MODEL ...]`: Download outputs only for specific model slug(s).
 *   `-o, --output <DIRECTORY>`: Directory to download output files into (defaults to current working directory).
+*   `-s, --include-source`: Also download the kernel session's source notebooks.
 
 **Examples:**
 
@@ -290,6 +291,12 @@ kaggle benchmarks tasks download <TASK> [options]
     kaggle b t download my-task -m gemini-2.5-pro -o ./results
     ```
 
+3.  Download outputs with source notebooks included:
+
+    ```bash
+    kaggle b t download my-task --include-source
+    ```
+
 **Purpose:**
 
 Downloads and extracts the output zip archive for each completed run. Files are organized in a hierarchical layout that includes the task's version number (or `unset` if unavailable):
@@ -300,6 +307,59 @@ Downloads and extracts the output zip archive for each completed run. Files are 
 ```
 
 Already-downloaded runs (where the output directory exists) are automatically skipped.
+
+When `--include-source` is used, the downloaded zip also contains the kernel session's source files (e.g., `__notebook__.ipynb` and `__notebook_source__.ipynb`).
+
+---
+
+### `kaggle benchmarks tasks log`
+
+Get execution logs for benchmark task run(s).
+
+**Usage:**
+
+```bash
+kaggle benchmarks tasks log <TASK> [options]
+```
+
+**Arguments:**
+
+*   `<TASK>`: Task name (slug).
+
+**Options:**
+
+*   `-m, --model <MODEL> [MODEL ...]`: Filter logs to specific model slug(s). If omitted, logs for all runs are shown.
+
+**Aliases:** `log`, `logs`
+
+**Examples:**
+
+1.  Show logs for all runs of a task:
+
+    ```bash
+    kaggle b t log my-task
+    ```
+
+2.  Show logs for a specific model's run(s):
+
+    ```bash
+    kaggle b t log my-task -m gemini-2.5-pro
+    ```
+
+3.  Show logs for multiple models:
+
+    ```bash
+    kaggle b t logs my-task -m gemini-2.5-pro claude-sonnet-4
+    ```
+
+**Purpose:**
+
+Fetches and displays execution logs for benchmark task runs. When multiple runs match, each run's logs are printed with a header showing the model name and run ID. For a single matching run, the header is omitted for clean output.
+
+The command handles two response types from the server:
+
+*   **Active runs**: Logs are streamed in real-time via Server-Sent Events (SSE).
+*   **Completed runs**: The persisted log file is returned and printed.
 
 ### Model Slug Normalization
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -6,7 +6,7 @@ The top-level command is `kaggle benchmarks` (alias: `kaggle b`), which has thre
 
 *   **`auth`** — Fetch Model Proxy credentials.
 *   **`init`** — Fetch credentials and default environment variables for local development.
-*   **`tasks`** (alias: `t`) — Manage benchmark tasks (push, run, list, status, download, log, models, delete).
+*   **`tasks`** (alias: `t`) — Manage benchmark tasks (push, run, list, status, download, log, models, delete, publish).
 
 ## `kaggle benchmarks auth`
 
@@ -110,6 +110,8 @@ kaggle benchmarks tasks push <TASK> -f <FILE> [options]
 *   `--wait [TIMEOUT]`: Wait for the task creation to complete. Optionally specify a timeout in seconds (`0` or omit value = wait indefinitely).
 *   `--poll-interval <SECONDS>`: Maximum seconds between status polls (default: `60`). Polling starts at 5s and increases by 50% each iteration until reaching this value.
 *   `-v, --verbose`: Enable verbose polling logs.
+*   `-d, --kaggle-dataset <DATASET> [DATASET ...]`: Kaggle dataset(s) to attach to the task's underlying notebook. Each is formatted as `owner/dataset-slug`. The latest published version of each dataset is attached. Datasets are mounted at `/kaggle/input/<dataset-slug>/` during task execution.
+
 
 **Examples:**
 
@@ -126,14 +128,28 @@ kaggle benchmarks tasks push <TASK> -f <FILE> [options]
     ```
 
 3.  Push a task and wait with a 60-second timeout, polling every 5 seconds:
-
-    ```bash
-    kaggle b t push my-task -f benchmark.py --wait 60 --poll-interval 5
-    ```
+ 
+     ```bash
+     kaggle b t push my-task -f benchmark.py --wait 60 --poll-interval 5
+     ```
+ 
+4.  Push a task with Kaggle datasets attached:
+ 
+     ```bash
+     kaggle b t push my-task -f benchmark.py -d kaggle/titanic user/my-dataset
+     ```
+ 
+5.  Push a task with datasets and wait:
+ 
+     ```bash
+     kaggle b t push my-task -f benchmark.py --wait -d kaggle/titanic
+     ```
 
 **Purpose:**
 
 This command reads a `.py` file, converts it to a Jupyter notebook format, and uploads it to Kaggle as a benchmark task. If a task with the same slug already exists, a new version is created. The file is validated to ensure it contains a `@task` decorator matching the given task name.
+ 
+**Note on dataset attachment:** When `--kaggle-dataset` / `-d` is specified, the listed datasets are attached to the task's underlying notebook kernel. During execution, they are accessible at `/kaggle/input/<dataset-slug>/`. If you re-push without `-d`, all previously-attached datasets are detached (a warning is printed). To preserve datasets across pushes, re-specify them each time. If any specified dataset is invalid, non-existent, or inaccessible, the push command will **fail** with an error: `Failed to push task: Failed to attach the following data sources (not found or inaccessible): <dataset>`.
 
 ---
 
@@ -456,6 +472,44 @@ kaggle b t delete my-task -y
 **Purpose:**
 
 Deletes a benchmark task and all associated runs. **Note:** This command is not yet supported by the server.
+ 
+---
+ 
+### `kaggle benchmarks tasks publish`
+ 
+Publishes a benchmark task, making it publicly visible.
+ 
+**Usage:**
+ 
+```bash
+kaggle benchmarks tasks publish <TASK> [options]
+```
+ 
+**Arguments:**
+ 
+*   `<TASK>`: Task name (slug).
+ 
+**Options:**
+ 
+*   `--publish-backing-notebook`: Also publish the backing notebook associated with the task. When omitted, only the task metadata is made public.
+ 
+**Examples:**
+ 
+1.  Publish a task:
+ 
+    ```bash
+    kaggle b t publish my-task
+    ```
+ 
+2.  Publish a task and its backing notebook:
+ 
+    ```bash
+    kaggle b t publish my-task --publish-backing-notebook
+    ```
+ 
+**Purpose:**
+ 
+This command changes the task's visibility from private to public. Optionally, the backing notebook (the kernel associated with the task) can be published at the same time via `--publish-backing-notebook`. Publishing is idempotent — re-publishing an already-public task prints a message and returns successfully. Unpublishing is not supported through this command.
 
 ## `kaggle benchmarks topics list`
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -110,7 +110,7 @@ kaggle benchmarks tasks push <TASK> -f <FILE> [options]
 *   `--wait [TIMEOUT]`: Wait for the task creation to complete. Optionally specify a timeout in seconds (`0` or omit value = wait indefinitely).
 *   `--poll-interval <SECONDS>`: Maximum seconds between status polls (default: `60`). Polling starts at 5s and increases by 50% each iteration until reaching this value.
 *   `-v, --verbose`: Enable verbose polling logs.
-*   `-d, --kaggle-dataset <DATASET> [DATASET ...]`: Kaggle dataset(s) to attach to the task's underlying notebook. Each is formatted as `owner/dataset-slug`. The latest published version of each dataset is attached. Datasets are mounted at `/kaggle/input/<dataset-slug>/` during task execution.
+*   `-d, --kaggle-dataset <DATASET> [DATASET ...]`: Kaggle dataset(s) to attach to the task's underlying notebook (format: `owner/dataset-slug`). Mounted at `/kaggle/input/<dataset-slug>/` by default. If a naming conflict occurs, the fully qualified mount path `/kaggle/input/<owner>/<dataset-slug>/` is used instead.
 
 
 **Examples:**
@@ -149,7 +149,7 @@ kaggle benchmarks tasks push <TASK> -f <FILE> [options]
 
 This command reads a `.py` file, converts it to a Jupyter notebook format, and uploads it to Kaggle as a benchmark task. If a task with the same slug already exists, a new version is created. The file is validated to ensure it contains a `@task` decorator matching the given task name.
  
-**Note on dataset attachment:** When `--kaggle-dataset` / `-d` is specified, the listed datasets are attached to the task's underlying notebook kernel. During execution, they are accessible at `/kaggle/input/<dataset-slug>/`. If you re-push without `-d`, all previously-attached datasets are detached (a warning is printed). To preserve datasets across pushes, re-specify them each time. If any specified dataset is invalid, non-existent, or inaccessible, the push command will **fail** with an error: `Failed to push task: Failed to attach the following data sources (not found or inaccessible): <dataset>`.
+**Note on dataset attachment:** When `--kaggle-dataset` / `-d` is specified, the listed datasets are attached to the task's underlying notebook kernel. During execution, they are accessible at `/kaggle/input/<dataset-slug>/` by default, falling back to `/kaggle/input/<owner>/<dataset-slug>/` in the event of a naming conflict. If you re-push without `-d`, all previously-attached datasets are detached (a warning is printed). To preserve datasets across pushes, re-specify them each time. If any specified dataset is invalid, non-existent, or inaccessible, the push command will **fail** with an error: `Failed to push task: Failed to attach the following data sources (not found or inaccessible): <dataset>`.
 
 ---
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -165,11 +165,11 @@ kaggle benchmarks tasks run <TASK> [options]
 
 **Arguments:**
 
-*   `<TASK>`: Task name (slug).
+*   `<TASK>`: Task name (slug, e.g. `my-task`).
 
 **Options:**
 
-*   `-m, --model <MODEL> [MODEL ...]`: One or more model slugs to run against. If omitted, an interactive model picker is displayed.
+*   `-m, --model <MODEL> [MODEL ...]`: One or more model slugs (e.g. `gemini-2.5-pro`) to run against. If omitted, an interactive model picker is displayed.
 *   `--wait [TIMEOUT]`: Wait for runs to complete. Optionally specify a timeout in seconds (`0` or omit value = wait indefinitely).
 *   `--poll-interval <SECONDS>`: Maximum seconds between status polls (default: `60`). Polling starts at 5s and increases by 50% each iteration until reaching this value.
 *   `-v, --verbose`: Enable verbose polling logs.
@@ -247,11 +247,11 @@ kaggle benchmarks tasks status <TASK> [options]
 
 **Arguments:**
 
-*   `<TASK>`: Task name (slug).
+*   `<TASK>`: Task name (slug, e.g. `my-task`).
 
 **Options:**
 
-*   `-m, --model <MODEL> [MODEL ...]`: Filter the run table to specific model slug(s).
+*   `-m, --model <MODEL> [MODEL ...]`: Filter the run table to specific model slug(s) (e.g. `gemini-2.5-pro`).
 
 **Examples:**
 
@@ -285,11 +285,11 @@ kaggle benchmarks tasks download <TASK> [options]
 
 **Arguments:**
 
-*   `<TASK>`: Task name (slug).
+*   `<TASK>`: Task name (slug, e.g. `my-task`).
 
 **Options:**
 
-*   `-m, --model <MODEL> [MODEL ...]`: Download outputs only for specific model slug(s).
+*   `-m, --model <MODEL> [MODEL ...]`: Download outputs only for specific model slug(s) (e.g. `gemini-2.5-pro`).
 *   `-o, --output <DIRECTORY>`: Directory to download output files into (defaults to current working directory).
 *   `-s, --include-source`: Also download the kernel session's source notebooks.
 *   `-f, --force`: Force re-download of already completed runs, overwriting local files.
@@ -347,11 +347,11 @@ kaggle benchmarks tasks log <TASK> [options]
 
 **Arguments:**
 
-*   `<TASK>`: Task name (slug).
+*   `<TASK>`: Task name (slug, e.g. `my-task`).
 
 **Options:**
 
-*   `-m, --model <MODEL> [MODEL ...]`: Filter logs to specific model slug(s). If omitted, logs for all runs are shown.
+*   `-m, --model <MODEL> [MODEL ...]`: Filter logs to specific model slug(s) (e.g. `gemini-2.5-pro`). If omitted, logs for all runs are shown.
 
 **Aliases:** `log`, `logs`
 
@@ -457,7 +457,7 @@ kaggle benchmarks tasks delete <TASK> [options]
 
 **Arguments:**
 
-*   `<TASK>`: Task name (slug).
+*   `<TASK>`: Task name (slug, e.g. `my-task`).
 
 **Options:**
 
@@ -477,7 +477,7 @@ Deletes a benchmark task and all associated runs. **Note:** This command is not 
  
 ### `kaggle benchmarks tasks publish`
  
-Publishes a benchmark task, making it publicly visible.
+Publishes a benchmark task, making it publicly visible. By default, the backing notebook is also published.
  
 **Usage:**
  
@@ -487,29 +487,29 @@ kaggle benchmarks tasks publish <TASK> [options]
  
 **Arguments:**
  
-*   `<TASK>`: Task name (slug).
+*   `<TASK>`: Task name (slug, e.g. `my-task`).
  
 **Options:**
  
-*   `--publish-backing-notebook`: Also publish the backing notebook associated with the task. When omitted, only the task metadata is made public.
+*   `--no-publish-backing-notebook`: Do not publish the backing notebook (it is published by default).
  
 **Examples:**
  
-1.  Publish a task:
+1.  Publish a task and its backing notebook (default):
  
     ```bash
     kaggle b t publish my-task
     ```
  
-2.  Publish a task and its backing notebook:
+2.  Publish a task without its backing notebook:
  
     ```bash
-    kaggle b t publish my-task --publish-backing-notebook
+    kaggle b t publish my-task --no-publish-backing-notebook
     ```
  
 **Purpose:**
  
-This command changes the task's visibility from private to public. Optionally, the backing notebook (the kernel associated with the task) can be published at the same time via `--publish-backing-notebook`. Publishing is idempotent — re-publishing an already-public task prints a message and returns successfully. Unpublishing is not supported through this command.
+This command changes the task's visibility from private to public. By default, the backing notebook (the kernel associated with the task) is also published. Use `--no-publish-backing-notebook` to publish only the task metadata. Publishing is idempotent — re-publishing an already-public task prints a message and returns successfully. Unpublishing is not supported through this command.
 
 ## `kaggle benchmarks topics list`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ keywords = ["Kaggle", "API"]
 requires-python = ">= 3.11"
 dependencies = [
     "bleach",
-    "kagglesdk >= 0.1.23, < 1.0", # sync with kagglehub
+    "kagglesdk >= 0.1.24, < 1.0", # sync with kagglehub
     "python-slugify",
     "requests",
     "python-dateutil",

--- a/requirements.lock
+++ b/requirements.lock
@@ -26,7 +26,7 @@ jupyter-core==5.9.1
     # via nbformat
 jupytext==1.19.1
     # via kaggle (pyproject.toml)
-kagglesdk==0.1.20
+kagglesdk==0.1.24
     # via kaggle (pyproject.toml)
 markdown-it-py==4.0.0
     # via

--- a/skills/references/benchmarks.md
+++ b/skills/references/benchmarks.md
@@ -275,6 +275,7 @@ kaggle b t logs my-task -m gemini-2.5-pro claude-sonnet-4
 - Each run's logs are printed with a header including run state: `═══ Logs for gemini-2.5-pro (Run 456) [COMPLETED] ═══`
 - Each run ends with a line count footer: `═══ (42 lines) ═══`
 - A summary is printed at the end: `Showed logs for N run(s) across N model(s).`
+- Runs are logged **sequentially** in the loop: If the first run is active, the CLI blocks and streams it in real-time until completion before printing or streaming the next run's logs. This prevents terminal log interleaving.
 - Active runs: Logs are streamed in real-time via Server-Sent Events (SSE)
 - Completed runs: The persisted log file is returned and printed
 - No runs found: `No runs found for task 'my-task'. Use 'kaggle b t run my-task' to start one.`

--- a/skills/references/benchmarks.md
+++ b/skills/references/benchmarks.md
@@ -224,11 +224,15 @@ kaggle b t download my-task -m gemini-2.5-pro
 
 # Download to a custom directory
 kaggle b t download my-task -o ./results
+
+# Download with source notebooks included
+kaggle b t download my-task --include-source
 ```
 
 **Options:**
 - `-m, --model <MODEL> [MODEL ...]`: Download only for specific models
 - `-o, --output <DIRECTORY>`: Output directory (default: current directory)
+- `-s, --include-source`: Also download the kernel session's source notebooks (`__notebook__.ipynb`, `__notebook_source__.ipynb`)
 
 **Output directory structure:**
 ```
@@ -243,6 +247,34 @@ kaggle b t download my-task -o ./results
 - Corrupt zips: Warning printed, raw `.zip` file kept, continues with other models
 - No downloadable runs (all still in progress): `No downloadable runs yet — N run(s) still in progress. Use 'kaggle b t status my-task' to check progress.`
 - No runs at all: `No runs found for task 'my-task'. Use 'kaggle b t run my-task' to start one.`
+
+### Step 6: View Logs
+
+```bash
+# Show logs for all runs of a task
+kaggle b t log my-task
+
+# Show logs for a specific model's run(s)
+kaggle b t log my-task -m gemini-2.5-pro
+
+# Show logs for multiple models
+kaggle b t logs my-task -m gemini-2.5-pro claude-sonnet-4
+```
+
+**Arguments:**
+- `<TASK>` (positional, required): Task name/slug
+
+**Options:**
+- `-m, --model <MODEL> [MODEL ...]`: Filter logs to specific model(s). If omitted, logs for all runs are shown.
+
+**Aliases:** `log`, `logs`
+
+**Behavior details:**
+- When multiple runs match, each run's logs are printed with a header: `═══ Logs for gemini-2.5-pro (Run 456) ═══`
+- For a single matching run, the header is omitted for clean output
+- Active runs: Logs are streamed in real-time via Server-Sent Events (SSE)
+- Completed runs: The persisted log file is returned and printed
+- No runs found: `No runs found for task 'my-task'. Use 'kaggle b t run my-task' to start one.`
 
 ## Additional Commands
 

--- a/skills/references/benchmarks.md
+++ b/skills/references/benchmarks.md
@@ -20,6 +20,7 @@ kaggle benchmarks (alias: kaggle b)
     ├── list          — List your benchmark tasks
     ├── status        — Show task details and per-model run status
     ├── download      — Download completed run outputs
+    ├── log / logs    — View execution logs for runs
     ├── models        — List available benchmark models
     └── delete        — Delete a task (not yet supported by server)
 ```
@@ -233,6 +234,7 @@ kaggle b t download my-task --include-source
 - `-m, --model <MODEL> [MODEL ...]`: Download only for specific models
 - `-o, --output <DIRECTORY>`: Output directory (default: current directory)
 - `-s, --include-source`: Also download the kernel session's source notebooks (`__notebook__.ipynb`, `__notebook_source__.ipynb`)
+- `-f, --force`: Force re-download of already completed runs, overwriting local files
 
 **Output directory structure:**
 ```
@@ -243,7 +245,7 @@ kaggle b t download my-task --include-source
 **Behavior details:**
 - Downloads outputs for all runs in a **terminal state** — this includes both `COMPLETED` and `ERRORED` runs (errored runs may still have partial output)
 - Downloads zip archives and extracts them automatically
-- Already-downloaded runs are skipped: `Skipping gemini-2.5-pro (run 123) — already downloaded to ./my-task/1/gemini-2.5-pro/123`
+- Already-downloaded runs are skipped (use `--force` to re-download): `Skipping gemini-2.5-pro (run 123) — already downloaded to ./my-task/1/gemini-2.5-pro/123`
 - Corrupt zips: Warning printed, raw `.zip` file kept, continues with other models
 - No downloadable runs (all still in progress): `No downloadable runs yet — N run(s) still in progress. Use 'kaggle b t status my-task' to check progress.`
 - No runs at all: `No runs found for task 'my-task'. Use 'kaggle b t run my-task' to start one.`
@@ -270,8 +272,9 @@ kaggle b t logs my-task -m gemini-2.5-pro claude-sonnet-4
 **Aliases:** `log`, `logs`
 
 **Behavior details:**
-- When multiple runs match, each run's logs are printed with a header: `═══ Logs for gemini-2.5-pro (Run 456) ═══`
-- For a single matching run, the header is omitted for clean output
+- Each run's logs are printed with a header including run state: `═══ Logs for gemini-2.5-pro (Run 456) [COMPLETED] ═══`
+- Each run ends with a line count footer: `═══ (42 lines) ═══`
+- A summary is printed at the end: `Showed logs for N run(s) across N model(s).`
 - Active runs: Logs are streamed in real-time via Server-Sent Events (SSE)
 - Completed runs: The persisted log file is returned and printed
 - No runs found: `No runs found for task 'my-task'. Use 'kaggle b t run my-task' to start one.`

--- a/skills/references/benchmarks.md
+++ b/skills/references/benchmarks.md
@@ -132,7 +132,7 @@ kaggle b t push my-task -f task.py --wait -d kaggle/titanic user/my-dataset
 - `--wait [TIMEOUT]`: Wait for creation to complete. `--wait` alone = wait indefinitely. `--wait 60` = timeout after 60s.
 - `--poll-interval <SECONDS>`: Maximum seconds between status polls (default: `60`). Polling starts at 5s and increases by 50% each iteration until reaching this value.
 - `-v, --verbose`: Enable verbose polling logs.
-- `-d, --kaggle-dataset <DATASET> [DATASET ...]`: Attach Kaggle datasets to the task's backing notebook. Format: `owner/dataset-slug`. Mounted at `/kaggle/input/<owner>/<dataset-slug>/` during execution.
+- `-d, --kaggle-dataset <DATASET> [DATASET ...]`: Attach Kaggle datasets to the task's backing notebook (format: `owner/dataset-slug`). Mounted at `/kaggle/input/<dataset-slug>/` by default. If a naming conflict occurs, the fully qualified mount path `/kaggle/input/<owner>/<dataset-slug>/` is used instead.
 
 
 **What happens:**

--- a/skills/references/benchmarks.md
+++ b/skills/references/benchmarks.md
@@ -125,14 +125,14 @@ kaggle b t push my-task -f task.py --wait -d kaggle/titanic user/my-dataset
 ```
 
 **Arguments:**
-- `<TASK>` (positional, required): Task name/slug
+- `<TASK>` (positional, required): Task name/slug (e.g. `my-task`)
 - `-f, --file <FILE>` (required): Path to the `.py` source file
 
 **Options:**
 - `--wait [TIMEOUT]`: Wait for creation to complete. `--wait` alone = wait indefinitely. `--wait 60` = timeout after 60s.
 - `--poll-interval <SECONDS>`: Maximum seconds between status polls (default: `60`). Polling starts at 5s and increases by 50% each iteration until reaching this value.
 - `-v, --verbose`: Enable verbose polling logs.
-- `-d, --kaggle-dataset <DATASET> [DATASET ...]`: Attach Kaggle datasets to the task's backing notebook. Format: `owner/dataset-slug`. Mounted at `/kaggle/input/<dataset-slug>/` during execution.
+- `-d, --kaggle-dataset <DATASET> [DATASET ...]`: Attach Kaggle datasets to the task's backing notebook. Format: `owner/dataset-slug`. Mounted at `/kaggle/input/<owner>/<dataset-slug>/` during execution.
 
 
 **What happens:**
@@ -171,10 +171,10 @@ kaggle b t run my-task -m gemini-2.5-pro --wait 30 --poll-interval 5
 ```
 
 **Arguments:**
-- `<TASK>` (positional, required): Task name/slug
+- `<TASK>` (positional, required): Task name/slug (e.g. `my-task`)
 
 **Options:**
-- `-m, --model <MODEL> [MODEL ...]`: One or more model slugs. If omitted, shows interactive picker.
+- `-m, --model <MODEL> [MODEL ...]` (e.g. `gemini-2.5-pro`): One or more model slugs. If omitted, shows interactive picker.
 - `--wait [TIMEOUT]`: Wait for runs to complete. `0` or omit value = indefinite.
 - `--poll-interval <SECONDS>`: Maximum seconds between status polls (default: `60`). Polling starts at 5s and increases by 50% each iteration until reaching this value.
 - `-v, --verbose`: Enable verbose polling logs.
@@ -240,7 +240,7 @@ kaggle b t download my-task --include-source
 ```
 
 **Options:**
-- `-m, --model <MODEL> [MODEL ...]`: Download only for specific models
+- `-m, --model <MODEL> [MODEL ...]` (e.g. `gemini-2.5-pro`): Download only for specific models
 - `-o, --output <DIRECTORY>`: Output directory (default: current directory)
 - `-s, --include-source`: Also download the kernel session's source notebooks (`__notebook__.ipynb`, `__notebook_source__.ipynb`)
 - `-f, --force`: Force re-download of already completed runs, overwriting local files
@@ -273,10 +273,10 @@ kaggle b t logs my-task -m gemini-2.5-pro claude-sonnet-4
 ```
 
 **Arguments:**
-- `<TASK>` (positional, required): Task name/slug
+- `<TASK>` (positional, required): Task name/slug (e.g. `my-task`)
 
 **Options:**
-- `-m, --model <MODEL> [MODEL ...]`: Filter logs to specific model(s). If omitted, logs for all runs are shown.
+- `-m, --model <MODEL> [MODEL ...]` (e.g. `gemini-2.5-pro`): Filter logs to specific model(s). If omitted, logs for all runs are shown.
 
 **Aliases:** `log`, `logs`
 
@@ -331,15 +331,15 @@ kaggle b t delete my-task -y   # skip confirmation
 ### Publish a Task
 
 ```bash
-# Publish a task (make it public)
+# Publish a task and its backing notebook (default)
 kaggle b t publish my-task
 
-# Also publish the task's backing notebook in the same request
-kaggle b t publish my-task --publish-backing-notebook
+# Publish without the backing notebook
+kaggle b t publish my-task --no-publish-backing-notebook
 ```
 
 **Options:**
-- `--publish-backing-notebook`: Also publish the task's backing notebook.
+- `--no-publish-backing-notebook`: Do not publish the backing notebook (it is published by default).
 
 **Notes:**
 - Idempotent: re-publishing an already-public task prints a message and returns successfully.

--- a/skills/references/benchmarks.md
+++ b/skills/references/benchmarks.md
@@ -151,13 +151,13 @@ kaggle b t push my-task -f task.py --wait 60 --poll-interval 5
 kaggle b t run my-task
 
 # Run against specific models
-kaggle b t run my-task -m google/gemini-2.5-pro anthropic/claude-sonnet-4
+kaggle b t run my-task -m gemini-2.5-pro claude-sonnet-4
 
 # Run against a model and wait for completion
-kaggle b t run my-task -m google/gemini-2.5-pro --wait
+kaggle b t run my-task -m gemini-2.5-pro --wait
 
 # Run with timeout and custom poll interval
-kaggle b t run my-task -m google/gemini-2.5-pro --wait 30 --poll-interval 5
+kaggle b t run my-task -m gemini-2.5-pro --wait 30 --poll-interval 5
 ```
 
 **Arguments:**
@@ -188,8 +188,8 @@ kaggle b t run my-task -m google/gemini-2.5-pro --wait 30 --poll-interval 5
 kaggle b t status my-task
 
 # Filter to specific models
-kaggle b t status my-task -m google/gemini-2.5-pro
-kaggle b t status my-task -m google/gemini-2.5-pro anthropic/claude-sonnet-4
+kaggle b t status my-task -m gemini-2.5-pro
+kaggle b t status my-task -m gemini-2.5-pro claude-sonnet-4
 ```
 
 **Output format:**
@@ -220,7 +220,7 @@ If no runs exist: `No runs yet. Use 'kaggle b t run my-task' to start one.`
 kaggle b t download my-task
 
 # Download for specific model(s)
-kaggle b t download my-task -m google/gemini-2.5-pro
+kaggle b t download my-task -m gemini-2.5-pro
 
 # Download to a custom directory
 kaggle b t download my-task -o ./results
@@ -302,10 +302,10 @@ The slug must match between the `@task(name=...)` decorator in the file and the 
 
 Benchmark model names are automatically normalized on both input and output. This makes it easy to pass various formats interchangeably while keeping displays and directories clean.
 
-- **Flexible Inputs**: The CLI accepts prefixed and proxy-style model names:
+- **Flexible Inputs**: The CLI accepts model names in several formats:
+  - **Canonical Slugs (recommended)**: `gemini-2.5-pro` or `claude-sonnet-4`
   - **With Provider Prefix**: `google/gemini-2.5-pro` or `anthropic/claude-sonnet-4`
   - **With Version/Proxy `@` symbols**: `anthropic/claude-haiku-4-5@20251001` or `claude-sonnet-4-6@default`
-  - **Canonical Slugs**: `gemini-2.5-pro` or `claude-haiku-4-5-20251001`
 - **Unified Normalization**: The client automatically strips any provider prefix (e.g., `google/` or `anthropic/`) and replaces `@` characters with `-` to match the server's canonical database slug format.
 - **Clean Outputs**:
   - **Status Display**: Tables and error logs display the canonical, hyphenated slugs (e.g., `claude-haiku-4-5-20251001` and `gemini-2.0-flash-lite-001`) for readability.
@@ -325,7 +325,7 @@ kaggle b init -y
 kaggle b t push my-task -f task.py --wait
 
 # 4. Run against models
-kaggle b t run my-task -m google/gemini-2.5-pro anthropic/claude-sonnet-4 --wait
+kaggle b t run my-task -m gemini-2.5-pro claude-sonnet-4 --wait
 
 # 5. Check status
 kaggle b t status my-task
@@ -361,7 +361,7 @@ python task.py
 **4. Once satisfied, push to the server:**
 ```bash
 kaggle b t push my-task -f task.py --wait && \
-kaggle b t run my-task -m google/gemini-2.5-pro --wait && \
+kaggle b t run my-task -m gemini-2.5-pro --wait && \
 kaggle b t download my-task -o ./results
 ```
 
@@ -372,7 +372,7 @@ kaggle b t download my-task -o ./results
 ```bash
 # Push and wait, then run and wait, all in sequence
 kaggle b t push my-task -f task.py --wait && \
-kaggle b t run my-task -m google/gemini-2.5-pro --wait && \
+kaggle b t run my-task -m gemini-2.5-pro --wait && \
 kaggle b t download my-task -o ./results
 ```
 
@@ -397,7 +397,7 @@ d.run(kbench.llm)
 kaggle b t push d -f t.py --wait
 
 # Run — will complete with ERRORED status
-kaggle b t run d -m google/gemini-3-flash-preview --wait
+kaggle b t run d -m gemini-3-flash-preview --wait
 
 # Status shows clean table + separate Errors section
 kaggle b t status d

--- a/skills/references/benchmarks.md
+++ b/skills/references/benchmarks.md
@@ -22,7 +22,8 @@ kaggle benchmarks (alias: kaggle b)
     ├── download      — Download completed run outputs
     ├── log / logs    — View execution logs for runs
     ├── models        — List available benchmark models
-    └── delete        — Delete a task (not yet supported by server)
+    ├── delete        — Delete a task (not yet supported by server)
+    └── publish       — Publish a task (make it public)
 ```
 
 ## Setup & Authentication
@@ -116,6 +117,9 @@ kaggle b t push my-task -f task.py --wait
 # Push with timeout (60s) and custom poll interval (5s)
 kaggle b t push my-task -f task.py --wait 60 --poll-interval 5
 
+# Push with Kaggle datasets attached
+kaggle b t push my-task -f task.py --wait -d kaggle/titanic user/my-dataset
+
 # Push without waiting (fire-and-forget; check status with `kaggle b t status`)
 # kaggle b t push my-task -f task.py
 ```
@@ -128,6 +132,8 @@ kaggle b t push my-task -f task.py --wait 60 --poll-interval 5
 - `--wait [TIMEOUT]`: Wait for creation to complete. `--wait` alone = wait indefinitely. `--wait 60` = timeout after 60s.
 - `--poll-interval <SECONDS>`: Maximum seconds between status polls (default: `60`). Polling starts at 5s and increases by 50% each iteration until reaching this value.
 - `-v, --verbose`: Enable verbose polling logs.
+- `-d, --kaggle-dataset <DATASET> [DATASET ...]`: Attach Kaggle datasets to the task's backing notebook. Format: `owner/dataset-slug`. Mounted at `/kaggle/input/<dataset-slug>/` during execution.
+
 
 **What happens:**
 1. Validates the file is a `.py` file and exists
@@ -144,6 +150,9 @@ kaggle b t push my-task -f task.py --wait 60 --poll-interval 5
 - Task name mismatch: `ValueError: Task 'wrong-name' not found in file task.py. Found tasks: real-task`
 - Re-push while previous is still processing (without `--wait`): `ValueError: Task 'my-task' is currently being created (pending). Cannot push now. Use --wait to monitor the existing creation.`
 - Re-push with `--wait`: Waits for existing creation to complete, then pushes new version automatically
+- Re-push without `-d` when previous version had datasets: Prints yellow warning to stderr: `⚠ Warning: The previous version of 'my-task' had attached Kaggle datasets: ...` and detaches them (re-specify `-d` to keep them).
+- Invalid or inaccessible Kaggle dataset: `Failed to push task: Failed to attach the following data sources (not found or inaccessible): <dataset>`
+
 
 ### Step 3: Run the Task Against Models
 
@@ -318,6 +327,25 @@ kaggle b t delete my-task -y   # skip confirmation
 ```
 
 **Note:** Delete is not yet supported by the server. Currently prints: `Delete is not supported by the server yet.`
+
+### Publish a Task
+
+```bash
+# Publish a task (make it public)
+kaggle b t publish my-task
+
+# Also publish the task's backing notebook in the same request
+kaggle b t publish my-task --publish-backing-notebook
+```
+
+**Options:**
+- `--publish-backing-notebook`: Also publish the task's backing notebook.
+
+**Notes:**
+- Idempotent: re-publishing an already-public task prints a message and returns successfully.
+- Unpublishing is not supported through this command.
+- If task not found, raises `ValueError: Task 'my-task' not found. Check the task name and try again. Use 'kaggle b t list' to see your tasks.`
+
 
 ## Task Name Normalization
 

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -7230,11 +7230,9 @@ class KaggleApi:
 
         task_slug = slugify(task)
         if task_slug != task:
-            print(
-                f"\n{self._warn(f'⚠ Warning: task name {task!r} was normalized to slug {task_slug!r}.')}\n"
-                f"{self._warn_detail(f'  Use {task_slug!r} in future commands.')}\n",
-                file=sys.stderr,
-            )
+            msg1 = self._warn(f"⚠ Warning: task name {task!r} was normalized to slug {task_slug!r}.")
+            msg2 = self._warn_detail(f"  Use {task_slug!r} in future commands.")
+            print(f"\n{msg1}\n{msg2}\n", file=sys.stderr)
 
         notebook_content = self._convert_py_to_notebook(content)
 
@@ -7256,12 +7254,13 @@ class KaggleApi:
                 prev_options = getattr(task_info, "options", None)
                 if prev_options and prev_options.dataset_data_sources:
                     prev_sources = ", ".join(prev_options.dataset_data_sources)
-                    print(
-                        f"{self._warn(f"⚠ Warning: The previous version of '{task_slug}' had attached "
-                        f"Kaggle datasets: {prev_sources}")}\n" f"{self._warn_detail('  Re-pushing without --kaggle-dataset / -d will detach them.')}\n" f"{self._warn_detail(f"  To keep them, add: -d "
-                        f"{' '.join(prev_options.dataset_data_sources)}")}",
-                        file=sys.stderr,
+                    msg1 = self._warn(
+                        f"⚠ Warning: The previous version of '{task_slug}' had attached "
+                        f"Kaggle datasets: {prev_sources}"
                     )
+                    msg2 = self._warn_detail("  Re-pushing without --kaggle-dataset / -d will detach them.")
+                    msg3 = self._warn_detail(f"  To keep them, add: -d {' '.join(prev_options.dataset_data_sources)}")
+                    print(f"{msg1}\n{msg2}\n{msg3}", file=sys.stderr)
 
             request = ApiCreateBenchmarkTaskRequest()
             request.slug = task_slug
@@ -7291,11 +7290,10 @@ class KaggleApi:
                     print(f"Attached Kaggle dataset(s): {', '.join(attached.dataset_data_sources)}")
                 invalid = getattr(response, "invalid_dataset_sources", None)
                 if invalid:
-                    print(
-                        f"{self._warn(f'⚠ Warning: The following Kaggle datasets could not be resolved: '
-                        f"{', '.join(invalid)}")}",
-                        file=sys.stderr,
+                    msg = self._warn(
+                        f"⚠ Warning: The following Kaggle datasets could not be resolved: " f"{', '.join(invalid)}"
                     )
+                    print(msg, file=sys.stderr)
 
             if wait is None:
                 print(f"   Model Output:  {model_output_url}")

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -7436,8 +7436,6 @@ class KaggleApi:
                     print(f"{row_prefix} {size_str:<{size_col}} {'Skipped':<{prog_col}}")
                     skipped += 1
                     continue
-                if os.path.isdir(outdir):
-                    shutil.rmtree(outdir)
 
                 dl_request = ApiDownloadBenchmarkTaskRunOutputRequest()
                 dl_request.run_id = r.id
@@ -7447,23 +7445,37 @@ class KaggleApi:
                 )(dl_request)
                 zipfile_path = outdir + ".zip"
                 size_str = ""
+                # Download and extract to a staging directory, then swap on
+                # success so a failed download doesn't destroy a previous
+                # good output when using --force.
+                tmp_outdir = outdir + ".download"
+                if os.path.isdir(tmp_outdir):
+                    shutil.rmtree(tmp_outdir)
                 try:
+                    # quiet=True: intermediate zip, extracted and removed below
                     self.download_file(response, zipfile_path, kaggle.http_client(), quiet=True)
                     size_str = self._format_size(os.path.getsize(zipfile_path)) if os.path.exists(zipfile_path) else ""
-                    # Extract the zip archive into the output directory.
                     # Note: extractall() is safe here because the zip originates from
                     # the trusted Kaggle server, not user-supplied input (zip-slip).
                     with zipfile.ZipFile(zipfile_path, "r") as zf:
-                        zf.extractall(outdir)
+                        zf.extractall(tmp_outdir)
                 except zipfile.BadZipFile:
                     print(f"{row_prefix} {size_str:<{size_col}} {'Bad zip':<{prog_col}}")
+                    if os.path.isdir(tmp_outdir):
+                        shutil.rmtree(tmp_outdir)
                     continue
                 except Exception:
-                    # Clean up partial zip on network/download failure
+                    # Clean up partial zip and staging dir on failure
                     if os.path.exists(zipfile_path):
                         os.remove(zipfile_path)
+                    if os.path.isdir(tmp_outdir):
+                        shutil.rmtree(tmp_outdir)
                     raise
                 os.remove(zipfile_path)
+                # Swap: remove old output only after new download succeeds
+                if os.path.isdir(outdir):
+                    shutil.rmtree(outdir)
+                os.rename(tmp_outdir, outdir)
                 downloaded += 1
                 print(f"{row_prefix} {size_str:<{size_col}} {'Done':<{prog_col}}")
 
@@ -7504,7 +7516,12 @@ class KaggleApi:
         if isinstance(log_entry, dict) and "data" in log_entry:
             text = log_entry["data"]
             print(text, end="", flush=flush)
-            return text.count("\n"), text.endswith("\n")
+            # Count visual lines: newlines, plus one for a partial trailing
+            # line that is printed but has no newline terminator.
+            lines = text.count("\n")
+            if text and not text.endswith("\n"):
+                lines += 1
+            return lines, text.endswith("\n")
         print(log_entry, flush=flush)
         return 1, True
 
@@ -7537,7 +7554,10 @@ class KaggleApi:
                 line_count = 0
                 content_type = response.headers.get("Content-Type", "")
                 if "text/event-stream" in content_type:
-                    # Active run — stream SSE events in real-time
+                    # Active run — stream SSE events in real-time.
+                    # Note: the SSE spec allows multi-line data: continuation,
+                    # but currently the server emits one data: line per event
+                    # so we treat each line independently.
                     last_ended_with_newline = True
                     for line in response.iter_lines():
                         decoded = line.decode("utf-8") if isinstance(line, bytes) else line

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -7470,7 +7470,7 @@ class KaggleApi:
                 model_hint = self._format_model_hint(model)
                 print(f"No runs found for task '{task}'{model_hint}.")
                 print(f"Use 'kaggle b t run {task}' to start one.")
-                print(f"\nDone: 0 downloaded.")
+                print(f"\nDone: 0 runs downloaded.")
                 return
 
             downloadable = [r for r in runs if r.state in self._TERMINAL_RUN_STATES]
@@ -7478,7 +7478,7 @@ class KaggleApi:
                 pending = len(runs)
                 print(f"No downloadable runs yet — {pending} run(s) still in progress.")
                 print(f"Use 'kaggle b t status {task}' to check progress.")
-                print(f"\nDone: 0 downloaded.")
+                print(f"\nDone: 0 runs downloaded.")
                 return
 
             target_dir = os.path.join(output, task)
@@ -7554,7 +7554,7 @@ class KaggleApi:
                 print(f"{row_prefix} {size_str:<{size_col}} {'Done':<{prog_col}}")
 
             # Summary
-            parts = [f"{n} {label}" for n, label in ((downloaded, "downloaded"), (skipped, "skipped")) if n]
+            parts = [f"{n} run(s) {label}" for n, label in ((downloaded, "downloaded"), (skipped, "skipped")) if n]
             print(f"\nDone: {', '.join(parts) or '0 runs downloaded'}.")
 
     @staticmethod
@@ -7705,7 +7705,7 @@ class KaggleApi:
         # TODO: Normalize task name via slugify(task) when server supports delete.
         print("Delete is not supported by the server yet.")
 
-    def benchmarks_tasks_publish_cli(self, task, publish_backing_notebook=False):
+    def benchmarks_tasks_publish_cli(self, task, publish_backing_notebook=True):
         """Publish a benchmark task, making it public."""
         task = slugify(task)
 

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -7375,7 +7375,17 @@ class KaggleApi:
 
             self._print_run_table(runs)
 
-    def benchmarks_tasks_download_cli(self, task, model=None, output=None, include_source=False):
+    @staticmethod
+    def _format_model_hint(model):
+        """Format a human-readable model filter hint for error messages."""
+        if isinstance(model, str):
+            return f" for model '{model}'"
+        if model:
+            return f" for model(s) {', '.join(model)}"
+        return ""
+
+    def benchmarks_tasks_download_cli(self, task, model=None, output=None, include_source=False, force=False):
+        """Download output files for completed/errored benchmark task runs."""
         task = slugify(task)
         output = output or "."
 
@@ -7385,12 +7395,7 @@ class KaggleApi:
             runs = self._fetch_task_runs(kaggle, task, model)
 
             if not runs:
-                if isinstance(model, str):
-                    model_hint = f" for model '{model}'"
-                elif model:
-                    model_hint = f" for models {', '.join(model)}"
-                else:
-                    model_hint = ""
+                model_hint = self._format_model_hint(model)
                 print(f"No runs found for task '{task}'{model_hint}.")
                 print(f"Use 'kaggle b t run {task}' to start one.")
                 return
@@ -7419,16 +7424,20 @@ class KaggleApi:
             print(f"{'Model':<{model_col}} {'File':<{file_col}} {'Size':<{size_col}} {'Progress':<{prog_col}}")
             print(f"{'─' * model_col} {'─' * file_col} {'─' * size_col} {'─' * prog_col}")
 
+            downloaded, skipped = 0, 0
             for r, display_file in zip(downloadable, display_files):
                 slug = self._normalize_model_slug(r.model_version_slug)
                 # Hierarchical layout: {output}/{task}/{version}/{model}/{run_id}/
                 outdir = os.path.join(output, task, version, slug, str(r.id))
                 row_prefix = f"{slug:<{model_col}} {display_file:<{file_col}}"
 
-                if os.path.isdir(outdir):
+                if os.path.isdir(outdir) and not force:
                     size_str = self._format_size(self._dir_size(outdir))
                     print(f"{row_prefix} {size_str:<{size_col}} {'Skipped':<{prog_col}}")
+                    skipped += 1
                     continue
+                if os.path.isdir(outdir):
+                    shutil.rmtree(outdir)
 
                 dl_request = ApiDownloadBenchmarkTaskRunOutputRequest()
                 dl_request.run_id = r.id
@@ -7437,19 +7446,30 @@ class KaggleApi:
                     kaggle.benchmarks.benchmark_tasks_api_client.download_benchmark_task_run_output
                 )(dl_request)
                 zipfile_path = outdir + ".zip"
-                self.download_file(response, zipfile_path, kaggle.http_client(), quiet=True)
-                size_str = self._format_size(os.path.getsize(zipfile_path)) if os.path.exists(zipfile_path) else ""
-                # Extract the zip archive into the output directory.
-                # Note: extractall() is safe here because the zip originates from
-                # the trusted Kaggle server, not user-supplied input (zip-slip).
+                size_str = ""
                 try:
+                    self.download_file(response, zipfile_path, kaggle.http_client(), quiet=True)
+                    size_str = self._format_size(os.path.getsize(zipfile_path)) if os.path.exists(zipfile_path) else ""
+                    # Extract the zip archive into the output directory.
+                    # Note: extractall() is safe here because the zip originates from
+                    # the trusted Kaggle server, not user-supplied input (zip-slip).
                     with zipfile.ZipFile(zipfile_path, "r") as zf:
                         zf.extractall(outdir)
                 except zipfile.BadZipFile:
                     print(f"{row_prefix} {size_str:<{size_col}} {'Bad zip':<{prog_col}}")
                     continue
+                except Exception:
+                    # Clean up partial zip on network/download failure
+                    if os.path.exists(zipfile_path):
+                        os.remove(zipfile_path)
+                    raise
                 os.remove(zipfile_path)
+                downloaded += 1
                 print(f"{row_prefix} {size_str:<{size_col}} {'Done':<{prog_col}}")
+
+            # Summary
+            parts = [f"{n} {label}" for n, label in ((downloaded, "downloaded"), (skipped, "skipped")) if n]
+            print(f"\nDone: {', '.join(parts) or '0 runs downloaded'}.")
 
     @staticmethod
     def _format_size(n) -> str:
@@ -7473,39 +7493,48 @@ class KaggleApi:
                     total += os.path.getsize(fp)
         return total
 
+    @staticmethod
+    def _print_log_entry(log_entry, flush=False):
+        """Print a single log entry, returning (lines_printed, ended_with_newline).
+
+        Log entries from the benchmark server are either:
+        - dicts with a "data" key containing the log text, or
+        - raw strings/values to print as-is.
+        """
+        if isinstance(log_entry, dict) and "data" in log_entry:
+            text = log_entry["data"]
+            print(text, end="", flush=flush)
+            return text.count("\n"), text.endswith("\n")
+        print(log_entry, flush=flush)
+        return 1, True
+
     def benchmarks_tasks_log_cli(self, task, model=None):
         """Print execution logs for benchmark task run(s)."""
         task = slugify(task)
 
         with self.build_kaggle_client() as kaggle:
+            self._get_benchmark_task(task, kaggle)
             runs = self._fetch_task_runs(kaggle, task, model)
 
             if not runs:
-                model_hint = ""
-                if isinstance(model, str):
-                    model_hint = f" for model '{model}'"
-                elif model:
-                    model_hint = f" for model(s) {', '.join(model)}"
-                raise ValueError(
-                    f"No runs found for task '{task}'{model_hint}. "
-                    f"Use 'kaggle b t run {task}' to start one."
-                )
-
-            show_headers = len(runs) > 1
+                model_hint = self._format_model_hint(model)
+                print(f"No runs found for task '{task}'{model_hint}. Use 'kaggle b t run {task}' to start one.")
+                return
 
             for run in runs:
                 slug = self._normalize_model_slug(run.model_version_slug)
+                state = self._clean_enum_str(run.state)
 
-                if show_headers:
-                    print(f"\n═══ Logs for {slug} (Run {run.id}) ═══")
+                print(f"\n═══ Logs for {slug} (Run {run.id}) [{state}] ═══")
 
                 request = ApiGetBenchmarkTaskRunLogsRequest()
                 request.run_id = run.id
 
-                response = self.with_retry(
-                    kaggle.benchmarks.benchmark_tasks_api_client.get_benchmark_task_run_logs
-                )(request)
+                response = self.with_retry(kaggle.benchmarks.benchmark_tasks_api_client.get_benchmark_task_run_logs)(
+                    request
+                )
 
+                line_count = 0
                 content_type = response.headers.get("Content-Type", "")
                 if "text/event-stream" in content_type:
                     # Active run — stream SSE events in real-time
@@ -7515,19 +7544,14 @@ class KaggleApi:
                         if decoded.startswith("data:"):
                             event_data = decoded[5:].lstrip()
                             try:
-                                log_entry = json.loads(event_data)
-                                if isinstance(log_entry, dict) and "data" in log_entry:
-                                    text = log_entry["data"]
-                                    print(text, end="", flush=True)
-                                    last_ended_with_newline = text.endswith("\n")
-                                else:
-                                    print(event_data, flush=True)
-                                    last_ended_with_newline = True
-                            except Exception:
-                                print(event_data, flush=True)
-                                last_ended_with_newline = True
+                                entry = json.loads(event_data)
+                            except (json.JSONDecodeError, ValueError):
+                                entry = event_data
+                            lines, last_ended_with_newline = self._print_log_entry(entry, flush=True)
+                            line_count += lines
                         elif decoded.strip():
                             print(decoded, flush=True)
+                            line_count += 1
                             last_ended_with_newline = True
                     if not last_ended_with_newline:
                         print()
@@ -7535,22 +7559,25 @@ class KaggleApi:
                     # Completed/errored run — persisted log
                     try:
                         logs = json.loads(response.text)
-                        if isinstance(logs, list):
-                            last_ended_with_newline = True
-                            for log_entry in logs:
-                                if isinstance(log_entry, dict) and "data" in log_entry:
-                                    text = log_entry["data"]
-                                    print(text, end="")
-                                    last_ended_with_newline = text.endswith("\n")
-                                else:
-                                    print(log_entry)
-                                    last_ended_with_newline = True
-                            if not last_ended_with_newline:
-                                print()
-                        else:
-                            print(response.text)
-                    except Exception:
+                    except (json.JSONDecodeError, ValueError):
+                        logs = None
+
+                    if isinstance(logs, list):
+                        last_ended_with_newline = True
+                        for log_entry in logs:
+                            lines, last_ended_with_newline = self._print_log_entry(log_entry)
+                            line_count += lines
+                        if not last_ended_with_newline:
+                            print()
+                    else:
                         print(response.text)
+                        line_count = response.text.count("\n")
+
+                print(f"═══ ({line_count} lines) ═══")
+
+            # Summary
+            models_seen = {self._normalize_model_slug(r.model_version_slug) for r in runs}
+            print(f"\nShowed logs for {len(runs)} run(s) across {len(models_seen)} model(s).")
 
     def benchmarks_tasks_models_cli(self):
         """List all available benchmark models."""

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -7444,6 +7444,7 @@ class KaggleApi:
                 return
 
             self._print_run_table(runs)
+            print(f"\nView logs: kaggle b t log {task} [-m <model>]")
 
     @staticmethod
     def _format_model_hint(model):

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -6752,7 +6752,6 @@ class KaggleApi:
                 last_line = next((ln for ln in reversed(msg.strip().splitlines()) if ln.strip()), msg.strip())
                 print(f"{KaggleApi._error(f'  [{slug}]')} {KaggleApi._error_detail(last_line.strip())}")
 
-
     @staticmethod
     def _strip_ipython_magics(source: str) -> str:
         """Remove IPython/Jupyter magic lines so ast.parse() can handle them.

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -63,6 +63,7 @@ from kagglesdk.benchmarks.types.benchmark_tasks_api_service import (
     ApiCreateBenchmarkTaskRequest,
     ApiListBenchmarkTasksRequest,
     ApiGetBenchmarkTaskRequest,
+    ApiGetBenchmarkTaskRunLogsRequest,
     ApiListBenchmarkTaskRunsRequest,
     ApiBenchmarkTaskSlug,
     ApiBatchScheduleBenchmarkTaskRunsRequest,
@@ -7374,7 +7375,7 @@ class KaggleApi:
 
             self._print_run_table(runs)
 
-    def benchmarks_tasks_download_cli(self, task, model=None, output=None):
+    def benchmarks_tasks_download_cli(self, task, model=None, output=None, include_source=False):
         task = slugify(task)
         output = output or "."
 
@@ -7431,6 +7432,7 @@ class KaggleApi:
 
                 dl_request = ApiDownloadBenchmarkTaskRunOutputRequest()
                 dl_request.run_id = r.id
+                dl_request.include_source = include_source
                 response = self.with_retry(
                     kaggle.benchmarks.benchmark_tasks_api_client.download_benchmark_task_run_output
                 )(dl_request)
@@ -7470,6 +7472,85 @@ class KaggleApi:
                 if os.path.isfile(fp):
                     total += os.path.getsize(fp)
         return total
+
+    def benchmarks_tasks_log_cli(self, task, model=None):
+        """Print execution logs for benchmark task run(s)."""
+        task = slugify(task)
+
+        with self.build_kaggle_client() as kaggle:
+            runs = self._fetch_task_runs(kaggle, task, model)
+
+            if not runs:
+                model_hint = ""
+                if isinstance(model, str):
+                    model_hint = f" for model '{model}'"
+                elif model:
+                    model_hint = f" for model(s) {', '.join(model)}"
+                raise ValueError(
+                    f"No runs found for task '{task}'{model_hint}. "
+                    f"Use 'kaggle b t run {task}' to start one."
+                )
+
+            show_headers = len(runs) > 1
+
+            for run in runs:
+                slug = self._normalize_model_slug(run.model_version_slug)
+
+                if show_headers:
+                    print(f"\n═══ Logs for {slug} (Run {run.id}) ═══")
+
+                request = ApiGetBenchmarkTaskRunLogsRequest()
+                request.run_id = run.id
+
+                response = self.with_retry(
+                    kaggle.benchmarks.benchmark_tasks_api_client.get_benchmark_task_run_logs
+                )(request)
+
+                content_type = response.headers.get("Content-Type", "")
+                if "text/event-stream" in content_type:
+                    # Active run — stream SSE events in real-time
+                    last_ended_with_newline = True
+                    for line in response.iter_lines():
+                        decoded = line.decode("utf-8") if isinstance(line, bytes) else line
+                        if decoded.startswith("data:"):
+                            event_data = decoded[5:].lstrip()
+                            try:
+                                log_entry = json.loads(event_data)
+                                if isinstance(log_entry, dict) and "data" in log_entry:
+                                    text = log_entry["data"]
+                                    print(text, end="", flush=True)
+                                    last_ended_with_newline = text.endswith("\n")
+                                else:
+                                    print(event_data, flush=True)
+                                    last_ended_with_newline = True
+                            except Exception:
+                                print(event_data, flush=True)
+                                last_ended_with_newline = True
+                        elif decoded.strip():
+                            print(decoded, flush=True)
+                            last_ended_with_newline = True
+                    if not last_ended_with_newline:
+                        print()
+                else:
+                    # Completed/errored run — persisted log
+                    try:
+                        logs = json.loads(response.text)
+                        if isinstance(logs, list):
+                            last_ended_with_newline = True
+                            for log_entry in logs:
+                                if isinstance(log_entry, dict) and "data" in log_entry:
+                                    text = log_entry["data"]
+                                    print(text, end="")
+                                    last_ended_with_newline = text.endswith("\n")
+                                else:
+                                    print(log_entry)
+                                    last_ended_with_newline = True
+                            if not last_ended_with_newline:
+                                print()
+                        else:
+                            print(response.text)
+                    except Exception:
+                        print(response.text)
 
     def benchmarks_tasks_models_cli(self):
         """List all available benchmark models."""

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -68,7 +68,9 @@ from kagglesdk.benchmarks.types.benchmark_tasks_api_service import (
     ApiBenchmarkTaskSlug,
     ApiBatchScheduleBenchmarkTaskRunsRequest,
     ApiDownloadBenchmarkTaskRunOutputRequest,
+    ApiPublishBenchmarkTaskRequest,
 )
+from kagglesdk.benchmarks.types.benchmark_types import BenchmarkTaskOptions
 from kagglesdk.benchmarks.types.benchmarks_api_service import ApiListBenchmarkModelsRequest
 from kagglesdk.competitions.types.competition_api_service import (
     ApiListCompetitionsRequest,
@@ -6669,6 +6671,40 @@ class KaggleApi:
         return KaggleApi._clean_enum_str(state).title()
 
     @staticmethod
+    def _ansi(code: str, text: str, stream=None) -> str:
+        """Wrap text in ANSI escape codes, stripping them for non-TTY output."""
+        if stream is None:
+            stream = sys.stdout
+        if not hasattr(stream, "isatty") or not stream.isatty():
+            return text
+        return f"\033[{code}m{text}\033[0m"
+
+    @classmethod
+    def _bold(cls, text: str) -> str:
+        """Bold text, TTY-aware."""
+        return cls._ansi("1", text)
+
+    @classmethod
+    def _warn(cls, text: str, stream=None) -> str:
+        """Yellow warning text, TTY-aware."""
+        return cls._ansi("1;33", text, stream or sys.stderr)
+
+    @classmethod
+    def _warn_detail(cls, text: str, stream=None) -> str:
+        """Yellow detail text (non-bold), TTY-aware."""
+        return cls._ansi("33", text, stream or sys.stderr)
+
+    @classmethod
+    def _error(cls, text: str) -> str:
+        """Red error text, TTY-aware."""
+        return cls._ansi("1;31", text)
+
+    @classmethod
+    def _error_detail(cls, text: str) -> str:
+        """Red detail text (non-bold), TTY-aware."""
+        return cls._ansi("31", text)
+
+    @staticmethod
     def _format_time(t) -> str:
         """Format a timestamp to seconds precision for display."""
         if isinstance(t, datetime):
@@ -6709,12 +6745,13 @@ class KaggleApi:
 
         if errors:
             print()
-            print(f"\033[1;31mErrors:\033[0m")
+            print(f"{KaggleApi._error('Errors:')}")
             for slug, msg in errors:
                 # Server-captured error_message may include a full Python traceback. The actual
                 # exception line is last; everything above is stack noise. Show just that line.
                 last_line = next((ln for ln in reversed(msg.strip().splitlines()) if ln.strip()), msg.strip())
-                print(f"\033[1;31m  [{slug}]\033[0m \033[31m{last_line.strip()}\033[0m")
+                print(f"{KaggleApi._error(f'  [{slug}]')} {KaggleApi._error_detail(last_line.strip())}")
+
 
     @staticmethod
     def _strip_ipython_magics(source: str) -> str:
@@ -7179,7 +7216,7 @@ class KaggleApi:
         print("  Run your first task using the example file:")
         print(f"  $ kaggle b t push what-is-kaggle -f {example_name} --wait")
 
-    def benchmarks_tasks_push_cli(self, task, file, wait=None, poll_interval=60, verbose=False):
+    def benchmarks_tasks_push_cli(self, task, file, wait=None, poll_interval=60, verbose=False, kaggle_datasets=None):
         if poll_interval is not None and poll_interval <= 0:
             raise ValueError("--poll-interval must be a positive integer")
         if not os.path.isfile(file):
@@ -7194,8 +7231,8 @@ class KaggleApi:
         task_slug = slugify(task)
         if task_slug != task:
             print(
-                f"\n\033[1;33mWarning: task name '{task}' was normalized to slug '{task_slug}'.\033[0m\n"
-                f"\033[33m  Use '{task_slug}' in future commands.\033[0m\n",
+                f"\n{self._warn(f'⚠ Warning: task name {task!r} was normalized to slug {task_slug!r}.')}\n"
+                f"{self._warn_detail(f'  Use {task_slug!r} in future commands.')}\n",
                 file=sys.stderr,
             )
 
@@ -7214,9 +7251,27 @@ class KaggleApi:
                 print(f"Task '{task_slug}' is already being created. Waiting for it to finish...")
                 self._poll_task_creation(kaggle, task_slug, wait, poll_interval, verbose=verbose)
 
+            # Warn if re-pushing without datasets when previous version had them
+            if task_info and not kaggle_datasets:
+                prev_options = getattr(task_info, "options", None)
+                if prev_options and prev_options.dataset_data_sources:
+                    prev_sources = ", ".join(prev_options.dataset_data_sources)
+                    print(
+                        f"{self._warn(f"⚠ Warning: The previous version of '{task_slug}' had attached "
+                        f"Kaggle datasets: {prev_sources}")}\n" f"{self._warn_detail('  Re-pushing without --kaggle-dataset / -d will detach them.')}\n" f"{self._warn_detail(f"  To keep them, add: -d "
+                        f"{' '.join(prev_options.dataset_data_sources)}")}",
+                        file=sys.stderr,
+                    )
+
             request = ApiCreateBenchmarkTaskRequest()
             request.slug = task_slug
             request.text = notebook_content
+
+            # Attach Kaggle datasets if specified
+            if kaggle_datasets:
+                options = BenchmarkTaskOptions()
+                options.dataset_data_sources = kaggle_datasets
+                request.options = options
 
             response = self.with_retry(kaggle.benchmarks.benchmark_tasks_api_client.create_benchmark_task)(request)
             error = getattr(response, "error", None)
@@ -7228,6 +7283,19 @@ class KaggleApi:
             banner_subject = f"new version of {task_slug}" if is_new_version else task_slug
             print(f"\nPushed {banner_subject}")
             print(f"   Task Details:  {url}")
+
+            # Report datasource attachment results
+            if kaggle_datasets:
+                attached = getattr(response, "options", None)
+                if attached and attached.dataset_data_sources:
+                    print(f"Attached Kaggle dataset(s): {', '.join(attached.dataset_data_sources)}")
+                invalid = getattr(response, "invalid_dataset_sources", None)
+                if invalid:
+                    print(
+                        f"{self._warn(f'⚠ Warning: The following Kaggle datasets could not be resolved: '
+                        f"{', '.join(invalid)}")}",
+                        file=sys.stderr,
+                    )
 
             if wait is None:
                 print(f"   Model Output:  {model_output_url}")
@@ -7363,9 +7431,13 @@ class KaggleApi:
             print(f"Version:  {version}")
             print(f"Status:   {self._format_state(task_info.creation_state)}")
             print(f"Created:  {self._format_time(task_info.create_time)}")
+            print(f"Public:   {getattr(task_info, 'is_public', False)}")
             url = getattr(task_info, "url", None)
             if url:
                 print(f"Task URL: {self._full_task_url(url)}\n")
+            options = getattr(task_info, "options", None)
+            if options and options.dataset_data_sources:
+                print(f"Datasets: {', '.join(options.dataset_data_sources)}")
 
             runs = self._fetch_task_runs(kaggle, task, model)
 
@@ -7381,7 +7453,8 @@ class KaggleApi:
         if isinstance(model, str):
             return f" for model '{model}'"
         if model:
-            return f" for model(s) {', '.join(model)}"
+            joined = "', '".join(model)
+            return f" for model(s) '{joined}'"
         return ""
 
     def benchmarks_tasks_download_cli(self, task, model=None, output=None, include_source=False, force=False):
@@ -7398,6 +7471,7 @@ class KaggleApi:
                 model_hint = self._format_model_hint(model)
                 print(f"No runs found for task '{task}'{model_hint}.")
                 print(f"Use 'kaggle b t run {task}' to start one.")
+                print(f"\nDone: 0 downloaded.")
                 return
 
             downloadable = [r for r in runs if r.state in self._TERMINAL_RUN_STATES]
@@ -7405,6 +7479,7 @@ class KaggleApi:
                 pending = len(runs)
                 print(f"No downloadable runs yet — {pending} run(s) still in progress.")
                 print(f"Use 'kaggle b t status {task}' to check progress.")
+                print(f"\nDone: 0 downloaded.")
                 return
 
             target_dir = os.path.join(output, task)
@@ -7522,7 +7597,11 @@ class KaggleApi:
             if text and not text.endswith("\n"):
                 lines += 1
             return lines, text.endswith("\n")
-        print(log_entry, flush=flush)
+        if isinstance(log_entry, dict):
+            text = json.dumps(log_entry)
+        else:
+            text = str(log_entry)
+        print(text, flush=flush)
         return 1, True
 
     def benchmarks_tasks_log_cli(self, task, model=None):
@@ -7547,9 +7626,17 @@ class KaggleApi:
                 request = ApiGetBenchmarkTaskRunLogsRequest()
                 request.run_id = run.id
 
-                response = self.with_retry(kaggle.benchmarks.benchmark_tasks_api_client.get_benchmark_task_run_logs)(
-                    request
-                )
+                # QUEUED runs have no logs yet — the server may return 404.
+                # Catch per-run so one missing log doesn't abort the whole command.
+                try:
+                    response = self.with_retry(
+                        kaggle.benchmarks.benchmark_tasks_api_client.get_benchmark_task_run_logs
+                    )(request)
+                except HTTPError as e:
+                    status = getattr(e.response, "status_code", None)
+                    print(f"  (No logs available — server returned {status})")
+                    print(f"═══ (0 lines) ═══")
+                    continue
 
                 line_count = 0
                 content_type = response.headers.get("Content-Type", "")
@@ -7618,6 +7705,41 @@ class KaggleApi:
     def benchmarks_tasks_delete_cli(self, task, no_confirm=False):
         # TODO: Normalize task name via slugify(task) when server supports delete.
         print("Delete is not supported by the server yet.")
+
+    def benchmarks_tasks_publish_cli(self, task, publish_backing_notebook=False):
+        """Publish a benchmark task, making it public."""
+        task = slugify(task)
+
+        with self.build_kaggle_client() as kaggle:
+            # Verify the task exists first
+            task_info = self._get_benchmark_task(task, kaggle)
+
+            # Check if already public
+            if getattr(task_info, "is_public", False):
+                print(f"Task '{task}' is already public.")
+                if publish_backing_notebook and not getattr(task_info, "is_backing_notebook_published", False):
+                    print("Publishing the backing notebook...")
+                elif publish_backing_notebook:
+                    print("Backing notebook is already published.")
+                    return
+                else:
+                    return
+
+            request = ApiPublishBenchmarkTaskRequest()
+            request.slug = self._make_task_slug(task)
+            request.publish_backing_notebook = publish_backing_notebook
+
+            response = self.with_retry(kaggle.benchmarks.benchmark_tasks_api_client.publish_benchmark_task)(request)
+
+            url = self._full_task_url(response.url)
+            print(f"Task '{task}' published successfully.")
+            print(f"{self._bold(f'Task URL: {url}')}")
+
+            if publish_backing_notebook:
+                if getattr(response, "is_backing_notebook_published", False):
+                    print("Backing notebook also published.")
+                else:
+                    print("Note: No backing notebook is associated with this task.")
 
 
 class TqdmBufferedReader(io.BufferedReader):

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -1466,6 +1466,14 @@ def parse_benchmark_tasks(subparsers) -> None:
         action="store_true",
         help=Help.param_benchmarks_verbose,
     )
+    parser_push_optional.add_argument(
+        "-d",
+        "--kaggle-dataset",
+        dest="kaggle_datasets",
+        nargs="+",
+        required=False,
+        help=Help.param_benchmarks_kaggle_dataset,
+    )
     parser_push._action_groups.append(parser_push_optional)
     parser_push.set_defaults(func=api.benchmarks_tasks_push_cli)
 
@@ -1608,6 +1616,24 @@ def parse_benchmark_tasks(subparsers) -> None:
     )
     parser_delete._action_groups.append(parser_delete_optional)
     parser_delete.set_defaults(func=api.benchmarks_tasks_delete_cli)
+
+    # publish
+    parser_publish = subparsers_tasks.add_parser(
+        "publish",
+        formatter_class=argparse.RawTextHelpFormatter,
+        help=Help.command_benchmarks_tasks_publish,
+    )
+    parser_publish_optional = parser_publish._action_groups.pop()
+    parser_publish_optional.add_argument("task", help=Help.param_benchmarks_task)
+    parser_publish_optional.add_argument(
+        "--publish-backing-notebook",
+        dest="publish_backing_notebook",
+        action="store_true",
+        required=False,
+        help=Help.param_benchmarks_publish_backing_notebook,
+    )
+    parser_publish._action_groups.append(parser_publish_optional)
+    parser_publish.set_defaults(func=api.benchmarks_tasks_publish_cli)
 
 
 def parse_config(subparsers) -> None:
@@ -1844,7 +1870,18 @@ class Help(object):
     model_instance_versions_choices = ["init", "create", "download", "delete", "files", "list"]
     files_choices = ["upload"]
     benchmarks_choices = ["tasks", "t", "auth", "init", "topics"]
-    benchmarks_tasks_choices = ["push", "run", "list", "status", "download", "log", "logs", "models", "delete"]
+    benchmarks_tasks_choices = [
+        "push",
+        "run",
+        "list",
+        "status",
+        "download",
+        "log",
+        "logs",
+        "models",
+        "delete",
+        "publish",
+    ]
     forums_choices = ["list", "topics"]
     forums_topics_choices = ["list", "show"]
     entity_topics_choices = ["list", "show"]
@@ -1977,6 +2014,7 @@ class Help(object):
     command_benchmarks_tasks_log = "Get execution logs for a benchmark task run"
     command_benchmarks_tasks_models = "List available benchmark models"
     command_benchmarks_tasks_delete = "Remove a task"
+    command_benchmarks_tasks_publish = "Publish a task (make it public)"
 
     # Config commands
     command_config_path = "Set folder where competition or dataset files will be " "downloaded"
@@ -2218,6 +2256,12 @@ class Help(object):
     param_benchmarks_list_all = "Print every task at once and skip the interactive pager"
     param_benchmarks_force = "Force re-download of already completed runs, overwriting local files."
     param_benchmarks_include_source = "Also download the kernel session's source notebooks."
+    param_benchmarks_kaggle_dataset = (
+        "Kaggle dataset(s) to attach (format: owner/dataset-slug). "
+        "The latest published version is used. "
+        "Omitting this on a re-push detaches previously-attached datasets."
+    )
+    param_benchmarks_publish_backing_notebook = "Also publish the backing notebook in the same request."
 
     # Files params
     param_files_upload_inbox_path = "Virtual path on the server where the uploaded files will be stored"

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -1626,11 +1626,11 @@ def parse_benchmark_tasks(subparsers) -> None:
     parser_publish_optional = parser_publish._action_groups.pop()
     parser_publish_optional.add_argument("task", help=Help.param_benchmarks_task)
     parser_publish_optional.add_argument(
-        "--publish-backing-notebook",
+        "--no-publish-backing-notebook",
         dest="publish_backing_notebook",
-        action="store_true",
+        action="store_false",
         required=False,
-        help=Help.param_benchmarks_publish_backing_notebook,
+        help=Help.param_benchmarks_no_publish_backing_notebook,
     )
     parser_publish._action_groups.append(parser_publish_optional)
     parser_publish.set_defaults(func=api.benchmarks_tasks_publish_cli)
@@ -2254,14 +2254,14 @@ class Help(object):
     param_benchmarks_status = "Filter tasks by creation status. " "Valid values: queued, running, completed, errored"
     param_benchmarks_list_page_size = "Tasks per page in the interactive pager (default: 20)"
     param_benchmarks_list_all = "Print every task at once and skip the interactive pager"
-    param_benchmarks_force = "Force re-download of already completed runs, overwriting local files."
+    param_benchmarks_force = "Force re-download, replacing existing output directories."
     param_benchmarks_include_source = "Also download the kernel session's source notebooks."
     param_benchmarks_kaggle_dataset = (
         "Kaggle dataset(s) to attach (format: owner/dataset-slug). "
         "The latest published version is used. "
         "Omitting this on a re-push detaches previously-attached datasets."
     )
-    param_benchmarks_publish_backing_notebook = "Also publish the backing notebook in the same request."
+    param_benchmarks_no_publish_backing_notebook = "Do not publish the backing notebook (it is published by default)."
 
     # Files params
     param_files_upload_inbox_path = "Virtual path on the server where the uploaded files will be stored"

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -1558,7 +1558,15 @@ def parse_benchmark_tasks(subparsers) -> None:
         dest="include_source",
         action="store_true",
         required=False,
-        help="Also download the kernel session's source notebooks.",
+        help=Help.param_benchmarks_include_source,
+    )
+    parser_download_optional.add_argument(
+        "-f",
+        "--force",
+        dest="force",
+        action="store_true",
+        required=False,
+        help=Help.param_benchmarks_force,
     )
     parser_download._action_groups.append(parser_download_optional)
     parser_download.set_defaults(func=api.benchmarks_tasks_download_cli)
@@ -1573,7 +1581,11 @@ def parse_benchmark_tasks(subparsers) -> None:
     parser_log_optional = parser_log._action_groups.pop()
     parser_log_optional.add_argument("task", help=Help.param_benchmarks_task)
     parser_log_optional.add_argument(
-        "-m", "--model", dest="model", nargs="+", required=False,
+        "-m",
+        "--model",
+        dest="model",
+        nargs="+",
+        required=False,
         help=Help.param_benchmarks_model,
     )
     parser_log._action_groups.append(parser_log_optional)
@@ -2204,6 +2216,8 @@ class Help(object):
     param_benchmarks_status = "Filter tasks by creation status. " "Valid values: queued, running, completed, errored"
     param_benchmarks_list_page_size = "Tasks per page in the interactive pager (default: 20)"
     param_benchmarks_list_all = "Print every task at once and skip the interactive pager"
+    param_benchmarks_force = "Force re-download of already completed runs, overwriting local files."
+    param_benchmarks_include_source = "Also download the kernel session's source notebooks."
 
     # Files params
     param_files_upload_inbox_path = "Virtual path on the server where the uploaded files will be stored"

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -1552,8 +1552,32 @@ def parse_benchmark_tasks(subparsers) -> None:
     parser_download_optional.add_argument(
         "-o", "--output", dest="output", required=False, help=Help.param_benchmarks_output
     )
+    parser_download_optional.add_argument(
+        "-s",
+        "--include-source",
+        dest="include_source",
+        action="store_true",
+        required=False,
+        help="Also download the kernel session's source notebooks.",
+    )
     parser_download._action_groups.append(parser_download_optional)
     parser_download.set_defaults(func=api.benchmarks_tasks_download_cli)
+
+    # log / logs
+    parser_log = subparsers_tasks.add_parser(
+        "log",
+        formatter_class=argparse.RawTextHelpFormatter,
+        help=Help.command_benchmarks_tasks_log,
+        aliases=["logs"],
+    )
+    parser_log_optional = parser_log._action_groups.pop()
+    parser_log_optional.add_argument("task", help=Help.param_benchmarks_task)
+    parser_log_optional.add_argument(
+        "-m", "--model", dest="model", nargs="+", required=False,
+        help=Help.param_benchmarks_model,
+    )
+    parser_log._action_groups.append(parser_log_optional)
+    parser_log.set_defaults(func=api.benchmarks_tasks_log_cli)
 
     # models
     parser_models = subparsers_tasks.add_parser(
@@ -1808,7 +1832,7 @@ class Help(object):
     model_instance_versions_choices = ["init", "create", "download", "delete", "files", "list"]
     files_choices = ["upload"]
     benchmarks_choices = ["tasks", "t", "auth", "init", "topics"]
-    benchmarks_tasks_choices = ["push", "run", "list", "status", "download", "models", "delete"]
+    benchmarks_tasks_choices = ["push", "run", "list", "status", "download", "log", "logs", "models", "delete"]
     forums_choices = ["list", "topics"]
     forums_topics_choices = ["list", "show"]
     entity_topics_choices = ["list", "show"]
@@ -1938,6 +1962,7 @@ class Help(object):
     command_benchmarks_tasks_status = "Show task details and per-model run status"
 
     command_benchmarks_tasks_download = "Download output files for completed runs"
+    command_benchmarks_tasks_log = "Get execution logs for a benchmark task run"
     command_benchmarks_tasks_models = "List available benchmark models"
     command_benchmarks_tasks_delete = "Remove a task"
 

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -5,7 +5,8 @@ Organized by command (matching the spec):
   TestRun       – ``kaggle benchmarks tasks run <task> [-m ...] [--wait]``
   TestList      – ``kaggle benchmarks tasks list [--name-regex] [--status]``
   TestStatus    – ``kaggle benchmarks tasks status <task> [-m ...]``
-  TestDownload  – ``kaggle benchmarks tasks download <task> [-m ...] [-o ...]``
+  TestDownload  – ``kaggle benchmarks tasks download <task> [-m ...] [-o ...] [-s]``
+  TestLog       – ``kaggle benchmarks tasks log <task> [-m ...]``
   TestDelete    – ``kaggle benchmarks tasks delete <task> [-y]``
   TestCliArgParsing – argparse wiring for all subcommands
 """
@@ -1196,6 +1197,126 @@ class TestDownload:
         expected = os.path.join(".", "my-task", "unset", "gemini-pro", "1.zip")
         assert zippath == expected
 
+    def test_download_include_source_flag(self, api, capsys):
+        """--include-source passes include_source=True to the SDK request."""
+        _setup_runs_response(api, [_make_run()])
+        self._mock_download(api)
+        with patch("zipfile.ZipFile"), patch("os.remove"):
+            api.benchmarks_tasks_download_cli("my-task", include_source=True)
+        request = api._mock_benchmarks.download_benchmark_task_run_output.call_args[0][0]
+        assert request.include_source is True
+
+    def test_download_include_source_default_false(self, api, capsys):
+        """Without --include-source, include_source defaults to False."""
+        _setup_runs_response(api, [_make_run()])
+        self._mock_download(api)
+        with patch("zipfile.ZipFile"), patch("os.remove"):
+            api.benchmarks_tasks_download_cli("my-task")
+        request = api._mock_benchmarks.download_benchmark_task_run_output.call_args[0][0]
+        assert request.include_source is False
+
+
+# ============================================================
+# Log
+# ============================================================
+
+
+class TestLog:
+    """``kaggle benchmarks tasks log <task> [-m <model> ...]``"""
+
+    def _mock_log_response(self, api, content="log output", content_type="application/json"):
+        """Set up a mock log response."""
+        _setup_completed_task(api)
+        response = MagicMock()
+        response.headers = {"Content-Type": content_type}
+        response.text = content
+        response.iter_lines.return_value = []
+        api._mock_benchmarks.get_benchmark_task_run_logs.return_value = response
+        return response
+
+    @pytest.mark.parametrize("status_code", [403, 404], ids=["forbidden", "not_found"])
+    def test_log_task_not_found(self, api, status_code):
+        """Log gives friendly error when task doesn't exist (403/404)."""
+        api._mock_benchmarks.list_benchmark_task_runs.side_effect = HTTPError(
+            response=MagicMock(status_code=status_code)
+        )
+        with pytest.raises(HTTPError):
+            api.benchmarks_tasks_log_cli("no-such-task")
+
+    def test_log_no_runs(self, api):
+        """No runs raises ValueError with helpful message."""
+        _setup_completed_task(api)
+        _setup_runs_response(api, [])
+        with pytest.raises(ValueError, match="No runs found"):
+            api.benchmarks_tasks_log_cli("my-task")
+
+    def test_log_no_runs_with_model_filter(self, api):
+        """No runs for a specific model gives descriptive error."""
+        _setup_completed_task(api)
+        _setup_runs_response(api, [])
+        with pytest.raises(ValueError, match="No runs found.*model"):
+            api.benchmarks_tasks_log_cli("my-task", model=["nonexistent-model"])
+
+    def test_log_single_run_no_header(self, api, capsys):
+        """Single run prints logs without header."""
+        _setup_runs_response(api, [_make_run()])
+        self._mock_log_response(api, content="hello world")
+        api.benchmarks_tasks_log_cli("my-task")
+        output = capsys.readouterr().out
+        assert "hello world" in output
+        assert "═══" not in output  # No header for single run
+
+    def test_log_multiple_runs_with_headers(self, api, capsys):
+        """Multiple runs print logs with model headers."""
+        _setup_runs_response(
+            api,
+            [
+                _make_run(model="gemini-pro", run_id=1),
+                _make_run(model="claude-4", run_id=2),
+            ],
+        )
+        self._mock_log_response(api, content="log output")
+        api.benchmarks_tasks_log_cli("my-task")
+        output = capsys.readouterr().out
+        assert "═══ Logs for gemini-pro (Run 1) ═══" in output
+        assert "═══ Logs for claude-4 (Run 2) ═══" in output
+
+    def test_log_with_model_filter(self, api, capsys):
+        """Model filter is passed to _fetch_task_runs."""
+        _setup_runs_response(api, [_make_run(model="gemini-pro")])
+        self._mock_log_response(api, content="filtered logs")
+        api.benchmarks_tasks_log_cli("my-task", model=["gemini-pro"])
+        request = api._mock_benchmarks.list_benchmark_task_runs.call_args[0][0]
+        assert request.model_version_slugs == ["gemini-pro"]
+        output = capsys.readouterr().out
+        assert "filtered logs" in output
+
+    def test_log_sse_stream(self, api, capsys):
+        """SSE responses are streamed line by line."""
+        _setup_runs_response(api, [_make_run()])
+        _setup_completed_task(api)
+        response = MagicMock()
+        response.headers = {"Content-Type": "text/event-stream"}
+        response.iter_lines.return_value = [
+            b"data: Starting benchmark...",
+            b"",
+            b"data: Running task function...",
+            b"event: done",
+        ]
+        api._mock_benchmarks.get_benchmark_task_run_logs.return_value = response
+        api.benchmarks_tasks_log_cli("my-task")
+        output = capsys.readouterr().out
+        assert "Starting benchmark..." in output
+        assert "Running task function..." in output
+
+    def test_log_json_response(self, api, capsys):
+        """JSON responses are printed as text."""
+        _setup_runs_response(api, [_make_run()])
+        self._mock_log_response(api, content='{"logs": "some data"}')
+        api.benchmarks_tasks_log_cli("my-task")
+        output = capsys.readouterr().out
+        assert '{"logs": "some data"}' in output
+
 
 # ============================================================
 # download_file (Content-Length handling)
@@ -1453,13 +1574,39 @@ class TestCliArgParsing:
             # download
             (
                 "benchmarks tasks download my-task",
-                {"task": "my-task", "model": None, "output": None},
+                {"task": "my-task", "model": None, "output": None, "include_source": False},
             ),
-            ("benchmarks tasks download my-task -o ./results", {"output": "./results"}),
+            ("benchmarks tasks download my-task -o ./results", {"output": "./results", "include_source": False}),
             (
                 "benchmarks tasks download my-task -m gemini-3 -o ./results",
-                {"model": ["gemini-3"], "output": "./results"},
+                {"model": ["gemini-3"], "output": "./results", "include_source": False},
             ),
+            (
+                "benchmarks tasks download my-task --include-source",
+                {"task": "my-task", "include_source": True},
+            ),
+            (
+                "benchmarks tasks download my-task -s -m gemini-3",
+                {"model": ["gemini-3"], "include_source": True},
+            ),
+            # log
+            (
+                "benchmarks tasks log my-task",
+                {"task": "my-task", "model": None},
+            ),
+            (
+                "benchmarks tasks log my-task -m gemini-3",
+                {"task": "my-task", "model": ["gemini-3"]},
+            ),
+            (
+                "benchmarks tasks log my-task -m gemini-3 claude-4",
+                {"model": ["gemini-3", "claude-4"]},
+            ),
+            (
+                "benchmarks tasks logs my-task",
+                {"task": "my-task", "model": None},
+            ),
+            ("b t log my-task", {"task": "my-task", "model": None}),
             # delete
             (
                 "benchmarks tasks delete my-task",
@@ -1493,6 +1640,7 @@ class TestCliArgParsing:
             "benchmarks tasks run my-task -m",  # -m requires at least one arg
             "benchmarks tasks status my-task -m",  # -m requires at least one arg
             "benchmarks tasks download my-task -m",  # -m requires at least one arg
+            "benchmarks tasks log my-task -m",  # -m requires at least one arg
         ],
     )
     def test_parse_error(self, cmd):

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -448,6 +448,95 @@ class TestPush:
         with pytest.raises(ValueError, match="--poll-interval must be a positive integer"):
             api.benchmarks_tasks_push_cli("my-task", filepath, wait=0, poll_interval=interval)
 
+    # -- Kaggle dataset attachment --
+
+    def test_push_with_kaggle_datasets(self, api, tmp_path, capsys):
+        """Push attaches Kaggle datasets via BenchmarkTaskOptions."""
+        filepath = _write_task_file(tmp_path)
+        _setup_create_response(api, "my-task")
+        resp = api._mock_benchmarks.create_benchmark_task.return_value
+        resp.options = MagicMock()
+        resp.options.dataset_data_sources = ["user/dataset-one", "user/dataset-two"]
+        resp.invalid_dataset_sources = []
+
+        jt, ctx = _mock_jupytext()
+        with ctx:
+            api.benchmarks_tasks_push_cli("my-task", filepath, kaggle_datasets=["user/dataset-one", "user/dataset-two"])
+
+        request = api._mock_benchmarks.create_benchmark_task.call_args[0][0]
+        assert request.options is not None
+        assert request.options.dataset_data_sources == ["user/dataset-one", "user/dataset-two"]
+        output = capsys.readouterr().out
+        assert "Attached Kaggle dataset(s)" in output
+
+    def test_push_with_invalid_kaggle_dataset_warns(self, api, tmp_path, capsys):
+        """Push warns about invalid/unresolvable Kaggle datasets."""
+        filepath = _write_task_file(tmp_path)
+        _setup_create_response(api, "my-task")
+        resp = api._mock_benchmarks.create_benchmark_task.return_value
+        resp.options = MagicMock()
+        resp.options.dataset_data_sources = ["user/valid"]
+        resp.invalid_dataset_sources = ["user/nonexistent"]
+
+        jt, ctx = _mock_jupytext()
+        with ctx:
+            api.benchmarks_tasks_push_cli("my-task", filepath, kaggle_datasets=["user/valid", "user/nonexistent"])
+
+        captured = capsys.readouterr()
+        assert "could not be resolved" in captured.err
+        assert "user/nonexistent" in captured.err
+
+    def test_push_without_kaggle_datasets_sends_no_options(self, api, tmp_path, capsys):
+        """Push without --kaggle-dataset does not set options on the request."""
+        filepath = _write_task_file(tmp_path)
+        _setup_create_response(api, "my-task")
+        _push(api, "my-task", filepath)
+        request = api._mock_benchmarks.create_benchmark_task.call_args[0][0]
+        # When no datasets are specified, options should not be set
+        assert not hasattr(request, "options") or request.options is None
+
+    def test_push_warns_when_removing_previously_attached_datasets(self, api, tmp_path, capsys):
+        """Re-pushing without --kaggle-dataset warns when previous version had datasets."""
+        filepath = _write_task_file(tmp_path)
+        _setup_create_response(api, "my-task")
+
+        # Previous version had datasets attached
+        prev_task = _make_task(slug="my-task", state=COMPLETED)
+        prev_task.options = MagicMock()
+        prev_task.options.dataset_data_sources = ["user/important-data"]
+        api._mock_benchmarks.get_benchmark_task.return_value = prev_task
+
+        jt, ctx = _mock_jupytext()
+        with ctx:
+            api.benchmarks_tasks_push_cli("my-task", filepath)  # no kaggle_datasets
+
+        captured = capsys.readouterr()
+        assert "previous version" in captured.err
+        assert "user/important-data" in captured.err
+        assert "will detach" in captured.err
+
+    def test_push_no_warning_when_re_push_keeps_datasets(self, api, tmp_path, capsys):
+        """Re-pushing WITH --kaggle-dataset does NOT warn about detaching."""
+        filepath = _write_task_file(tmp_path)
+        _setup_create_response(api, "my-task")
+
+        prev_task = _make_task(slug="my-task", state=COMPLETED)
+        prev_task.options = MagicMock()
+        prev_task.options.dataset_data_sources = ["user/important-data"]
+        api._mock_benchmarks.get_benchmark_task.return_value = prev_task
+
+        resp = api._mock_benchmarks.create_benchmark_task.return_value
+        resp.options = MagicMock()
+        resp.options.dataset_data_sources = ["user/important-data"]
+        resp.invalid_dataset_sources = []
+
+        jt, ctx = _mock_jupytext()
+        with ctx:
+            api.benchmarks_tasks_push_cli("my-task", filepath, kaggle_datasets=["user/important-data"])
+
+        captured = capsys.readouterr()
+        assert "will detach" not in captured.err
+
 
 # ============================================================
 # Run
@@ -844,8 +933,10 @@ class TestStatus:
     """``kaggle benchmarks tasks status <task> [-m <model> ...]``"""
 
     def test_status_header(self, api, capsys):
-        """Status prints Task/Status/Created header."""
-        api._mock_benchmarks.get_benchmark_task.return_value = _make_task()
+        """Status prints Task/Status/Created/Public header."""
+        task = _make_task()
+        task.is_public = True
+        api._mock_benchmarks.get_benchmark_task.return_value = task
         _setup_runs_response(api, [])
         api.benchmarks_tasks_status_cli("my-task")
         output = capsys.readouterr().out
@@ -853,6 +944,7 @@ class TestStatus:
         assert "Version:" in output
         assert "Status:   Completed" in output
         assert "Created:" in output
+        assert "Public:   True" in output
         assert "Task URL:" in output
 
     @pytest.mark.parametrize("status_code", [403, 404], ids=["forbidden", "not_found"])
@@ -1253,6 +1345,37 @@ class TestDownload:
         request = api._mock_benchmarks.download_benchmark_task_run_output.call_args[0][0]
         assert request.include_source is False
 
+    def test_download_bad_zip_with_force_replaces_output(self, api, capsys, tmp_path):
+        """BadZipFile with --force keeps raw zip; existing output is NOT deleted."""
+        _setup_completed_task(api)
+        _setup_runs_response(api, [_make_run(model="bad-model", run_id=10)])
+        api._mock_benchmarks.download_benchmark_task_run_output.return_value = MagicMock()
+
+        outdir = str(tmp_path / "out")
+        existing_dir = os.path.join(outdir, "my-task", "1", "bad-model", "10")
+        os.makedirs(existing_dir)
+        # Write a sentinel file in existing output
+        sentinel = os.path.join(existing_dir, "old_result.txt")
+        with open(sentinel, "w") as f:
+            f.write("previous run")
+
+        def fake_download(response, outfile, http_client, quiet=False):
+            os.makedirs(os.path.dirname(outfile), exist_ok=True)
+            with open(outfile, "wb") as f:
+                f.write(b"this is not a zip")
+
+        api.download_file = MagicMock(side_effect=fake_download)
+
+        api.benchmarks_tasks_download_cli("my-task", output=outdir, force=True)
+
+        output = capsys.readouterr().out
+        assert "not a valid zip archive" in output
+        # Raw zip file is kept
+        zip_path = os.path.join(outdir, "my-task", "1", "bad-model", "10.zip")
+        assert os.path.isfile(zip_path)
+        # Existing output directory is preserved (not deleted by --force)
+        assert os.path.isfile(sentinel)
+
 
 # ============================================================
 # Log
@@ -1358,6 +1481,34 @@ class TestLog:
         api.benchmarks_tasks_log_cli("my-task")
         output = capsys.readouterr().out
         assert '{"logs": "some data"}' in output
+
+    def test_log_queued_run_server_error(self, api, capsys):
+        """A QUEUED run whose log endpoint returns 404 prints a friendly message."""
+        _setup_completed_task(api)
+        _setup_runs_response(api, [_make_run(model="gemini-pro", state=RUN_QUEUED, run_id=1)])
+        api._mock_benchmarks.get_benchmark_task_run_logs.side_effect = HTTPError(response=MagicMock(status_code=404))
+        api.benchmarks_tasks_log_cli("my-task")
+        output = capsys.readouterr().out
+        assert "No logs available" in output
+        assert "404" in output
+        assert "0 lines" in output
+
+    def test_log_json_list_with_data_key(self, api, capsys):
+        """JSON response containing list of {"data": ...} entries prints each entry."""
+        import json
+
+        _setup_runs_response(api, [_make_run()])
+        log_entries = [
+            {"data": "line one\n"},
+            {"data": "line two\n"},
+        ]
+        content = json.dumps(log_entries)
+        self._mock_log_response(api, content=content)
+        api.benchmarks_tasks_log_cli("my-task")
+        output = capsys.readouterr().out
+        # JSON log content is printed as raw text from response.text
+        assert "line one" in output
+        assert "line two" in output
 
 
 # ============================================================
@@ -1668,6 +1819,29 @@ class TestCliArgParsing:
             ("benchmarks init -y", {"no_confirm": True}),
             ("benchmarks init --env-file custom.env", {"env_file": "custom.env"}),
             ("benchmarks init --example-file my_task.py", {"example_file": "my_task.py"}),
+            # publish
+            (
+                "benchmarks tasks publish my-task",
+                {"task": "my-task", "publish_backing_notebook": False},
+            ),
+            (
+                "benchmarks tasks publish my-task --publish-backing-notebook",
+                {"task": "my-task", "publish_backing_notebook": True},
+            ),
+            ("b t publish my-task", {"task": "my-task", "publish_backing_notebook": False}),
+            # push with --kaggle-dataset
+            (
+                "benchmarks tasks push my-task -f ./task.py -d user/dataset1 user/dataset2",
+                {"task": "my-task", "file": "./task.py", "kaggle_datasets": ["user/dataset1", "user/dataset2"]},
+            ),
+            (
+                "benchmarks tasks push my-task -f ./task.py --kaggle-dataset user/ds",
+                {"kaggle_datasets": ["user/ds"]},
+            ),
+            (
+                "benchmarks tasks push my-task -f ./task.py",
+                {"kaggle_datasets": None},
+            ),
         ],
     )
     def test_parse_success(self, cmd, expected):
@@ -1688,6 +1862,29 @@ class TestCliArgParsing:
     def test_parse_error(self, cmd):
         with pytest.raises(SystemExit):
             self._parse(cmd)
+
+    @pytest.mark.parametrize(
+        "cmd, expected",
+        [
+            (
+                "benchmarks tasks download my-task --force",
+                {"task": "my-task", "force": True},
+            ),
+            (
+                "benchmarks tasks download my-task -f",
+                {"force": True},
+            ),
+            (
+                "benchmarks tasks download my-task",
+                {"force": False},
+            ),
+        ],
+        ids=["force_long", "force_short", "force_default"],
+    )
+    def test_parse_download_force(self, cmd, expected):
+        args = self._parse(cmd)
+        for key, val in expected.items():
+            assert getattr(args, key) == val
 
 
 # ============================================================
@@ -2119,3 +2316,99 @@ class TestFormatModalities:
         v.output_modalities = MagicMock()
         v.output_modalities.__iter__ = MagicMock(side_effect=TypeError)
         assert KaggleApi._format_modalities(v) == ""
+
+
+# Publish
+# ============================================================
+
+
+class TestPublish:
+    """``kaggle benchmarks tasks publish <task> [--publish-backing-notebook]``"""
+
+    def _setup_publish(self, api, slug="my-task", is_public=False, is_notebook_published=False):
+        """Wire up get + publish mocks."""
+        task = _make_task(slug=slug)
+        task.is_public = is_public
+        task.is_backing_notebook_published = is_notebook_published
+        api._mock_benchmarks.get_benchmark_task.return_value = task
+
+        resp = _make_task(slug=slug)
+        resp.is_public = True
+        resp.is_backing_notebook_published = is_notebook_published
+        api._mock_benchmarks.publish_benchmark_task.return_value = resp
+        return task, resp
+
+    def test_publish_success(self, api, capsys):
+        """Publish a task successfully."""
+        self._setup_publish(api)
+        api.benchmarks_tasks_publish_cli("my-task")
+        output = capsys.readouterr().out
+        assert "published successfully" in output
+        assert "Task URL:" in output
+
+    def test_publish_already_public(self, api, capsys):
+        """Publishing an already-public task prints info and returns."""
+        self._setup_publish(api, is_public=True)
+        api.benchmarks_tasks_publish_cli("my-task")
+        output = capsys.readouterr().out
+        assert "already public" in output
+        api._mock_benchmarks.publish_benchmark_task.assert_not_called()
+
+    def test_publish_already_public_notebook_not_published(self, api, capsys):
+        """Already-public task with unpublished notebook proceeds to publish notebook."""
+        self._setup_publish(api, is_public=True, is_notebook_published=False)
+        api.benchmarks_tasks_publish_cli("my-task", publish_backing_notebook=True)
+        output = capsys.readouterr().out
+        assert "already public" in output
+        assert "Publishing the backing notebook" in output
+        api._mock_benchmarks.publish_benchmark_task.assert_called_once()
+
+    def test_publish_already_public_notebook_already_published(self, api, capsys):
+        """Already-public task with already-published notebook returns early."""
+        self._setup_publish(api, is_public=True, is_notebook_published=True)
+        api.benchmarks_tasks_publish_cli("my-task", publish_backing_notebook=True)
+        output = capsys.readouterr().out
+        assert "already public" in output
+        assert "already published" in output
+        api._mock_benchmarks.publish_benchmark_task.assert_not_called()
+
+    def test_publish_with_backing_notebook(self, api, capsys):
+        """Publish task and its backing notebook."""
+        task, resp = self._setup_publish(api)
+        resp.is_backing_notebook_published = True
+        api.benchmarks_tasks_publish_cli("my-task", publish_backing_notebook=True)
+        request = api._mock_benchmarks.publish_benchmark_task.call_args[0][0]
+        assert request.publish_backing_notebook is True
+        output = capsys.readouterr().out
+        assert "Backing notebook also published" in output
+
+    def test_publish_with_backing_notebook_no_notebook(self, api, capsys):
+        """Publish with --publish-backing-notebook when no notebook exists."""
+        task, resp = self._setup_publish(api)
+        resp.is_backing_notebook_published = False
+        api.benchmarks_tasks_publish_cli("my-task", publish_backing_notebook=True)
+        output = capsys.readouterr().out
+        assert "No backing notebook is associated" in output
+
+    @pytest.mark.parametrize("status_code", [403, 404], ids=["forbidden", "not_found"])
+    def test_publish_task_not_found(self, api, status_code):
+        """Publish gives friendly error when task doesn't exist."""
+        api._mock_benchmarks.get_benchmark_task.side_effect = HTTPError(response=MagicMock(status_code=status_code))
+        with pytest.raises(ValueError, match="not found"):
+            api.benchmarks_tasks_publish_cli("no-such-task")
+
+    def test_publish_normalizes_task_name(self, api, capsys):
+        """Publish slugifies the task name."""
+        self._setup_publish(api)
+        api.benchmarks_tasks_publish_cli("My Task")
+        request = api._mock_benchmarks.publish_benchmark_task.call_args[0][0]
+        assert request.slug.task_slug == "my-task"
+
+    def test_publish_server_error_propagates(self, api):
+        """Non-403/404 server errors (e.g. 500) from publish propagate as HTTPError."""
+        task = _make_task()
+        task.is_public = False
+        api._mock_benchmarks.get_benchmark_task.return_value = task
+        api._mock_benchmarks.publish_benchmark_task.side_effect = HTTPError(response=MagicMock(status_code=500))
+        with pytest.raises(HTTPError):
+            api.benchmarks_tasks_publish_cli("my-task")

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -1170,7 +1170,7 @@ class TestDownload:
         output = capsys.readouterr().out
         assert "gemini-pro" in output
         assert "Skipped" in output
-        assert "1 skipped" in output
+        assert "1 run(s) skipped" in output
         # No download API call should have been made
         api._mock_benchmarks.download_benchmark_task_run_output.assert_not_called()
 
@@ -1190,8 +1190,8 @@ class TestDownload:
             api.benchmarks_tasks_download_cli("my-task", output=outdir)
 
         output = capsys.readouterr().out
-        assert "1 downloaded" in output
-        assert "1 skipped" in output
+        assert "1 run(s) downloaded" in output
+        assert "1 run(s) skipped" in output
 
     def test_download_force_overwrites_existing_output(self, api, capsys, tmp_path):
         """Using force=True re-downloads and overwrites existing output."""
@@ -1206,8 +1206,9 @@ class TestDownload:
             api.benchmarks_tasks_download_cli("my-task", output=outdir, force=True)
 
         output = capsys.readouterr().out
-        assert "Downloading output for run 42 (gemini-pro)..." in output
-        assert "Downloaded output for gemini-pro" in output
+        assert "gemini-pro" in output
+        assert "Done" in output
+        assert "1 run(s) downloaded" in output
         # The download API call must have been made!
         api._mock_benchmarks.download_benchmark_task_run_output.assert_called_once()
 
@@ -1385,12 +1386,36 @@ class TestDownload:
         api.benchmarks_tasks_download_cli("my-task", output=outdir, force=True)
 
         output = capsys.readouterr().out
-        assert "not a valid zip archive" in output
+        assert "bad-model" in output
+        assert "Bad zip" in output
+        assert "Done: 0 runs downloaded." in output
         # Raw zip file is kept
         zip_path = os.path.join(outdir, "my-task", "1", "bad-model", "10.zip")
         assert os.path.isfile(zip_path)
         # Existing output directory is preserved (not deleted by --force)
         assert os.path.isfile(sentinel)
+
+    def test_download_all_bad_zips_shows_zero_downloaded(self, api, capsys, tmp_path):
+        """When every download is a BadZipFile, summary says '0 downloaded'."""
+        _setup_completed_task(api)
+        _setup_runs_response(api, [_make_run(model="bad-model", run_id=10)])
+        api._mock_benchmarks.download_benchmark_task_run_output.return_value = MagicMock()
+
+        outdir = str(tmp_path / "out")
+
+        def fake_download(response, outfile, http_client, quiet=False):
+            os.makedirs(os.path.dirname(outfile), exist_ok=True)
+            with open(outfile, "wb") as f:
+                f.write(b"this is not a zip")
+
+        api.download_file = MagicMock(side_effect=fake_download)
+
+        api.benchmarks_tasks_download_cli("my-task", output=outdir)
+
+        output = capsys.readouterr().out
+        assert "bad-model" in output
+        assert "Bad zip" in output
+        assert "Done: 0 runs downloaded." in output
 
 
 # ============================================================
@@ -1838,13 +1863,13 @@ class TestCliArgParsing:
             # publish
             (
                 "benchmarks tasks publish my-task",
-                {"task": "my-task", "publish_backing_notebook": False},
-            ),
-            (
-                "benchmarks tasks publish my-task --publish-backing-notebook",
                 {"task": "my-task", "publish_backing_notebook": True},
             ),
-            ("b t publish my-task", {"task": "my-task", "publish_backing_notebook": False}),
+            (
+                "benchmarks tasks publish my-task --no-publish-backing-notebook",
+                {"task": "my-task", "publish_backing_notebook": False},
+            ),
+            ("b t publish my-task", {"task": "my-task", "publish_backing_notebook": True}),
             # push with --kaggle-dataset
             (
                 "benchmarks tasks push my-task -f ./task.py -d user/dataset1 user/dataset2",
@@ -2339,7 +2364,7 @@ class TestFormatModalities:
 
 
 class TestPublish:
-    """``kaggle benchmarks tasks publish <task> [--publish-backing-notebook]``"""
+    """``kaggle benchmarks tasks publish <task> [--no-publish-backing-notebook]``"""
 
     def _setup_publish(self, api, slug="my-task", is_public=False, is_notebook_published=False):
         """Wire up get + publish mocks."""
@@ -2363,9 +2388,9 @@ class TestPublish:
         assert "Task URL:" in output
 
     def test_publish_already_public(self, api, capsys):
-        """Publishing an already-public task prints info and returns."""
+        """Publishing an already-public task (without notebook) prints info and returns."""
         self._setup_publish(api, is_public=True)
-        api.benchmarks_tasks_publish_cli("my-task")
+        api.benchmarks_tasks_publish_cli("my-task", publish_backing_notebook=False)
         output = capsys.readouterr().out
         assert "already public" in output
         api._mock_benchmarks.publish_benchmark_task.assert_not_called()
@@ -2389,17 +2414,24 @@ class TestPublish:
         api._mock_benchmarks.publish_benchmark_task.assert_not_called()
 
     def test_publish_with_backing_notebook(self, api, capsys):
-        """Publish task and its backing notebook."""
+        """Publish task and its backing notebook (default behavior)."""
         task, resp = self._setup_publish(api)
         resp.is_backing_notebook_published = True
-        api.benchmarks_tasks_publish_cli("my-task", publish_backing_notebook=True)
+        api.benchmarks_tasks_publish_cli("my-task")
         request = api._mock_benchmarks.publish_benchmark_task.call_args[0][0]
         assert request.publish_backing_notebook is True
         output = capsys.readouterr().out
         assert "Backing notebook also published" in output
 
+    def test_publish_without_backing_notebook(self, api, capsys):
+        """Publish with --no-publish-backing-notebook skips notebook."""
+        self._setup_publish(api)
+        api.benchmarks_tasks_publish_cli("my-task", publish_backing_notebook=False)
+        request = api._mock_benchmarks.publish_benchmark_task.call_args[0][0]
+        assert request.publish_backing_notebook is False
+
     def test_publish_with_backing_notebook_no_notebook(self, api, capsys):
-        """Publish with --publish-backing-notebook when no notebook exists."""
+        """Publish when no backing notebook exists."""
         task, resp = self._setup_publish(api)
         resp.is_backing_notebook_published = False
         api.benchmarks_tasks_publish_cli("my-task", publish_backing_notebook=True)

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -975,7 +975,7 @@ class TestDownload:
     def test_download_to_specific_output(self, api, capsys):
         _setup_runs_response(api, [_make_run()])
         self._mock_download(api)
-        with patch("zipfile.ZipFile"), patch("os.remove"):
+        with patch("zipfile.ZipFile"), patch("os.remove"), patch("os.rename"):
             api.benchmarks_tasks_download_cli("my-task", output="my_output_dir")
         output = capsys.readouterr().out
         assert "Downloading output runs for my-task" in output
@@ -987,7 +987,7 @@ class TestDownload:
         """Default output is ./{task}/{model}/{run_id}.zip."""
         _setup_runs_response(api, [_make_run(run_id=1)])
         self._mock_download(api)
-        with patch("zipfile.ZipFile"), patch("os.remove"):
+        with patch("zipfile.ZipFile"), patch("os.remove"), patch("os.rename"):
             api.benchmarks_tasks_download_cli("my-task")
         # download_file receives the .zip path
         call_args = api.download_file.call_args
@@ -998,7 +998,7 @@ class TestDownload:
     def test_download_with_model_filter(self, api, capsys):
         _setup_runs_response(api, [_make_run()])
         self._mock_download(api)
-        with patch("zipfile.ZipFile"), patch("os.remove"):
+        with patch("zipfile.ZipFile"), patch("os.remove"), patch("os.rename"):
             api.benchmarks_tasks_download_cli("my-task", model="gemini-pro")
         request = api._mock_benchmarks.list_benchmark_task_runs.call_args[0][0]
         assert request.model_version_slugs == ["gemini-pro"]
@@ -1014,7 +1014,7 @@ class TestDownload:
             ],
         )
         self._mock_download(api)
-        with patch("zipfile.ZipFile"), patch("os.remove"):
+        with patch("zipfile.ZipFile"), patch("os.remove"), patch("os.rename"):
             api.benchmarks_tasks_download_cli("my-task")
         # Only the completed run should be downloaded
         assert api._mock_benchmarks.download_benchmark_task_run_output.call_count == 1
@@ -1078,7 +1078,7 @@ class TestDownload:
         existing = os.path.join(outdir, "my-task", "1", "old-model", "2")
         os.makedirs(existing)
 
-        with patch("zipfile.ZipFile"), patch("os.remove"):
+        with patch("zipfile.ZipFile"), patch("os.remove"), patch("os.rename"):
             api.benchmarks_tasks_download_cli("my-task", output=outdir)
 
         output = capsys.readouterr().out
@@ -1094,7 +1094,7 @@ class TestDownload:
         existing = os.path.join(outdir, "my-task", "1", "gemini-pro", "42")
         os.makedirs(existing)
 
-        with patch("zipfile.ZipFile"), patch("os.remove"):
+        with patch("zipfile.ZipFile"), patch("os.remove"), patch("os.rename"):
             api.benchmarks_tasks_download_cli("my-task", output=outdir, force=True)
 
         output = capsys.readouterr().out
@@ -1107,7 +1107,7 @@ class TestDownload:
         """ERRORED runs are also downloadable per spec."""
         _setup_runs_response(api, [_make_run(state=RUN_ERRORED)])
         self._mock_download(api)
-        with patch("zipfile.ZipFile"), patch("os.remove"):
+        with patch("zipfile.ZipFile"), patch("os.remove"), patch("os.rename"):
             api.benchmarks_tasks_download_cli("my-task")
         assert api._mock_benchmarks.download_benchmark_task_run_output.call_count == 1
 
@@ -1122,7 +1122,7 @@ class TestDownload:
             ],
         )
         self._mock_download(api)
-        with patch("zipfile.ZipFile"), patch("os.remove"):
+        with patch("zipfile.ZipFile"), patch("os.remove"), patch("os.rename"):
             api.benchmarks_tasks_download_cli("my-task")
         assert api._mock_benchmarks.download_benchmark_task_run_output.call_count == 2
 
@@ -1170,7 +1170,7 @@ class TestDownload:
             [_make_run(model="anthropic/claude-sonnet-4-6@default", run_id=10)],
         )
         self._mock_download(api)
-        with patch("zipfile.ZipFile"), patch("os.remove"):
+        with patch("zipfile.ZipFile"), patch("os.remove"), patch("os.rename"):
             api.benchmarks_tasks_download_cli("my-task", model="claude-sonnet-4-6-default")
         # The run should NOT have been filtered out
         assert api._mock_benchmarks.download_benchmark_task_run_output.call_count == 1
@@ -1229,7 +1229,7 @@ class TestDownload:
         _setup_runs_response(api, [_make_run(run_id=1)])
         api._mock_benchmarks.download_benchmark_task_run_output.return_value = MagicMock()
         api.download_file = MagicMock()
-        with patch("zipfile.ZipFile"), patch("os.remove"):
+        with patch("zipfile.ZipFile"), patch("os.remove"), patch("os.rename"):
             api.benchmarks_tasks_download_cli("my-task")
         zippath = api.download_file.call_args[0][1]
         expected = os.path.join(".", "my-task", "unset", "gemini-pro", "1.zip")
@@ -1239,7 +1239,7 @@ class TestDownload:
         """--include-source passes include_source=True to the SDK request."""
         _setup_runs_response(api, [_make_run()])
         self._mock_download(api)
-        with patch("zipfile.ZipFile"), patch("os.remove"):
+        with patch("zipfile.ZipFile"), patch("os.remove"), patch("os.rename"):
             api.benchmarks_tasks_download_cli("my-task", include_source=True)
         request = api._mock_benchmarks.download_benchmark_task_run_output.call_args[0][0]
         assert request.include_source is True
@@ -1248,7 +1248,7 @@ class TestDownload:
         """Without --include-source, include_source defaults to False."""
         _setup_runs_response(api, [_make_run()])
         self._mock_download(api)
-        with patch("zipfile.ZipFile"), patch("os.remove"):
+        with patch("zipfile.ZipFile"), patch("os.remove"), patch("os.rename"):
             api.benchmarks_tasks_download_cli("my-task")
         request = api._mock_benchmarks.download_benchmark_task_run_output.call_args[0][0]
         assert request.include_source is False
@@ -1500,7 +1500,7 @@ class TestModelSlugNormalization:
         _setup_runs_response(api, [_make_run()])
         api._mock_benchmarks.download_benchmark_task_run_output.return_value = MagicMock()
         api.download_file = MagicMock()
-        with patch("zipfile.ZipFile"), patch("os.remove"):
+        with patch("zipfile.ZipFile"), patch("os.remove"), patch("os.rename"):
             api.benchmarks_tasks_download_cli("my-task", model="xai/grok-4.3")
         request = api._mock_benchmarks.list_benchmark_task_runs.call_args[0][0]
         assert request.model_version_slugs == ["grok-4.3"]

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -1026,6 +1026,22 @@ class TestStatus:
         assert "[gemma-2b]" in output
         assert "[gemma-2b]\n" not in output
 
+    def test_status_shows_log_hint(self, api, capsys):
+        """Status with runs shows a hint to use 'kaggle b t log' for details."""
+        api._mock_benchmarks.get_benchmark_task.return_value = _make_task()
+        _setup_runs_response(api, [_make_run(model="gemini-pro", run_id=42)])
+        api.benchmarks_tasks_status_cli("my-task")
+        output = capsys.readouterr().out
+        assert "View logs: kaggle b t log my-task [-m <model>]" in output
+
+    def test_status_no_log_hint_without_runs(self, api, capsys):
+        """Status without runs does NOT show the log hint."""
+        api._mock_benchmarks.get_benchmark_task.return_value = _make_task()
+        _setup_runs_response(api, [])
+        api.benchmarks_tasks_status_cli("my-task")
+        output = capsys.readouterr().out
+        assert "View logs:" not in output
+
     def test_status_pagination(self, api, capsys):
         """Status fetches all pages of runs."""
         api._mock_benchmarks.get_benchmark_task.return_value = _make_task()

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -1062,8 +1062,46 @@ class TestDownload:
         output = capsys.readouterr().out
         assert "gemini-pro" in output
         assert "Skipped" in output
+        assert "1 skipped" in output
         # No download API call should have been made
         api._mock_benchmarks.download_benchmark_task_run_output.assert_not_called()
+
+    def test_download_summary_counts(self, api, capsys, tmp_path):
+        """Download summary shows correct downloaded and skipped counts."""
+        _setup_runs_response(
+            api,
+            [_make_run(model="new-model", run_id=1), _make_run(model="old-model", run_id=2)],
+        )
+        self._mock_download(api)
+        outdir = str(tmp_path / "out")
+        # Pre-create only run 2 to simulate a previous download
+        existing = os.path.join(outdir, "my-task", "1", "old-model", "2")
+        os.makedirs(existing)
+
+        with patch("zipfile.ZipFile"), patch("os.remove"):
+            api.benchmarks_tasks_download_cli("my-task", output=outdir)
+
+        output = capsys.readouterr().out
+        assert "1 downloaded" in output
+        assert "1 skipped" in output
+
+    def test_download_force_overwrites_existing_output(self, api, capsys, tmp_path):
+        """Using force=True re-downloads and overwrites existing output."""
+        _setup_runs_response(api, [_make_run(run_id=42)])
+        self._mock_download(api)
+        outdir = str(tmp_path / "out")
+        # Pre-create the output directory to simulate a previous download
+        existing = os.path.join(outdir, "my-task", "1", "gemini-pro", "42")
+        os.makedirs(existing)
+
+        with patch("zipfile.ZipFile"), patch("os.remove"):
+            api.benchmarks_tasks_download_cli("my-task", output=outdir, force=True)
+
+        output = capsys.readouterr().out
+        assert "Downloading output for run 42 (gemini-pro)..." in output
+        assert "Downloaded output for gemini-pro" in output
+        # The download API call must have been made!
+        api._mock_benchmarks.download_benchmark_task_run_output.assert_called_once()
 
     def test_download_includes_errored_runs(self, api, capsys):
         """ERRORED runs are also downloadable per spec."""
@@ -1237,37 +1275,40 @@ class TestLog:
     @pytest.mark.parametrize("status_code", [403, 404], ids=["forbidden", "not_found"])
     def test_log_task_not_found(self, api, status_code):
         """Log gives friendly error when task doesn't exist (403/404)."""
-        api._mock_benchmarks.list_benchmark_task_runs.side_effect = HTTPError(
-            response=MagicMock(status_code=status_code)
-        )
-        with pytest.raises(HTTPError):
+        api._mock_benchmarks.get_benchmark_task.side_effect = HTTPError(response=MagicMock(status_code=status_code))
+        with pytest.raises(ValueError, match="not found"):
             api.benchmarks_tasks_log_cli("no-such-task")
 
-    def test_log_no_runs(self, api):
-        """No runs raises ValueError with helpful message."""
+    def test_log_no_runs(self, api, capsys):
+        """No runs prints a helpful message and returns."""
         _setup_completed_task(api)
         _setup_runs_response(api, [])
-        with pytest.raises(ValueError, match="No runs found"):
-            api.benchmarks_tasks_log_cli("my-task")
+        api.benchmarks_tasks_log_cli("my-task")
+        output = capsys.readouterr().out
+        assert "No runs found" in output
 
-    def test_log_no_runs_with_model_filter(self, api):
-        """No runs for a specific model gives descriptive error."""
+    def test_log_no_runs_with_model_filter(self, api, capsys):
+        """No runs for a specific model prints descriptive message and returns."""
         _setup_completed_task(api)
         _setup_runs_response(api, [])
-        with pytest.raises(ValueError, match="No runs found.*model"):
-            api.benchmarks_tasks_log_cli("my-task", model=["nonexistent-model"])
+        api.benchmarks_tasks_log_cli("my-task", model=["nonexistent-model"])
+        output = capsys.readouterr().out
+        assert "No runs found" in output
+        assert "nonexistent-model" in output
 
-    def test_log_single_run_no_header(self, api, capsys):
-        """Single run prints logs without header."""
-        _setup_runs_response(api, [_make_run()])
+    def test_log_single_run_with_header(self, api, capsys):
+        """Single run prints logs with model header including state."""
+        _setup_runs_response(api, [_make_run(model="gemini-pro", run_id=1)])
         self._mock_log_response(api, content="hello world")
         api.benchmarks_tasks_log_cli("my-task")
         output = capsys.readouterr().out
         assert "hello world" in output
-        assert "═══" not in output  # No header for single run
+        assert "═══ Logs for gemini-pro (Run 1) [COMPLETED] ═══" in output
+        assert "═══ (" in output  # line count footer
+        assert "Showed logs for 1 run(s) across 1 model(s)." in output
 
     def test_log_multiple_runs_with_headers(self, api, capsys):
-        """Multiple runs print logs with model headers."""
+        """Multiple runs print logs with model headers and a summary."""
         _setup_runs_response(
             api,
             [
@@ -1278,8 +1319,9 @@ class TestLog:
         self._mock_log_response(api, content="log output")
         api.benchmarks_tasks_log_cli("my-task")
         output = capsys.readouterr().out
-        assert "═══ Logs for gemini-pro (Run 1) ═══" in output
-        assert "═══ Logs for claude-4 (Run 2) ═══" in output
+        assert "═══ Logs for gemini-pro (Run 1) [COMPLETED] ═══" in output
+        assert "═══ Logs for claude-4 (Run 2) [COMPLETED] ═══" in output
+        assert "Showed logs for 2 run(s) across 2 model(s)." in output
 
     def test_log_with_model_filter(self, api, capsys):
         """Model filter is passed to _fetch_task_runs."""


### PR DESCRIPTION


# feat(benchmarks): Add `publish` and `log` commands, support dataset `push`, and improve `download`

**TODO: release `kaggle-sdk-python` new version and use it here.**

## Publish command (new)

Adds `kaggle b t publish <task> [--publish-backing-notebook]` to make a benchmark task public.
- Handles partial states: if a task is already public but the backing notebook is private (and the flag is set), it will publish only the notebook.
- Returns clear warnings if no backing notebook is associated with the task.

## Log command (new)

Adds `kaggle b t log <task> [-m <model> ...]` to view execution logs.
- **Streaming**: Active (`RUNNING`) runs stream live output via SSE; completed/errored runs print the persisted log.
- **Robustness**: Gracefully handles `QUEUED` runs (which have no logs yet) by catching the server's 404/400 per-run, printing a friendly indicator, and continuing to show logs for other runs instead of crashing.
- **Multi-model**: Logs for each model are printed sequentially (not interleaved), with a header showing run ID and state, a line-count footer, and a final summary.

## Push with dataset (new)

Adds `-d` / `--kaggle-dataset` to `kaggle b t push` to attach Kaggle datasets as data sources.
- Visual warning if re-pushing a task without `-d` would detach previously associated datasets.
- Clean validation checks to warn about unresolved dataset slugs on the server.

## Download improvements

- **`--include-source` / `-s`**: Also download the kernel session's source notebooks alongside output files.
- **`--force` / `-f`**: Re-download and overwrite previously downloaded runs instead of skipping them. Downloads to a staging directory first so the previous output is preserved if the download fails.
- **Summary line**: Prints a final `Done: X downloaded, Y skipped.` count (and outputs `Done: 0 downloaded.` consistently on early returns).

## Refactors & Code Quality

- **TTY-Aware Colors**: Replaced all raw ANSI escape codes (`\033[`) with static utility helpers (`_bold()`, `_warn()`, `_error()`) that automatically strip color codes when the output stream is redirected (non-TTY, pipes, logs, agents).
- **Format Improvements**: 
  - Unified `_format_model_hint()` to fix model name quoting inconsistencies.
  - `_print_log_entry()` now prints fallback dictionaries with formatting via `json.dumps()` instead of Python's raw `repr()`.