### PR TITLE
fix(retry): restore jitter in _calculate_backoff_delay

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -916,9 +916,7 @@ class KaggleApi:
 
     def _calculate_backoff_delay(self, attempt, initial_delay_millis, retry_multiplier, randomness_factor):
         delay_ms = initial_delay_millis * (retry_multiplier**attempt)
-        # TODO: int() truncates (random() - 0.5) to 0 for all values in [-0.5, 0.5),
-        # making jitter always zero. Apply int() to the whole expression instead.
-        random_wait_ms = int(random() - 0.5) * 2 * delay_ms * randomness_factor
+        random_wait_ms = int((random() - 0.5) * 2 * delay_ms * randomness_factor)
         total_delay = (delay_ms + random_wait_ms) / 1000.0
         return total_delay
 


### PR DESCRIPTION
## Summary

Fixes a jitter calculation bug in `_calculate_backoff_delay` that caused
retry back-off jitter to always evaluate to zero, making retries fully
deterministic instead of randomized.

## Root Cause

### Before (broken)

```python
random_wait_ms = int(random() - 0.5) * 2 * delay_ms * randomness_factor
#                ^^^^^^^^^^^^^^^^^^^
#                int() applied too early — always truncates to 0
```

`random() - 0.5` produces values in the range `[-0.5, 0.5)`. Applying
`int()` before scaling truncates every possible value to `0`, causing
the jitter term to always evaluate to zero.

### After (correct)

```python
random_wait_ms = int((random() - 0.5) * 2 * delay_ms * randomness_factor)
#                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#                    int() applied after scaling
```

Applying `int()` after the full expression preserves randomized jitter
while still returning an integer millisecond delay.