### PR TITLE
Route benchmarks warnings and errors to stderr

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -7204,7 +7204,7 @@ class KaggleApi:
         example_file = os.path.abspath(example_file)
         if os.path.exists(example_file):
             if not quiet:
-                print(f"Example file already exists at {example_file}, skipping.")
+                print(f"Example file already exists at '{example_file}', skipping.", file=sys.stderr)
             return
 
         with open(example_file, "w") as f:
@@ -7217,7 +7217,7 @@ class KaggleApi:
         ref_file = os.path.join(os.path.abspath(directory), "kaggle_benchmarks_reference.md")
         if os.path.exists(ref_file):
             if not quiet:
-                print(f"Reference file already exists at {ref_file}, skipping.")
+                print(f"Reference file already exists at '{ref_file}', skipping.", file=sys.stderr)
             return
 
         with open(ref_file, "w") as f:
@@ -7679,7 +7679,7 @@ class KaggleApi:
                     )(request)
                 except HTTPError as e:
                     status = getattr(e.response, "status_code", None)
-                    print(f"  (No logs available — server returned {status})")
+                    print(f"  (No logs available — server returned {status})", file=sys.stderr)
                     print(f"═══ (0 lines) ═══")
                     continue
 
@@ -7749,7 +7749,7 @@ class KaggleApi:
 
     def benchmarks_tasks_delete_cli(self, task, no_confirm=False):
         # TODO: Normalize task name via slugify(task) when server supports delete.
-        print("Delete is not supported by the server yet.")
+        print("Delete is not supported by the server yet.", file=sys.stderr)
 
     def benchmarks_tasks_publish_cli(self, task, publish_backing_notebook=True):
         """Publish a benchmark task, making it public."""
@@ -7784,7 +7784,7 @@ class KaggleApi:
                 if getattr(response, "is_backing_notebook_published", False):
                     print("Backing notebook also published.")
                 else:
-                    print("Note: No backing notebook is associated with this task.")
+                    print("Note: No backing notebook is associated with this task.", file=sys.stderr)
 
 
 class TqdmBufferedReader(io.BufferedReader):


### PR DESCRIPTION
## Summary

Phase 2 of the Kaggle benchmarks CLI error-message polish. Five benchmarks messages currently print to stdout but represent warnings or errors. Routing them to stderr keeps stdout clean for piped/parsed output.

- `benchmarks tasks delete` — "Delete is not supported by the server yet."
- `benchmarks tasks log` — "(No logs available — server returned N)" fallback when a per-run log fetch 404s.
- `benchmarks init` — "Example file already exists at '…', skipping." and "Reference file already exists at '…', skipping." (also quoted the path for consistency with Phase 1).
- `benchmarks tasks publish` — "Note: No backing notebook is associated with this task."

Scoped to benchmarks-only call sites; no shared infrastructure touched.

## Note on overlap with #1030 (Phase 1)

I deliberately omitted the two `Timed out…` messages in `_poll_task_creation` / `_poll_runs` — Phase 1 (#1030) already edits those lines, and rerouting them here would conflict. Happy to follow up with a small rebase PR once #1030 lands if reviewers want those routed to stderr too.

## Test plan

- [x] Existing test suite passes (`pytest tests/` — 45/45)
- [ ] Spot-check one of the affected paths (e.g. `kaggle benchmarks init` in a directory where the example file already exists) renders the warning to stderr