### PR TITLE
Set proper perms on auth file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ keywords = ["Kaggle", "API"]
 requires-python = ">= 3.11"
 dependencies = [
     "bleach",
-    "kagglesdk >= 0.1.24, < 1.0", # sync with kagglehub
+    "kagglesdk >= 0.1.26, < 1.0", # sync with kagglehub
     "python-slugify",
     "requests",
     "python-dateutil",

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -1197,6 +1197,7 @@ class KaggleApi:
             None:
         """
 
+        old_file = os.path.exists(self.config)
         config_data = self._read_config_file()
 
         if value is not None:
@@ -1209,6 +1210,8 @@ class KaggleApi:
 
             # If defined by client, set and save!
             self._write_config_file(config_data)
+            if not old_file:
+                os.chmod(self.config, 0o600)
 
             if not quiet:
                 self.print_config_value(name, separator=" is now set to: ")


### PR DESCRIPTION
Fixes permissions on newly-created `kaggle.json`, found while investigating #1009. Also pulls in `kagglesdk` to fix #1009.

