### PR TITLE
Polish benchmarks CLI error messages

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -7405,10 +7405,11 @@ class KaggleApi:
                 if res.run_scheduled:
                     print(f"  {model_slug}: Scheduled")
                 else:
-                    print(
-                        f"  {model_slug}: Skipped ({res.run_skipped_reason}). "
-                        f"Run 'kaggle b t models' to see supported models."
-                    )
+                    reason = (res.run_skipped_reason or "").rstrip(".")
+                    msg = f"  {model_slug}: Skipped ({reason})."
+                    if "model version" in reason.lower():
+                        msg += " Run 'kaggle b t models' to see supported models."
+                    print(msg)
 
             if wait is None:
                 print("\nNext steps:")

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -7120,10 +7120,7 @@ class KaggleApi:
             print(f"  {pending} run(s) still in progress...")
 
             if wait > 0 and (time.time() - start_time) > wait:
-                print(
-                    f"Timed out after {wait}s waiting for runs.\n"
-                    f"Check status with: kaggle b t status {task}"
-                )
+                print(f"Timed out after {wait}s waiting for runs.\nCheck status with: kaggle b t status {task}")
                 return
 
             current_interval = self._adaptive_sleep(current_interval, poll_interval, verbose)

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -7078,7 +7078,7 @@ class KaggleApi:
             elif state not in self._PENDING_CREATION_STATES:
                 error_msg = f"Task '{task}' creation failed (status: {self._clean_enum_str(state)})."
                 error = getattr(task_info, "error", None) or getattr(task_info, "creation_error_message", None)
-                if error and verbose:
+                if error:
                     error_msg += f"\n  Error: {error}"
                 raise ValueError(error_msg)
 
@@ -7377,7 +7377,7 @@ class KaggleApi:
                     f"Task '{task}' is not ready to run (status: {self._clean_enum_str(state)}). "
                     f"Only completed tasks can be run."
                 )
-                if verbose and state == self._TASK_CREATION_ERRORED:
+                if state == self._TASK_CREATION_ERRORED:
                     error_msg += f"\n  Task Info: {task_info}"
                 raise ValueError(error_msg)
 

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -7431,6 +7431,12 @@ class KaggleApi:
                 return self.with_retry(kaggle.benchmarks.benchmark_tasks_api_client.list_benchmark_tasks)(request)
 
             all_tasks = self._paginate(_fetch, lambda r: r.tasks or [])
+            if not all_tasks:
+                if name_regex or status:
+                    print("No tasks found matching the given filters.")
+                else:
+                    print("No tasks found. Use 'kaggle b t push' to create one.")
+                return
             if show_all:
                 self._paginated_task_display(all_tasks, page_size=max(len(all_tasks), 1), interactive=False)
             else:
@@ -7439,9 +7445,6 @@ class KaggleApi:
     def _paginated_task_display(self, tasks, page_size=20, interactive=True):
         """Display *tasks* one page at a time with an interactive n/p/q prompt."""
         total = len(tasks)
-        if total == 0:
-            print("No tasks found. Use 'kaggle b t push' to create one.")
-            return
 
         # Extract owner username from a task URL of the form /benchmarks/tasks/{user}/{slug}/{ver}.
         username = None

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -6927,7 +6927,7 @@ class KaggleApi:
                 if allow_not_found:
                     return None
                 raise ValueError(
-                    f"Task '{task}' not found. Verify the name or run 'kaggle b t list' to see available tasks."
+                    f"Task '{task}' not found. Verify the name or run 'kaggle benchmarks tasks list' to see available tasks."
                 ) from None
             raise
 
@@ -7010,7 +7010,7 @@ class KaggleApi:
                 raise ValueError(
                     "No model specified and no input received. "
                     "Pass one or more models with -m/--model, or use "
-                    "'kaggle b t models' to list available models."
+                    "'kaggle benchmarks tasks models' to list available models."
                 ) from None
 
             if selection == "n" and current_page < total_pages - 1:
