### PR TITLE
feat: support optional kernel version in specifier

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -4157,7 +4157,8 @@ class KaggleApi:
         """
         if kernel is None:
             raise ValueError("A kernel must be specified")
-        user_name, kernel_slug, kernel_version_number = self.split_dataset_string(kernel)
+        user_name, kernel_slug, kernel_version_number = self.parse_kernel_string(kernel)
+
 
         with self.build_kaggle_client() as kaggle:
             request = ApiListKernelFilesRequest()
@@ -4290,11 +4291,10 @@ class KaggleApi:
         if not slug and not id_no:
             raise ValueError("ID or slug must be specified in the metadata")
         if slug:
-            self.validate_kernel_string(slug)
-            if "/" in slug:
-                kernel_slug = slug.split("/")[1]
-            else:
-                kernel_slug = slug
+            owner, kernel_slug, version = self.parse_kernel_string(slug)
+            if version is not None:
+                raise ValueError("Kernel metadata 'id' (slug) cannot contain a version")
+
             if title:
                 as_slug = slugify(cast(str, title))
                 if kernel_slug.lower() != as_slug:
@@ -4456,14 +4456,8 @@ class KaggleApi:
                     else:
                         print("Using kernel " + kernel)
 
-        if "/" in kernel:
-            self.validate_kernel_string(kernel)
-            kernel_url_list = kernel.split("/")
-            owner_slug = kernel_url_list[0]
-            kernel_slug = kernel_url_list[1]
-        else:
-            owner_slug = self.get_config_value(self.CONFIG_NAME_USER)
-            kernel_slug = kernel
+        owner_slug, kernel_slug, version = self.parse_kernel_string(kernel)
+
 
         if path is None:
             effective_path = self.get_default_download_dir("kernels", owner_slug, kernel_slug)
@@ -4588,14 +4582,8 @@ class KaggleApi:
         """
         if kernel is None:
             raise ValueError("A kernel must be specified")
-        if "/" in kernel:
-            self.validate_kernel_string(kernel)
-            kernel_url_list = kernel.split("/")
-            owner_slug = kernel_url_list[0]
-            kernel_slug = kernel_url_list[1]
-        else:
-            owner_slug = cast(str, self.get_config_value(self.CONFIG_NAME_USER))
-            kernel_slug = kernel
+        owner_slug, kernel_slug, version = self.parse_kernel_string(kernel)
+
 
         if path is None:
             target_dir = self.get_default_download_dir("kernels", owner_slug, kernel_slug, "output")
@@ -4691,14 +4679,8 @@ class KaggleApi:
         """
         if kernel is None:
             raise ValueError("A kernel must be specified")
-        if "/" in kernel:
-            self.validate_kernel_string(kernel)
-            kernel_url_list = kernel.split("/")
-            owner_slug = kernel_url_list[0]
-            kernel_slug = kernel_url_list[1]
-        else:
-            owner_slug = self.get_config_value(self.CONFIG_NAME_USER)
-            kernel_slug = kernel
+        owner_slug, kernel_slug, version = self.parse_kernel_string(kernel)
+
         with self.build_kaggle_client() as kaggle:
             request = ApiGetKernelSessionStatusRequest()
             request.user_name = owner_slug
@@ -4744,14 +4726,8 @@ class KaggleApi:
         """
         if kernel is None:
             raise ValueError("A kernel must be specified")
-        if "/" in kernel:
-            self.validate_kernel_string(kernel)
-            kernel_url_list = kernel.split("/")
-            owner_slug = kernel_url_list[0]
-            kernel_slug = kernel_url_list[1]
-        else:
-            owner_slug = self.get_config_value(self.CONFIG_NAME_USER) or ""
-            kernel_slug = kernel
+        owner_slug, kernel_slug, version = self.parse_kernel_string(kernel)
+
 
         with self.build_kaggle_client() as kaggle:
             request = ApiListKernelSessionOutputRequest()
@@ -6510,7 +6486,8 @@ class KaggleApi:
     def validate_kernel_string(self, kernel: Optional[str]) -> None:
         """Validates a kernel string.
 
-        A kernel string is valid if it is in the format {username}/{kernel-slug}.
+        A kernel string is valid if it is in the format {username}/{kernel-slug}
+        or {username}/{kernel-slug}/{version}.
 
         Args:
             kernel (Optional[str]): The kernel name to validate.
@@ -6520,14 +6497,58 @@ class KaggleApi:
         """
         if kernel:
             if "/" not in kernel:
-                raise ValueError("Kernel must be specified in the form of " "'{username}/{kernel-slug}'")
+                raise ValueError(
+                    "Kernel must be specified in the form of "
+                    "'{username}/{kernel-slug}' or '{username}/{kernel-slug}/{version}'"
+                )
 
             split = kernel.split("/")
+            if len(split) > 3:
+                raise ValueError(
+                    "Kernel must be specified in the form of "
+                    "'{username}/{kernel-slug}' or '{username}/{kernel-slug}/{version}'"
+                )
+
             if not split[0] or not split[1]:
-                raise ValueError("Kernel must be specified in the form of " "'{username}/{kernel-slug}'")
+                raise ValueError(
+                    "Kernel must be specified in the form of "
+                    "'{username}/{kernel-slug}' or '{username}/{kernel-slug}/{version}'"
+                )
 
             if len(split[1]) < 5:
                 raise ValueError("Kernel slug must be at least five characters")
+
+            if len(split) == 3:
+                if not split[2]:
+                    raise ValueError("Kernel version cannot be empty if specified")
+                try:
+                    int(split[2])
+                except ValueError:
+                    raise ValueError("Kernel version must be an integer")
+
+    def parse_kernel_string(self, kernel: str) -> Tuple[str, str, Optional[str]]:
+        """Parses a kernel string.
+
+        Args:
+            kernel: The kernel string to parse. Can be 'slug', 'owner/slug', or 'owner/slug/version'.
+
+        Returns:
+            A tuple of (owner, slug, version).
+        """
+        if not kernel:
+            raise ValueError("A kernel must be specified")
+
+        if "/" in kernel:
+            self.validate_kernel_string(kernel)
+            parts = kernel.split("/")
+            owner = parts[0]
+            slug = parts[1]
+            version = parts[2] if len(parts) > 2 else None
+            return owner, slug, version
+        else:
+            owner = self.get_config_value(self.CONFIG_NAME_USER) or ""
+            return owner, kernel, None
+
 
     def validate_resources(
         self, folder: str, resources: List[Dict[str, Union[str, Dict[str, List[Dict[str, str]]]]]]

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -4468,7 +4468,8 @@ class KaggleApi:
         with self.build_kaggle_client() as kaggle:
             request = ApiGetKernelRequest()
             request.user_name = owner_slug
-            request.kernel_slug = kernel_slug
+            request.kernel_slug = f"{kernel_slug}/{version}" if version else kernel_slug
+
             response = kaggle.kernels.kernels_api_client.get_kernel(request)
 
         blob = response.blob

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -4159,7 +4159,6 @@ class KaggleApi:
             raise ValueError("A kernel must be specified")
         user_name, kernel_slug, kernel_version_number = self.parse_kernel_string(kernel)
 
-
         with self.build_kaggle_client() as kaggle:
             request = ApiListKernelFilesRequest()
             request.kernel_slug = kernel_slug
@@ -4458,7 +4457,6 @@ class KaggleApi:
 
         owner_slug, kernel_slug, version = self.parse_kernel_string(kernel)
 
-
         if path is None:
             effective_path = self.get_default_download_dir("kernels", owner_slug, kernel_slug)
         else:
@@ -4583,7 +4581,6 @@ class KaggleApi:
         if kernel is None:
             raise ValueError("A kernel must be specified")
         owner_slug, kernel_slug, version = self.parse_kernel_string(kernel)
-
 
         if path is None:
             target_dir = self.get_default_download_dir("kernels", owner_slug, kernel_slug, "output")
@@ -4727,7 +4724,6 @@ class KaggleApi:
         if kernel is None:
             raise ValueError("A kernel must be specified")
         owner_slug, kernel_slug, version = self.parse_kernel_string(kernel)
-
 
         with self.build_kaggle_client() as kaggle:
             request = ApiListKernelSessionOutputRequest()
@@ -6522,7 +6518,6 @@ class KaggleApi:
                 if not split[2]:
                     raise ValueError("Kernel version cannot be empty if specified")
 
-
     def parse_kernel_string(self, kernel: str) -> Tuple[str, str, Optional[str]]:
         """Parses a kernel string.
 
@@ -6545,7 +6540,6 @@ class KaggleApi:
         else:
             owner = self.get_config_value(self.CONFIG_NAME_USER) or ""
             return owner, kernel, None
-
 
     def validate_resources(
         self, folder: str, resources: List[Dict[str, Union[str, Dict[str, List[Dict[str, str]]]]]]

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -6521,10 +6521,7 @@ class KaggleApi:
             if len(split) == 3:
                 if not split[2]:
                     raise ValueError("Kernel version cannot be empty if specified")
-                try:
-                    int(split[2])
-                except ValueError:
-                    raise ValueError("Kernel version must be an integer")
+
 
     def parse_kernel_string(self, kernel: str) -> Tuple[str, str, Optional[str]]:
         """Parses a kernel string.

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -2147,7 +2147,10 @@ class Help(object):
     param_dataset_minsize = "Specify the minimum size of the dataset to return (bytes)"
 
     # Kernels params
-    param_kernel = 'Kernel URL suffix in format <owner>/<kernel-name> or <owner>/<kernel-name>/<version> (use "kaggle ' 'kernels list" to show options)'
+    param_kernel = (
+        'Kernel URL suffix in format <owner>/<kernel-name> or <owner>/<kernel-name>/<version> (use "kaggle '
+        'kernels list" to show options)'
+    )
 
     param_kernel_init = (
         "Create a metadata file for an existing kernel URL suffix in format "

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -2147,7 +2147,8 @@ class Help(object):
     param_dataset_minsize = "Specify the minimum size of the dataset to return (bytes)"
 
     # Kernels params
-    param_kernel = 'Kernel URL suffix in format <owner>/<kernel-name> (use "kaggle ' 'kernels list" to show options)'
+    param_kernel = 'Kernel URL suffix in format <owner>/<kernel-name> or <owner>/<kernel-name>/<version> (use "kaggle ' 'kernels list" to show options)'
+
     param_kernel_init = (
         "Create a metadata file for an existing kernel URL suffix in format "
         '<owner>/<kernel-name> (use "kaggle kernels list" to show options)'

--- a/tests/test_kernel_parsing.py
+++ b/tests/test_kernel_parsing.py
@@ -1,0 +1,78 @@
+# coding=utf-8
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, "../src")
+
+
+from kaggle.api.kaggle_api_extended import KaggleApi
+
+class TestKernelParsing(unittest.TestCase):
+
+    def setUp(self):
+        self.api = KaggleApi.__new__(KaggleApi)
+
+    def test_validate_kernel_string_valid(self):
+        # Valid formats
+        self.api.validate_kernel_string("owner/slug-name")
+        self.api.validate_kernel_string("owner/slug-name/1")
+        self.api.validate_kernel_string("owner/slug-name/123")
+
+    def test_validate_kernel_string_invalid_format(self):
+        # Invalid formats
+        with self.assertRaises(ValueError):
+            self.api.validate_kernel_string("noslash")
+        with self.assertRaises(ValueError):
+            self.api.validate_kernel_string("owner/slug/version/extra")
+        with self.assertRaises(ValueError):
+            self.api.validate_kernel_string("/slug")
+        with self.assertRaises(ValueError):
+            self.api.validate_kernel_string("owner/")
+        with self.assertRaises(ValueError):
+            self.api.validate_kernel_string("owner/slug/")
+
+    def test_validate_kernel_string_invalid_slug_length(self):
+        # Slug must be >= 5 chars
+        with self.assertRaises(ValueError):
+            self.api.validate_kernel_string("owner/slug") # slug is 4 chars
+        self.api.validate_kernel_string("owner/slug5") # slug is 5 chars
+
+    def test_validate_kernel_string_invalid_version(self):
+        # Version must be integer
+        with self.assertRaises(ValueError):
+            self.api.validate_kernel_string("owner/slug5/notanint")
+        with self.assertRaises(ValueError):
+            self.api.validate_kernel_string("owner/slug5/1.2")
+
+    def test_parse_kernel_string_three_parts(self):
+        owner, slug, version = self.api.parse_kernel_string("owner/slug-name/123")
+        self.assertEqual(owner, "owner")
+        self.assertEqual(slug, "slug-name")
+        self.assertEqual(version, "123")
+
+    def test_parse_kernel_string_two_parts(self):
+        owner, slug, version = self.api.parse_kernel_string("owner/slug-name")
+        self.assertEqual(owner, "owner")
+        self.assertEqual(slug, "slug-name")
+        self.assertEqual(version, None)
+
+    @patch.object(KaggleApi, "get_config_value")
+    def test_parse_kernel_string_one_part(self, mock_get_config):
+        mock_get_config.return_value = "default-owner"
+        owner, slug, version = self.api.parse_kernel_string("slug-name")
+        self.assertEqual(owner, "default-owner")
+        self.assertEqual(slug, "slug-name")
+        self.assertEqual(version, None)
+        mock_get_config.assert_called_once_with(KaggleApi.CONFIG_NAME_USER)
+
+    @patch.object(KaggleApi, "get_config_value")
+    def test_parse_kernel_string_one_part_no_config(self, mock_get_config):
+        mock_get_config.return_value = None
+        owner, slug, version = self.api.parse_kernel_string("slug-name")
+        self.assertEqual(owner, "")
+        self.assertEqual(slug, "slug-name")
+        self.assertEqual(version, None)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_parsing.py
+++ b/tests/test_kernel_parsing.py
@@ -8,6 +8,7 @@ sys.path.insert(0, "../src")
 
 from kaggle.api.kaggle_api_extended import KaggleApi
 
+
 class TestKernelParsing(unittest.TestCase):
 
     def setUp(self):
@@ -37,9 +38,8 @@ class TestKernelParsing(unittest.TestCase):
     def test_validate_kernel_string_invalid_slug_length(self):
         # Slug must be >= 5 chars
         with self.assertRaises(ValueError):
-            self.api.validate_kernel_string("owner/slug") # slug is 4 chars
-        self.api.validate_kernel_string("owner/slug5") # slug is 5 chars
-
+            self.api.validate_kernel_string("owner/slug")  # slug is 4 chars
+        self.api.validate_kernel_string("owner/slug5")  # slug is 5 chars
 
     def test_parse_kernel_string_three_parts(self):
         owner, slug, version = self.api.parse_kernel_string("owner/slug-name/123")
@@ -69,6 +69,7 @@ class TestKernelParsing(unittest.TestCase):
         self.assertEqual(owner, "")
         self.assertEqual(slug, "slug-name")
         self.assertEqual(version, None)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_kernel_parsing.py
+++ b/tests/test_kernel_parsing.py
@@ -18,6 +18,8 @@ class TestKernelParsing(unittest.TestCase):
         self.api.validate_kernel_string("owner/slug-name")
         self.api.validate_kernel_string("owner/slug-name/1")
         self.api.validate_kernel_string("owner/slug-name/123")
+        self.api.validate_kernel_string("owner/slug-name/notanint")
+        self.api.validate_kernel_string("owner/slug-name/1.2")
 
     def test_validate_kernel_string_invalid_format(self):
         # Invalid formats
@@ -38,12 +40,6 @@ class TestKernelParsing(unittest.TestCase):
             self.api.validate_kernel_string("owner/slug") # slug is 4 chars
         self.api.validate_kernel_string("owner/slug5") # slug is 5 chars
 
-    def test_validate_kernel_string_invalid_version(self):
-        # Version must be integer
-        with self.assertRaises(ValueError):
-            self.api.validate_kernel_string("owner/slug5/notanint")
-        with self.assertRaises(ValueError):
-            self.api.validate_kernel_string("owner/slug5/1.2")
 
     def test_parse_kernel_string_three_parts(self):
         owner, slug, version = self.api.parse_kernel_string("owner/slug-name/123")

--- a/tests/test_kernels_pull.py
+++ b/tests/test_kernels_pull.py
@@ -1,0 +1,139 @@
+# coding=utf-8
+import json
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock, mock_open
+
+sys.path.insert(0, "../src")
+
+from kaggle.api.kaggle_api_extended import KaggleApi
+
+class TestKernelsPull(unittest.TestCase):
+
+    def setUp(self):
+        self.api = KaggleApi.__new__(KaggleApi)
+        self.api.config_values = {"username": "testuser"}
+
+    @patch("os.path.exists", return_value=True)
+    @patch("os.path.isfile", return_value=False)
+    @patch("builtins.open", new_callable=mock_open)
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_kernels_pull_without_version(self, mock_client, mock_open_file, mock_isfile, mock_exists):
+        # Setup mocks
+        mock_kaggle = MagicMock()
+        mock_response = MagicMock()
+        mock_blob = MagicMock()
+        mock_blob.language = "python"
+        mock_blob.kernel_type = "script"
+        mock_blob.slug = "my-slug"
+        mock_blob.source = "print('hello')"
+        mock_response.blob = mock_blob
+        
+        mock_kaggle.kernels.kernels_api_client.get_kernel.return_value = mock_response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        # Call method
+        self.api.kernels_pull("owner/my-slug", path="/tmp/dummy")
+
+        # Verify request
+        call_args = mock_kaggle.kernels.kernels_api_client.get_kernel.call_args
+        request = call_args[0][0]
+        self.assertEqual(request.user_name, "owner")
+        self.assertEqual(request.kernel_slug, "my-slug")
+        
+        # Verify file write
+        mock_open_file.assert_called_once_with("/tmp/dummy/my-slug.py", "w", encoding="utf-8")
+        mock_open_file().write.assert_called_once_with("print('hello')")
+
+    @patch("os.path.exists", return_value=True)
+    @patch("os.path.isfile", return_value=False)
+    @patch("builtins.open", new_callable=mock_open)
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_kernels_pull_with_version(self, mock_client, mock_open_file, mock_isfile, mock_exists):
+        # Setup mocks
+        mock_kaggle = MagicMock()
+        mock_response = MagicMock()
+        mock_blob = MagicMock()
+        mock_blob.language = "python"
+        mock_blob.kernel_type = "script"
+        mock_blob.slug = "my-slug"
+        mock_blob.source = "print('hello')"
+        mock_response.blob = mock_blob
+        
+        mock_kaggle.kernels.kernels_api_client.get_kernel.return_value = mock_response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        # Call method with version
+        self.api.kernels_pull("owner/my-slug/3", path="/tmp/dummy")
+
+        # Verify request has version in slug
+        call_args = mock_kaggle.kernels.kernels_api_client.get_kernel.call_args
+        request = call_args[0][0]
+        self.assertEqual(request.user_name, "owner")
+        self.assertEqual(request.kernel_slug, "my-slug/3")
+        
+        # Verify file write (path should still use clean slug)
+        mock_open_file.assert_called_once_with("/tmp/dummy/my-slug.py", "w", encoding="utf-8")
+        mock_open_file().write.assert_called_once_with("print('hello')")
+
+    @patch("os.path.exists", return_value=True)
+    @patch("os.path.isfile", return_value=False)
+    @patch("builtins.open", new_callable=mock_open)
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_kernels_pull_with_metadata(self, mock_client, mock_open_file, mock_isfile, mock_exists):
+        # Setup mocks
+        mock_kaggle = MagicMock()
+        mock_response = MagicMock()
+        mock_blob = MagicMock()
+        mock_blob.language = "python"
+        mock_blob.kernel_type = "script"
+        mock_blob.slug = "my-slug"
+        mock_blob.source = "print('hello')"
+        mock_response.blob = mock_blob
+        
+        mock_metadata = MagicMock()
+        mock_metadata.ref = "owner/my-slug"
+        mock_metadata.id = 123
+        mock_metadata.title = "My Title"
+        mock_metadata.language = "python"
+        mock_metadata.kernel_type = "script"
+        mock_metadata.is_private = True
+        mock_metadata.enable_gpu = False
+        mock_metadata.enable_tpu = False
+        mock_metadata.enable_internet = True
+        mock_metadata.category_ids = []
+        mock_metadata.dataset_data_sources = []
+        mock_metadata.kernel_data_sources = []
+        mock_metadata.competition_data_sources = []
+        mock_metadata.model_data_sources = []
+        mock_metadata.docker_image = "some-image"
+        mock_metadata.machine_shape = "NvidiaTeslaT4"
+        mock_response.metadata = mock_metadata
+        
+        mock_kaggle.kernels.kernels_api_client.get_kernel.return_value = mock_response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        # Call method with metadata=True
+        self.api.kernels_pull("owner/my-slug/3", path="/tmp/dummy", metadata=True)
+
+        # Verify request has version in slug
+        call_args = mock_kaggle.kernels.kernels_api_client.get_kernel.call_args
+        request = call_args[0][0]
+        self.assertEqual(request.user_name, "owner")
+        self.assertEqual(request.kernel_slug, "my-slug/3")
+        
+        # Verify open was called twice (one for script, one for metadata)
+        self.assertEqual(mock_open_file.call_count, 2)
+        
+        # We can check the calls
+        # First call: script
+        mock_open_file.assert_any_call("/tmp/dummy/my-slug.py", "w", encoding="utf-8")
+        # Second call: metadata
+        mock_open_file.assert_any_call("/tmp/dummy/kernel-metadata.json", "w")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernels_pull.py
+++ b/tests/test_kernels_pull.py
@@ -9,6 +9,7 @@ sys.path.insert(0, "../src")
 
 from kaggle.api.kaggle_api_extended import KaggleApi
 
+
 class TestKernelsPull(unittest.TestCase):
 
     def setUp(self):
@@ -29,7 +30,7 @@ class TestKernelsPull(unittest.TestCase):
         mock_blob.slug = "my-slug"
         mock_blob.source = "print('hello')"
         mock_response.blob = mock_blob
-        
+
         mock_kaggle.kernels.kernels_api_client.get_kernel.return_value = mock_response
         mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
         mock_client.return_value.__exit__ = MagicMock(return_value=False)
@@ -42,7 +43,7 @@ class TestKernelsPull(unittest.TestCase):
         request = call_args[0][0]
         self.assertEqual(request.user_name, "owner")
         self.assertEqual(request.kernel_slug, "my-slug")
-        
+
         # Verify file write
         mock_open_file.assert_called_once_with("/tmp/dummy/my-slug.py", "w", encoding="utf-8")
         mock_open_file().write.assert_called_once_with("print('hello')")
@@ -61,7 +62,7 @@ class TestKernelsPull(unittest.TestCase):
         mock_blob.slug = "my-slug"
         mock_blob.source = "print('hello')"
         mock_response.blob = mock_blob
-        
+
         mock_kaggle.kernels.kernels_api_client.get_kernel.return_value = mock_response
         mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
         mock_client.return_value.__exit__ = MagicMock(return_value=False)
@@ -74,7 +75,7 @@ class TestKernelsPull(unittest.TestCase):
         request = call_args[0][0]
         self.assertEqual(request.user_name, "owner")
         self.assertEqual(request.kernel_slug, "my-slug/3")
-        
+
         # Verify file write (path should still use clean slug)
         mock_open_file.assert_called_once_with("/tmp/dummy/my-slug.py", "w", encoding="utf-8")
         mock_open_file().write.assert_called_once_with("print('hello')")
@@ -93,7 +94,7 @@ class TestKernelsPull(unittest.TestCase):
         mock_blob.slug = "my-slug"
         mock_blob.source = "print('hello')"
         mock_response.blob = mock_blob
-        
+
         mock_metadata = MagicMock()
         mock_metadata.ref = "owner/my-slug"
         mock_metadata.id = 123
@@ -112,7 +113,7 @@ class TestKernelsPull(unittest.TestCase):
         mock_metadata.docker_image = "some-image"
         mock_metadata.machine_shape = "NvidiaTeslaT4"
         mock_response.metadata = mock_metadata
-        
+
         mock_kaggle.kernels.kernels_api_client.get_kernel.return_value = mock_response
         mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
         mock_client.return_value.__exit__ = MagicMock(return_value=False)
@@ -125,15 +126,16 @@ class TestKernelsPull(unittest.TestCase):
         request = call_args[0][0]
         self.assertEqual(request.user_name, "owner")
         self.assertEqual(request.kernel_slug, "my-slug/3")
-        
+
         # Verify open was called twice (one for script, one for metadata)
         self.assertEqual(mock_open_file.call_count, 2)
-        
+
         # We can check the calls
         # First call: script
         mock_open_file.assert_any_call("/tmp/dummy/my-slug.py", "w", encoding="utf-8")
         # Second call: metadata
         mock_open_file.assert_any_call("/tmp/dummy/kernel-metadata.json", "w")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR refactors the kernel specifier parsing to support an optional version number and connects it to the `pull` command.

Currently, we use `<username>/<kernelslug>` to specify the kernel. This change allows `<username>/<kernelslug>/<version>` where the `/<version>` part is optional.

Changes:
- Updated `validate_kernel_string` to support the optional version (which can be any string).
- Added `parse_kernel_string` utility method to extract `owner`, `slug`, and `version`.
- Refactored `kernels_pull`, `kernels_output`, `kernels_status`, `kernels_logs`, and `kernels_list_files` to use the new utility.
- Connected the optional version to the `kernels_pull` command by passing `slug/version` to the API request if version is present.
- Disallowed version in `kernels_push` target slug.
- Updated help messages in `cli.py`.
- Added unit tests in `tests/test_kernel_parsing.py` and `tests/test_kernels_pull.py`.