### PR TITLE
Improve CLI error dispatch and retry-exhaustion messages

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -940,6 +940,19 @@ class KaggleApi:
                     return func(*args)
                 except Exception as e:
                     if type(e) is HTTPError:
+                        if self._is_retriable(e) and i >= max_retries:
+                            if self._is_rate_limited(e):
+                                print(
+                                    f"Rate limit exceeded after {max_retries} retries. "
+                                    "Try again in a few minutes.",
+                                    file=sys.stderr,
+                                )
+                            else:
+                                print(
+                                    f"Request failed after {max_retries} retries. "
+                                    "If the problem persists, check https://www.kaggle.com/status or try again later.",
+                                    file=sys.stderr,
+                                )
                         if self._is_retriable(e) and i < max_retries:
                             # Use Retry-After header for 429 responses when available
                             if self._is_rate_limited(e):

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -32,8 +32,26 @@ from kaggle.api.kaggle_api_extended import print_auth_help
 ApiException = IOError
 
 
+class _KaggleArgumentParser(argparse.ArgumentParser):
+    """ArgumentParser with friendlier error formatting for missing required args.
+
+    Rewrites argparse's default ``error: the following arguments are required: X``
+    into ``Error: Missing required argument 'X'.`` plus the usage line.
+    """
+
+    def error(self, message: str) -> None:  # type: ignore[override]
+        prefix = "the following arguments are required: "
+        if message.startswith(prefix):
+            required = message[len(prefix) :].strip()
+            args_quoted = ", ".join(f"'{a.strip()}'" for a in required.split(","))
+            label = "argument" if "," not in required else "arguments"
+            self.print_usage(sys.stderr)
+            self.exit(2, f"Error: Missing required {label} {args_quoted}.\n")
+        super().error(message)
+
+
 def main() -> None:
-    parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
+    parser = _KaggleArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
 
     parser.add_argument(
         "-v",
@@ -78,7 +96,12 @@ def main() -> None:
         if e.response is not None and e.response.status_code == 401:
             print_auth_help()
         else:
-            print(e, file=sys.stderr)
+            print(
+                "An unexpected server error occurred. "
+                "If the problem persists, check https://www.kaggle.com/status or try again later.",
+                file=sys.stderr,
+            )
+            print(f"Details: {e}", file=sys.stderr)
         out = None
         error = True
     except ApiException as e:


### PR DESCRIPTION
## Summary

Phase 2 of the Kaggle benchmarks CLI error-message polish. Where Phase 1 was per-handler wording, this PR touches the shared dispatch paths:

- **`cli.py` — argparse errors:** New `_KaggleArgumentParser` rewrites argparse's default `error: the following arguments are required: X` into `Error: Missing required argument 'X'.` plus the usage line.
- **`cli.py` — non-401 HTTPError dispatch:** Prepends a friendly message pointing to https://www.kaggle.com/status, with the raw error preserved on a `Details:` line.
- **`kaggle_api_extended.py` — `with_retry` exhaustion:** Prints a clear `Rate limit exceeded after N retries. Try again in a few minutes.` (or generic `Request failed after N retries…`) message when retries exhaust, before the original error is re-raised for callers.

## Blast radius

These edits live in shared code paths (`cli.py` `main()` and `with_retry`), so the wording change is visible beyond benchmarks. Scoping benchmarks-only would require significant duplication. Happy to rework or pare back if reviewers prefer.

## Test plan

- [x] Existing test suite passes (`pytest tests/` — 45/45)
- [x] Smoke-tested missing-arg via `kaggle benchmarks tasks status` — renders as `usage: …` + `Error: Missing required argument 'task'.`
- [ ] Reviewer eyes on scope (see "Blast radius" above)