@@ -7397,7 +7397,7 @@ class KaggleApi:
                 if e.response.status_code == 404:
                     raise ValueError(
                         f"Failed to schedule runs. Some model names may be invalid: {models}. "
-                        f"Run 'kaggle b t run {task}' without -m to select from available models."
+                        f"Run 'kaggle benchmarks tasks run {task}' without -m to select from available models."
                     ) from None
                 raise
             print(f"Submitted run(s) for task '{task}'.")
@@ -7405,11 +7405,7 @@ class KaggleApi:
                 if res.run_scheduled:
                     print(f"  {model_slug}: Scheduled")
                 else:
-                    reason = (res.run_skipped_reason or "").rstrip(".")
-                    msg = f"  {model_slug}: Skipped ({reason})."
-                    if "model version" in reason.lower():
-                        msg += " Run 'kaggle b t models' to see supported models."
-                    print(msg)
+                    print(f"  {model_slug}: Skipped ({res.run_skipped_reason})")
 
             if wait is None:
                 print("\nNext steps:")
@@ -7432,20 +7428,26 @@ class KaggleApi:
                 return self.with_retry(kaggle.benchmarks.benchmark_tasks_api_client.list_benchmark_tasks)(request)
 
             all_tasks = self._paginate(_fetch, lambda r: r.tasks or [])
-            if not all_tasks:
-                if name_regex or status:
-                    print("No tasks found matching the given filters.")
-                else:
-                    print("No tasks found. Use 'kaggle b t push' to create one.")
-                return
-            if show_all:
-                self._paginated_task_display(all_tasks, page_size=max(len(all_tasks), 1), interactive=False)
+            if name_regex or status:
+                empty_message = "No tasks found matching the given filters."
             else:
-                self._paginated_task_display(all_tasks, page_size=page_size or 20)
+                empty_message = "No tasks found. Use 'kaggle b t push' to create one."
+            if show_all:
+                self._paginated_task_display(
+                    all_tasks,
+                    page_size=max(len(all_tasks), 1),
+                    interactive=False,
+                    empty_message=empty_message,
+                )
+            else:
+                self._paginated_task_display(all_tasks, page_size=page_size or 20, empty_message=empty_message)
 
-    def _paginated_task_display(self, tasks, page_size=20, interactive=True):
+    def _paginated_task_display(self, tasks, page_size=20, interactive=True, empty_message="No tasks found."):
         """Display *tasks* one page at a time with an interactive n/p/q prompt."""
         total = len(tasks)
+        if total == 0:
+            print(empty_message)
+            return
 
         # Extract owner username from a task URL of the form /benchmarks/tasks/{user}/{slug}/{ver}.
         username = None

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -6882,11 +6882,13 @@ class KaggleApi:
         """
         task_names = KaggleApi._get_task_names_from_file(file_content)
         if not task_names:
-            raise ValueError(f"No @task decorators found in file {file}. The file must define at least one task.")
+            raise ValueError(
+                f"No @task decorators found in '{file}'. Add at least one @task decorator to define a task."
+            )
         task_slug = slugify(task)
         slugified_names = {slugify(n): n for n in task_names}
         if task_slug not in slugified_names:
-            raise ValueError(f"Task '{task}' not found in file {file}. Found tasks: {', '.join(slugified_names)}")
+            raise ValueError(f"Task '{task}' not found in '{file}'. Available tasks: {', '.join(slugified_names)}")
 
     @staticmethod
     def _convert_py_to_notebook(source: str) -> str:
@@ -6925,8 +6927,7 @@ class KaggleApi:
                 if allow_not_found:
                     return None
                 raise ValueError(
-                    f"Task '{task}' not found. Check the task name and try again. "
-                    f"Use 'kaggle b t list' to see your tasks."
+                    f"Task '{task}' not found. Verify the name or run 'kaggle b t list' to see available tasks."
                 ) from None
             raise
 
@@ -7021,7 +7022,7 @@ class KaggleApi:
                     indices = [int(s) for s in selection.split(",")]
                     return [available[i - 1].version.slug for i in indices]
                 except (ValueError, IndexError):
-                    raise ValueError(f"Invalid selection: {selection}")
+                    raise ValueError(f"'{selection}' is not a valid choice. Enter a list of numbers (e.g., 1,3,4).")
 
     @staticmethod
     def _truncate(s: str, max_len: int) -> str:
@@ -7075,16 +7076,19 @@ class KaggleApi:
             if state == BenchmarkTaskVersionCreationState.BENCHMARK_TASK_VERSION_CREATION_STATE_COMPLETED:
                 return True
             elif state not in self._PENDING_CREATION_STATES:
-                error_msg = f"Task '{task}' creation failed with status: {self._clean_enum_str(state)}"
+                error_msg = f"Task '{task}' creation failed (status: {self._clean_enum_str(state)})."
                 error = getattr(task_info, "error", None) or getattr(task_info, "creation_error_message", None)
-                if error:
-                    error_msg += f" Error: {error}"
+                if error and verbose:
+                    error_msg += f"\n  Error: {error}"
                 raise ValueError(error_msg)
 
             print(f"   Task status: {self._clean_enum_str(state)}...")
 
             if wait > 0 and (time.time() - start_time) > wait:
-                print(f"Timed out waiting for task creation after {wait} seconds.")
+                print(
+                    f"Timed out after {wait}s waiting for task creation.\n"
+                    f"Check status with: kaggle b t status {task}"
+                )
                 return False
 
             current_interval = self._adaptive_sleep(current_interval, poll_interval, verbose)
@@ -7109,14 +7113,17 @@ class KaggleApi:
                         slug = self._normalize_model_slug(r.model_version_slug)
                         msg = (getattr(r, "error_message", None) or "").strip() or "No error message"
                         details.append(f"  [{slug}]\n    {msg}")
-                    raise ValueError(f"{len(errored)} run(s) failed:\n" + "\n".join(details))
+                    raise ValueError(f"{len(errored)} run(s) failed. Details below:\n" + "\n".join(details))
                 return
 
             pending = sum(1 for r in all_runs if r.state not in self._TERMINAL_RUN_STATES)
             print(f"  {pending} run(s) still in progress...")
 
             if wait > 0 and (time.time() - start_time) > wait:
-                print(f"Timed out waiting for runs after {wait} seconds.")
+                print(
+                    f"Timed out after {wait}s waiting for runs.\n"
+                    f"Check status with: kaggle b t status {task}"
+                )
                 return
 
             current_interval = self._adaptive_sleep(current_interval, poll_interval, verbose)
@@ -7264,9 +7271,9 @@ class KaggleApi:
         if poll_interval is not None and poll_interval <= 0:
             raise ValueError("--poll-interval must be a positive integer")
         if not os.path.isfile(file):
-            raise ValueError(f"File {file} does not exist")
+            raise ValueError(f"File '{file}' does not exist.")
         if not file.endswith(".py"):
-            raise ValueError(f"File {file} must be a .py file")
+            raise ValueError(f"File '{file}' must be a Python (.py) file.")
 
         with open(file) as f:
             content = f.read()
@@ -7287,8 +7294,8 @@ class KaggleApi:
             if task_info and task_info.creation_state in self._PENDING_CREATION_STATES:
                 if wait is None:
                     raise ValueError(
-                        f"Task '{task_slug}' is currently being created (pending). Cannot push now. "
-                        f"Use --wait to monitor the existing creation."
+                        f"Task '{task_slug}' creation is still pending. "
+                        f"Run again with the --wait flag to wait for completion."
                     )
                 print(f"Task '{task_slug}' is already being created. Waiting for it to finish...")
                 self._poll_task_creation(kaggle, task_slug, wait, poll_interval, verbose=verbose)
@@ -7321,7 +7328,7 @@ class KaggleApi:
             response = self.with_retry(kaggle.benchmarks.benchmark_tasks_api_client.create_benchmark_task)(request)
             error = getattr(response, "error", None)
             if error:
-                raise ValueError(f"Failed to push task: {error}")
+                raise ValueError(f"Failed to push task. Error: {error}")
 
             url = self._full_task_url(response.url)
             model_output_url = re.sub(r"/\d+/?$", "", url) + "?compare=true"
@@ -7369,10 +7376,12 @@ class KaggleApi:
             task_info = self._get_benchmark_task(task, kaggle)
             state = task_info.creation_state
             if state != self._TASK_CREATION_COMPLETED:
-                error_msg = f"Task '{task}' is not ready to run (status: {self._clean_enum_str(state)})."
-                if state == self._TASK_CREATION_ERRORED:
-                    error_msg += f" Task Info: {task_info}."
-                error_msg += " Only completed tasks can be run."
+                error_msg = (
+                    f"Task '{task}' is not ready to run (status: {self._clean_enum_str(state)}). "
+                    f"Only completed tasks can be run."
+                )
+                if verbose and state == self._TASK_CREATION_ERRORED:
+                    error_msg += f"\n  Task Info: {task_info}"
                 raise ValueError(error_msg)
 
             if not models:
@@ -7390,8 +7399,8 @@ class KaggleApi:
             except HTTPError as e:
                 if e.response.status_code == 404:
                     raise ValueError(
-                        f"Failed to schedule runs. One or more model names may be invalid: {models}. "
-                        f"Use 'kaggle b t run {task}' (without -m) to select from available models."
+                        f"Failed to schedule runs. Some model names may be invalid: {models}. "
+                        f"Run 'kaggle b t run {task}' without -m to select from available models."
                     ) from None
                 raise
             print(f"Submitted run(s) for task '{task}'.")
@@ -7399,7 +7408,10 @@ class KaggleApi:
                 if res.run_scheduled:
                     print(f"  {model_slug}: Scheduled")
                 else:
-                    print(f"  {model_slug}: Skipped ({res.run_skipped_reason})")
+                    print(
+                        f"  {model_slug}: Skipped ({res.run_skipped_reason}). "
+                        f"Run 'kaggle b t models' to see supported models."
+                    )
 
             if wait is None:
                 print("\nNext steps:")
@@ -7431,7 +7443,7 @@ class KaggleApi:
         """Display *tasks* one page at a time with an interactive n/p/q prompt."""
         total = len(tasks)
         if total == 0:
-            print("No tasks found.")
+            print("No tasks found. Use 'kaggle b t push' to create one.")
             return
 
         # Extract owner username from a task URL of the form /benchmarks/tasks/{user}/{slug}/{ver}.
@@ -7736,7 +7748,7 @@ class KaggleApi:
         with self.build_kaggle_client() as kaggle:
             models = self._fetch_all_benchmark_models(kaggle)
             if not models:
-                print("No benchmark models available.")
+                print("No benchmark models available. This may be a temporary issue — try again later.")
                 return
 
             col_slug = 30

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -208,7 +208,7 @@ class TestPush:
         "task, filename, content, expected_error",
         [
             ("my-task", None, None, "does not exist"),
-            ("my-task", "task.txt", "hello", "must be a .py"),
+            ("my-task", "task.txt", "hello", "must be a Python"),
             ("any-task", "task.py", "def f(): pass\n", "No @task decorators"),
             ("wrong", "task.py", '@task(name="real")\ndef f(llm): pass\n', "not found"),
             ("any-task", "task.py", "def broken(\n", "No @task decorators"),
@@ -292,7 +292,7 @@ class TestPush:
         """Push without --wait rejects when task is pending, with a --wait hint."""
         filepath = _write_task_file(tmp_path)
         api._mock_benchmarks.get_benchmark_task.return_value = _make_task(state=state)
-        with pytest.raises(ValueError, match="currently being created") as exc_info:
+        with pytest.raises(ValueError, match="creation is still pending") as exc_info:
             _push(api, "my-task", filepath)
         assert "--wait" in str(exc_info.value)
 
@@ -336,7 +336,7 @@ class TestPush:
         resp.error = "Some backend error"
         api._mock_benchmarks.create_benchmark_task.return_value = resp
 
-        with pytest.raises(ValueError, match="Failed to push task: Some backend error"):
+        with pytest.raises(ValueError, match=r"Failed to push task\. Error: Some backend error"):
             _push(api, "my-task", filepath)
 
     def test_push_wait_polls_until_completion(self, api, capsys, tmp_path):
@@ -439,7 +439,7 @@ class TestPush:
             api.benchmarks_tasks_push_cli("my-task", filepath, wait=30)
 
         output = capsys.readouterr().out
-        assert "Timed out waiting for task creation after 30 seconds" in output
+        assert "Timed out after 30s waiting for task creation." in output
 
     @pytest.mark.parametrize("interval", [0, -1], ids=["zero", "negative"])
     def test_push_rejects_non_positive_poll_interval(self, api, tmp_path, interval):
@@ -647,7 +647,7 @@ class TestRun:
         _setup_completed_task(api)
         _setup_available_models(api, ["gemini-pro"])
         with patch("builtins.input", return_value="abc"):
-            with pytest.raises(ValueError, match="Invalid selection"):
+            with pytest.raises(ValueError, match="is not a valid choice"):
                 api.benchmarks_tasks_run_cli("my-task")
 
     def test_run_eof_without_models_raises(self, api):
@@ -786,7 +786,7 @@ class TestRun:
         with patch("time.sleep"), patch("time.time", side_effect=[1000, 1060]):
             api.benchmarks_tasks_run_cli("my-task", ["gemini-pro"], wait=30)
         output = capsys.readouterr().out
-        assert "Timed out waiting for runs after 30 seconds" in output
+        assert "Timed out after 30s waiting for runs." in output
 
     def test_run_wait_shows_errored_runs(self, api, capsys):
         """ERRORED runs display with ERRORED label and raise ValueError."""

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -594,38 +594,22 @@ class TestRun:
             assert f"{m}: Scheduled" in output
 
     def test_run_reports_skipped_with_reason(self, api, capsys):
-        """Non-model skip reasons print the reason but omit the model-list hint."""
+        """Skipped runs print the backend-provided reason."""
         _setup_completed_task(api)
         _setup_batch_schedule(api, [_make_run_result(scheduled=False, skipped_reason="Already running")])
         api.benchmarks_tasks_run_cli("my-task", ["gemini-pro"])
         output = capsys.readouterr().out
         assert "gemini-pro: Skipped" in output
         assert "Already running" in output
-        assert "kaggle b t models" not in output
-
-    @pytest.mark.parametrize(
-        "reason",
-        ["Unsupported model version", "No matching model version.", "Can not access model version."],
-        ids=["unsupported", "no_match", "no_access"],
-    )
-    def test_run_skipped_model_reason_shows_models_hint(self, api, capsys, reason):
-        """Model-related skip reasons append the 'kaggle b t models' hint."""
-        _setup_completed_task(api)
-        _setup_batch_schedule(api, [_make_run_result(scheduled=False, skipped_reason=reason)])
-        api.benchmarks_tasks_run_cli("my-task", ["gemini-pro"])
-        output = capsys.readouterr().out
-        assert "gemini-pro: Skipped" in output
-        assert "Run 'kaggle b t models' to see supported models." in output
 
     @pytest.mark.parametrize("reason", [None, ""], ids=["none", "empty"])
     def test_run_skipped_empty_reason_does_not_crash(self, api, capsys, reason):
-        """Empty/None skip reason renders without crashing and without the hint."""
+        """Empty/None skip reason renders without crashing."""
         _setup_completed_task(api)
         _setup_batch_schedule(api, [_make_run_result(scheduled=False, skipped_reason=reason)])
         api.benchmarks_tasks_run_cli("my-task", ["gemini-pro"])
         output = capsys.readouterr().out
         assert "gemini-pro: Skipped" in output
-        assert "kaggle b t models" not in output
 
     def test_run_no_status_hint_when_waiting(self, api, capsys):
         """When --wait is used, the status hint should not appear."""

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -872,12 +872,25 @@ class TestList:
 
     @pytest.mark.parametrize("tasks", [[], None], ids=["empty_list", "none"])
     def test_list_empty(self, api, capsys, tasks):
-        """Empty/None task list prints a friendly message instead of an empty table."""
+        """Unfiltered empty list prints the actionable push hint, not an empty table."""
         _setup_list_response(api, tasks)
         api.benchmarks_tasks_list_cli()
         output = capsys.readouterr().out
-        assert "No tasks found." in output
+        assert "No tasks found. Use 'kaggle b t push' to create one." in output
         assert "my-task" not in output
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [{"name_regex": "no-match.*"}, {"status": "completed"}, {"name_regex": "x", "status": "completed"}],
+        ids=["regex", "status", "both"],
+    )
+    def test_list_empty_with_filter(self, api, capsys, kwargs):
+        """Filtered empty list says 'matching the given filters' rather than the push hint."""
+        _setup_list_response(api, [])
+        api.benchmarks_tasks_list_cli(**kwargs)
+        output = capsys.readouterr().out
+        assert "No tasks found matching the given filters." in output
+        assert "kaggle b t push" not in output
 
     def test_list_table_format(self, api, capsys):
         """Table uses per-column unicode-line underlines spanning each column's full width."""

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -594,12 +594,38 @@ class TestRun:
             assert f"{m}: Scheduled" in output
 
     def test_run_reports_skipped_with_reason(self, api, capsys):
+        """Non-model skip reasons print the reason but omit the model-list hint."""
         _setup_completed_task(api)
         _setup_batch_schedule(api, [_make_run_result(scheduled=False, skipped_reason="Already running")])
         api.benchmarks_tasks_run_cli("my-task", ["gemini-pro"])
         output = capsys.readouterr().out
         assert "gemini-pro: Skipped" in output
         assert "Already running" in output
+        assert "kaggle b t models" not in output
+
+    @pytest.mark.parametrize(
+        "reason",
+        ["Unsupported model version", "No matching model version.", "Can not access model version."],
+        ids=["unsupported", "no_match", "no_access"],
+    )
+    def test_run_skipped_model_reason_shows_models_hint(self, api, capsys, reason):
+        """Model-related skip reasons append the 'kaggle b t models' hint."""
+        _setup_completed_task(api)
+        _setup_batch_schedule(api, [_make_run_result(scheduled=False, skipped_reason=reason)])
+        api.benchmarks_tasks_run_cli("my-task", ["gemini-pro"])
+        output = capsys.readouterr().out
+        assert "gemini-pro: Skipped" in output
+        assert "Run 'kaggle b t models' to see supported models." in output
+
+    @pytest.mark.parametrize("reason", [None, ""], ids=["none", "empty"])
+    def test_run_skipped_empty_reason_does_not_crash(self, api, capsys, reason):
+        """Empty/None skip reason renders without crashing and without the hint."""
+        _setup_completed_task(api)
+        _setup_batch_schedule(api, [_make_run_result(scheduled=False, skipped_reason=reason)])
+        api.benchmarks_tasks_run_cli("my-task", ["gemini-pro"])
+        output = capsys.readouterr().out
+        assert "gemini-pro: Skipped" in output
+        assert "kaggle b t models" not in output
 
     def test_run_no_status_hint_when_waiting(self, api, capsys):
         """When --wait is used, the status hint should not appear."""


### PR DESCRIPTION
## Summary
- Apply wording recommendations from the benchmarks [error-message analysis](https://docs.google.com/document/d/18PB7Qa-hvjrFxcG6IPtcAg9uln5COl5lDaZJTmWs8k4/edit?tab=t.0#heading=h.iwkswd2kuku3): quote file paths consistently, end messages with a period, point users at the right follow-up command in timeout and failure paths.
- No new tests: changes are wording-only which is easy to verify by reading the diff than by pinning exact strings. Existing 45 tests still pass.

## Test plan
- [ ] \`KAGGLE_USERNAME=test KAGGLE_KEY=test pytest tests/ --ignore=tests/unit_tests.py\` passes
- [ ] Manually trigger \`kaggle b t push\` with a missing file → friendlier error
- [ ] Manually trigger \`kaggle b t run <task>\` against an errored task → no \`Task Info\` dump by default; appears with \`--verbose\`
- [ ] Manually trigger a polling timeout → two-line message with \`kaggle b t status <task>\` hint