### PR TITLE
Upsert keys in .env for benchmarks auth/init instead of appending

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "packaging",
     "protobuf",
     "jupytext",
+    "python-dotenv",
 ]
 
 [project.scripts]
@@ -97,7 +98,8 @@ module = [
     # TODO(b/505845982): Generate type hints for kagglesdk
     "kagglesdk.*",
     "kaggle_api_extended.*",
-    "jupytext.*"
+    "jupytext.*",
+    "dotenv.*"
 ]
 ignore_missing_imports = true
 

--- a/requirements.lock
+++ b/requirements.lock
@@ -50,6 +50,8 @@ protobuf==7.34.1
     #   kagglesdk
 python-dateutil==2.9.0.post0
     # via kaggle (pyproject.toml)
+python-dotenv==1.2.2
+    # via kaggle (pyproject.toml)
 python-slugify==8.0.4
     # via kaggle (pyproject.toml)
 pyyaml==6.0.3

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -7194,9 +7194,8 @@ class KaggleApi:
             if not self.confirmation(f"write these settings to {os.path.basename(env_file_abs)}", default_to_yes=True):
                 return False
 
-        # Upsert via python-dotenv so reruns refresh in place rather than
-        # stacking duplicate lines (python-dotenv reads the first occurrence,
-        # so appended copies would let the oldest expired token win).
+        # Upsert (not append): python-dotenv reads the first occurrence, so
+        # stacking duplicates would let an expired token shadow the fresh one.
         for key, value in env_vars.items():
             dotenv.set_key(env_file_abs, key, value, quote_mode="never")
 

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -7194,8 +7194,8 @@ class KaggleApi:
             if not self.confirmation(f"write these settings to {os.path.basename(env_file_abs)}", default_to_yes=True):
                 return False
 
-        # Upsert (not append): python-dotenv reads the first occurrence, so
-        # stacking duplicates would let an expired token shadow the fresh one.
+        # Upsert in place rather than append so reruns don't stack duplicates
+        # in the user's .env and don't silently shadow any hand-edited values.
         for key, value in env_vars.items():
             dotenv.set_key(env_file_abs, key, value, quote_mode="never")
 

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -7193,14 +7193,46 @@ class KaggleApi:
             if not self.confirmation(f"write these settings to {os.path.basename(env_file_abs)}", default_to_yes=True):
                 return False
 
-        with open(env_file_abs, "a") as f:
-            f.write("\n")
-            for key, value in env_vars.items():
-                f.write(f"{key}={value}\n")
+        self._upsert_env_file(env_file_abs, env_vars)
 
         if not quiet:
             print(f"Environment variables have been written to {env_file_abs}.")
         return True
+
+    # Matches ``KEY=`` at the start of an env-file line, allowing leading
+    # whitespace and an optional ``export`` prefix.
+    _ENV_LINE_RE = re.compile(r"^[ \t]*(?:export[ \t]+)?([A-Za-z_][A-Za-z0-9_]*)[ \t]*=")
+
+    @classmethod
+    def _upsert_env_file(cls, env_file_abs, env_vars):
+        """Upsert ``KEY=VALUE`` pairs into a .env file in place.
+
+        Existing lines whose key matches one in ``env_vars`` are replaced with
+        ``KEY=VALUE`` (dropping any ``export`` prefix and surrounding
+        whitespace). Keys not already present are appended at the end.
+        Comments, blank lines, and unrelated entries are preserved verbatim.
+        Creates the file if it does not exist.
+        """
+        remaining = dict(env_vars)
+        new_lines: list[str] = []
+        if os.path.exists(env_file_abs):
+            with open(env_file_abs, "r") as f:
+                existing = f.readlines()
+            for line in existing:
+                match = cls._ENV_LINE_RE.match(line)
+                if match and match.group(1) in remaining:
+                    key = match.group(1)
+                    value = remaining.pop(key)
+                    newline = "\n" if line.endswith("\n") else ""
+                    new_lines.append(f"{key}={value}{newline}")
+                else:
+                    new_lines.append(line)
+            if remaining and new_lines and not new_lines[-1].endswith("\n"):
+                new_lines[-1] = new_lines[-1] + "\n"
+        for key, value in remaining.items():
+            new_lines.append(f"{key}={value}\n")
+        with open(env_file_abs, "w") as f:
+            f.writelines(new_lines)
 
     @staticmethod
     def _format_expiry(iso_timestamp):

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -40,6 +40,7 @@ from os.path import expanduser
 from random import random
 
 import bleach
+import dotenv
 import mimetypes
 import requests
 import urllib3.exceptions as urllib3_exceptions
@@ -7193,46 +7194,15 @@ class KaggleApi:
             if not self.confirmation(f"write these settings to {os.path.basename(env_file_abs)}", default_to_yes=True):
                 return False
 
-        self._upsert_env_file(env_file_abs, env_vars)
+        # Upsert via python-dotenv so reruns refresh in place rather than
+        # stacking duplicate lines (python-dotenv reads the first occurrence,
+        # so appended copies would let the oldest expired token win).
+        for key, value in env_vars.items():
+            dotenv.set_key(env_file_abs, key, value, quote_mode="never")
 
         if not quiet:
             print(f"Environment variables have been written to {env_file_abs}.")
         return True
-
-    # Matches ``KEY=`` at the start of an env-file line, allowing leading
-    # whitespace and an optional ``export`` prefix.
-    _ENV_LINE_RE = re.compile(r"^[ \t]*(?:export[ \t]+)?([A-Za-z_][A-Za-z0-9_]*)[ \t]*=")
-
-    @classmethod
-    def _upsert_env_file(cls, env_file_abs, env_vars):
-        """Upsert ``KEY=VALUE`` pairs into a .env file in place.
-
-        Existing lines whose key matches one in ``env_vars`` are replaced with
-        ``KEY=VALUE`` (dropping any ``export`` prefix and surrounding
-        whitespace). Keys not already present are appended at the end.
-        Comments, blank lines, and unrelated entries are preserved verbatim.
-        Creates the file if it does not exist.
-        """
-        remaining = dict(env_vars)
-        new_lines: list[str] = []
-        if os.path.exists(env_file_abs):
-            with open(env_file_abs, "r") as f:
-                existing = f.readlines()
-            for line in existing:
-                match = cls._ENV_LINE_RE.match(line)
-                if match and match.group(1) in remaining:
-                    key = match.group(1)
-                    value = remaining.pop(key)
-                    newline = "\n" if line.endswith("\n") else ""
-                    new_lines.append(f"{key}={value}{newline}")
-                else:
-                    new_lines.append(line)
-            if remaining and new_lines and not new_lines[-1].endswith("\n"):
-                new_lines[-1] = new_lines[-1] + "\n"
-        for key, value in remaining.items():
-            new_lines.append(f"{key}={value}\n")
-        with open(env_file_abs, "w") as f:
-            f.writelines(new_lines)
 
     @staticmethod
     def _format_expiry(iso_timestamp):

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -2112,150 +2112,15 @@ class TestBenchmarksInit:
 
 
 # ============================================================
-# Upsert .env helper
+# Upsert behavior (auth/init reruns)
 # ============================================================
 
 
-class TestUpsertEnvFile:
-    """Tests for ``KaggleApi._upsert_env_file`` static helper."""
-
-    NEW_VARS = {
-        "MODEL_PROXY_URL": "https://mp.example.com",
-        "MODEL_PROXY_API_KEY": "kaggle-benchmarks:new-token",
-        "MODEL_PROXY_EXPIRY_TIME": "2026-05-29T12:00:00Z",
-    }
-
-    def test_creates_file_when_missing(self, tmp_path):
-        env_file = tmp_path / ".env"
-        KaggleApi._upsert_env_file(str(env_file), self.NEW_VARS)
-        content = env_file.read_text()
-        assert content == (
-            "MODEL_PROXY_URL=https://mp.example.com\n"
-            "MODEL_PROXY_API_KEY=kaggle-benchmarks:new-token\n"
-            "MODEL_PROXY_EXPIRY_TIME=2026-05-29T12:00:00Z\n"
-        )
-
-    def test_writes_to_empty_file(self, tmp_path):
-        env_file = tmp_path / ".env"
-        env_file.write_text("")
-        KaggleApi._upsert_env_file(str(env_file), self.NEW_VARS)
-        content = env_file.read_text()
-        for k, v in self.NEW_VARS.items():
-            assert f"{k}={v}\n" in content
-        assert content.count("MODEL_PROXY_URL=") == 1
-
-    def test_replaces_existing_keys_in_place(self, tmp_path):
-        env_file = tmp_path / ".env"
-        env_file.write_text(
-            "MODEL_PROXY_URL=https://old.example.com\n"
-            "MODEL_PROXY_API_KEY=old-token\n"
-            "MODEL_PROXY_EXPIRY_TIME=2020-01-01T00:00:00Z\n"
-        )
-        KaggleApi._upsert_env_file(str(env_file), self.NEW_VARS)
-        content = env_file.read_text()
-        lines = content.splitlines()
-        assert len(lines) == 3
-        assert lines[0] == "MODEL_PROXY_URL=https://mp.example.com"
-        assert lines[1] == "MODEL_PROXY_API_KEY=kaggle-benchmarks:new-token"
-        assert lines[2] == "MODEL_PROXY_EXPIRY_TIME=2026-05-29T12:00:00Z"
-        assert content.count("MODEL_PROXY_URL=") == 1
-        assert content.count("MODEL_PROXY_API_KEY=") == 1
-        assert "old.example.com" not in content
-        assert "old-token" not in content
-
-    def test_preserves_comments_blanks_and_unrelated_keys(self, tmp_path):
-        env_file = tmp_path / ".env"
-        original = (
-            "# top-level comment\n"
-            "\n"
-            "UNRELATED=keep-me\n"
-            "# inline comment for url\n"
-            "MODEL_PROXY_URL=https://old.example.com\n"
-            "\n"
-            "ANOTHER=also-keep\n"
-        )
-        env_file.write_text(original)
-        KaggleApi._upsert_env_file(str(env_file), self.NEW_VARS)
-        content = env_file.read_text()
-        # Comments and blank lines preserved.
-        assert "# top-level comment\n" in content
-        assert "# inline comment for url\n" in content
-        assert "\n\n" in content
-        # Unrelated keys preserved verbatim and in order.
-        assert "UNRELATED=keep-me\n" in content
-        assert "ANOTHER=also-keep\n" in content
-        # URL replaced in place (still appears before ANOTHER).
-        url_idx = content.index("MODEL_PROXY_URL=https://mp.example.com")
-        another_idx = content.index("ANOTHER=also-keep")
-        assert url_idx < another_idx
-        # New keys not previously present appended at the end.
-        api_idx = content.index("MODEL_PROXY_API_KEY=")
-        expiry_idx = content.index("MODEL_PROXY_EXPIRY_TIME=")
-        assert api_idx > another_idx
-        assert expiry_idx > another_idx
-
-    def test_recognises_export_prefix_and_whitespace(self, tmp_path):
-        env_file = tmp_path / ".env"
-        env_file.write_text(
-            "  export MODEL_PROXY_URL=https://old.example.com\n" "\texport  MODEL_PROXY_API_KEY=old-token\n"
-        )
-        KaggleApi._upsert_env_file(str(env_file), self.NEW_VARS)
-        content = env_file.read_text()
-        assert "old.example.com" not in content
-        assert "old-token" not in content
-        assert "MODEL_PROXY_URL=https://mp.example.com\n" in content
-        assert "MODEL_PROXY_API_KEY=kaggle-benchmarks:new-token\n" in content
-        assert content.count("MODEL_PROXY_URL=") == 1
-        assert content.count("MODEL_PROXY_API_KEY=") == 1
-
-    def test_handles_file_without_trailing_newline(self, tmp_path):
-        env_file = tmp_path / ".env"
-        env_file.write_text("UNRELATED=keep")  # no trailing newline
-        KaggleApi._upsert_env_file(str(env_file), self.NEW_VARS)
-        content = env_file.read_text()
-        lines = content.splitlines()
-        # The unrelated line should not have been concatenated with a new key.
-        assert lines[0] == "UNRELATED=keep"
-        assert "MODEL_PROXY_URL=https://mp.example.com" in lines
-        # And the file should end with a newline.
-        assert content.endswith("\n")
-        # No duplicate key lines.
-        assert content.count("MODEL_PROXY_URL=") == 1
-
-    def test_does_not_match_keys_inside_other_lines(self, tmp_path):
-        env_file = tmp_path / ".env"
-        env_file.write_text("# MODEL_PROXY_URL=should-not-be-touched\n" "NOT_MODEL_PROXY_URL=keep\n")
-        KaggleApi._upsert_env_file(str(env_file), self.NEW_VARS)
-        content = env_file.read_text()
-        assert "# MODEL_PROXY_URL=should-not-be-touched\n" in content
-        assert "NOT_MODEL_PROXY_URL=keep\n" in content
-        # New key appended at the end.
-        assert content.rstrip().endswith("MODEL_PROXY_EXPIRY_TIME=2026-05-29T12:00:00Z")
-
-    def test_idempotent_when_rerun_with_same_values(self, tmp_path):
-        env_file = tmp_path / ".env"
-        KaggleApi._upsert_env_file(str(env_file), self.NEW_VARS)
-        first = env_file.read_text()
-        KaggleApi._upsert_env_file(str(env_file), self.NEW_VARS)
-        second = env_file.read_text()
-        assert first == second
-
-
-class TestBenchmarksAuthUpsertIntegration:
-    """End-to-end checks that ``kaggle benchmarks auth`` upserts rather than appends."""
-
-    def test_rerunning_auth_replaces_existing_keys(self, api, mock_token, tmp_path):
-        env_file = tmp_path / ".env"
-        api.benchmarks_auth_cli(no_confirm=True, env_file=str(env_file))
-        first = env_file.read_text()
-        api.benchmarks_auth_cli(no_confirm=True, env_file=str(env_file))
-        second = env_file.read_text()
-        # Same token response, so the file should be byte-stable across reruns.
-        assert first == second
-        # Exactly one occurrence of each managed key.
-        assert second.count("MODEL_PROXY_URL=") == 1
-        assert second.count("MODEL_PROXY_API_KEY=") == 1
-        assert second.count("MODEL_PROXY_EXPIRY_TIME=") == 1
+class TestBenchmarksUpsert:
+    """End-to-end checks that ``kaggle benchmarks auth/init`` upserts the
+    managed keys rather than appending duplicates. The line-by-line upsert
+    semantics are owned by ``python-dotenv``; these tests only verify wiring
+    and the user-facing contract."""
 
     def test_rerun_with_new_token_replaces_stale_value(self, api, tmp_path):
         # First run: original token.
@@ -2278,7 +2143,7 @@ class TestBenchmarksAuthUpsertIntegration:
 
     def test_preserves_user_added_keys_and_comments(self, api, mock_token, tmp_path):
         env_file = tmp_path / ".env"
-        env_file.write_text("# my notes\n" "MY_SECRET=hunter2\n" "MODEL_PROXY_URL=https://stale.example.com\n")
+        env_file.write_text("# my notes\nMY_SECRET=hunter2\nMODEL_PROXY_URL=https://stale.example.com\n")
         api.benchmarks_auth_cli(no_confirm=True, env_file=str(env_file))
         content = env_file.read_text()
         assert "# my notes\n" in content

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -2197,8 +2197,7 @@ class TestUpsertEnvFile:
     def test_recognises_export_prefix_and_whitespace(self, tmp_path):
         env_file = tmp_path / ".env"
         env_file.write_text(
-            "  export MODEL_PROXY_URL=https://old.example.com\n"
-            "\texport  MODEL_PROXY_API_KEY=old-token\n"
+            "  export MODEL_PROXY_URL=https://old.example.com\n" "\texport  MODEL_PROXY_API_KEY=old-token\n"
         )
         KaggleApi._upsert_env_file(str(env_file), self.NEW_VARS)
         content = env_file.read_text()
@@ -2225,10 +2224,7 @@ class TestUpsertEnvFile:
 
     def test_does_not_match_keys_inside_other_lines(self, tmp_path):
         env_file = tmp_path / ".env"
-        env_file.write_text(
-            "# MODEL_PROXY_URL=should-not-be-touched\n"
-            "NOT_MODEL_PROXY_URL=keep\n"
-        )
+        env_file.write_text("# MODEL_PROXY_URL=should-not-be-touched\n" "NOT_MODEL_PROXY_URL=keep\n")
         KaggleApi._upsert_env_file(str(env_file), self.NEW_VARS)
         content = env_file.read_text()
         assert "# MODEL_PROXY_URL=should-not-be-touched\n" in content
@@ -2282,11 +2278,7 @@ class TestBenchmarksAuthUpsertIntegration:
 
     def test_preserves_user_added_keys_and_comments(self, api, mock_token, tmp_path):
         env_file = tmp_path / ".env"
-        env_file.write_text(
-            "# my notes\n"
-            "MY_SECRET=hunter2\n"
-            "MODEL_PROXY_URL=https://stale.example.com\n"
-        )
+        env_file.write_text("# my notes\n" "MY_SECRET=hunter2\n" "MODEL_PROXY_URL=https://stale.example.com\n")
         api.benchmarks_auth_cli(no_confirm=True, env_file=str(env_file))
         content = env_file.read_text()
         assert "# my notes\n" in content

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -2112,6 +2112,208 @@ class TestBenchmarksInit:
 
 
 # ============================================================
+# Upsert .env helper
+# ============================================================
+
+
+class TestUpsertEnvFile:
+    """Tests for ``KaggleApi._upsert_env_file`` static helper."""
+
+    NEW_VARS = {
+        "MODEL_PROXY_URL": "https://mp.example.com",
+        "MODEL_PROXY_API_KEY": "kaggle-benchmarks:new-token",
+        "MODEL_PROXY_EXPIRY_TIME": "2026-05-29T12:00:00Z",
+    }
+
+    def test_creates_file_when_missing(self, tmp_path):
+        env_file = tmp_path / ".env"
+        KaggleApi._upsert_env_file(str(env_file), self.NEW_VARS)
+        content = env_file.read_text()
+        assert content == (
+            "MODEL_PROXY_URL=https://mp.example.com\n"
+            "MODEL_PROXY_API_KEY=kaggle-benchmarks:new-token\n"
+            "MODEL_PROXY_EXPIRY_TIME=2026-05-29T12:00:00Z\n"
+        )
+
+    def test_writes_to_empty_file(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("")
+        KaggleApi._upsert_env_file(str(env_file), self.NEW_VARS)
+        content = env_file.read_text()
+        for k, v in self.NEW_VARS.items():
+            assert f"{k}={v}\n" in content
+        assert content.count("MODEL_PROXY_URL=") == 1
+
+    def test_replaces_existing_keys_in_place(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "MODEL_PROXY_URL=https://old.example.com\n"
+            "MODEL_PROXY_API_KEY=old-token\n"
+            "MODEL_PROXY_EXPIRY_TIME=2020-01-01T00:00:00Z\n"
+        )
+        KaggleApi._upsert_env_file(str(env_file), self.NEW_VARS)
+        content = env_file.read_text()
+        lines = content.splitlines()
+        assert len(lines) == 3
+        assert lines[0] == "MODEL_PROXY_URL=https://mp.example.com"
+        assert lines[1] == "MODEL_PROXY_API_KEY=kaggle-benchmarks:new-token"
+        assert lines[2] == "MODEL_PROXY_EXPIRY_TIME=2026-05-29T12:00:00Z"
+        assert content.count("MODEL_PROXY_URL=") == 1
+        assert content.count("MODEL_PROXY_API_KEY=") == 1
+        assert "old.example.com" not in content
+        assert "old-token" not in content
+
+    def test_preserves_comments_blanks_and_unrelated_keys(self, tmp_path):
+        env_file = tmp_path / ".env"
+        original = (
+            "# top-level comment\n"
+            "\n"
+            "UNRELATED=keep-me\n"
+            "# inline comment for url\n"
+            "MODEL_PROXY_URL=https://old.example.com\n"
+            "\n"
+            "ANOTHER=also-keep\n"
+        )
+        env_file.write_text(original)
+        KaggleApi._upsert_env_file(str(env_file), self.NEW_VARS)
+        content = env_file.read_text()
+        # Comments and blank lines preserved.
+        assert "# top-level comment\n" in content
+        assert "# inline comment for url\n" in content
+        assert "\n\n" in content
+        # Unrelated keys preserved verbatim and in order.
+        assert "UNRELATED=keep-me\n" in content
+        assert "ANOTHER=also-keep\n" in content
+        # URL replaced in place (still appears before ANOTHER).
+        url_idx = content.index("MODEL_PROXY_URL=https://mp.example.com")
+        another_idx = content.index("ANOTHER=also-keep")
+        assert url_idx < another_idx
+        # New keys not previously present appended at the end.
+        api_idx = content.index("MODEL_PROXY_API_KEY=")
+        expiry_idx = content.index("MODEL_PROXY_EXPIRY_TIME=")
+        assert api_idx > another_idx
+        assert expiry_idx > another_idx
+
+    def test_recognises_export_prefix_and_whitespace(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "  export MODEL_PROXY_URL=https://old.example.com\n"
+            "\texport  MODEL_PROXY_API_KEY=old-token\n"
+        )
+        KaggleApi._upsert_env_file(str(env_file), self.NEW_VARS)
+        content = env_file.read_text()
+        assert "old.example.com" not in content
+        assert "old-token" not in content
+        assert "MODEL_PROXY_URL=https://mp.example.com\n" in content
+        assert "MODEL_PROXY_API_KEY=kaggle-benchmarks:new-token\n" in content
+        assert content.count("MODEL_PROXY_URL=") == 1
+        assert content.count("MODEL_PROXY_API_KEY=") == 1
+
+    def test_handles_file_without_trailing_newline(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("UNRELATED=keep")  # no trailing newline
+        KaggleApi._upsert_env_file(str(env_file), self.NEW_VARS)
+        content = env_file.read_text()
+        lines = content.splitlines()
+        # The unrelated line should not have been concatenated with a new key.
+        assert lines[0] == "UNRELATED=keep"
+        assert "MODEL_PROXY_URL=https://mp.example.com" in lines
+        # And the file should end with a newline.
+        assert content.endswith("\n")
+        # No duplicate key lines.
+        assert content.count("MODEL_PROXY_URL=") == 1
+
+    def test_does_not_match_keys_inside_other_lines(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "# MODEL_PROXY_URL=should-not-be-touched\n"
+            "NOT_MODEL_PROXY_URL=keep\n"
+        )
+        KaggleApi._upsert_env_file(str(env_file), self.NEW_VARS)
+        content = env_file.read_text()
+        assert "# MODEL_PROXY_URL=should-not-be-touched\n" in content
+        assert "NOT_MODEL_PROXY_URL=keep\n" in content
+        # New key appended at the end.
+        assert content.rstrip().endswith("MODEL_PROXY_EXPIRY_TIME=2026-05-29T12:00:00Z")
+
+    def test_idempotent_when_rerun_with_same_values(self, tmp_path):
+        env_file = tmp_path / ".env"
+        KaggleApi._upsert_env_file(str(env_file), self.NEW_VARS)
+        first = env_file.read_text()
+        KaggleApi._upsert_env_file(str(env_file), self.NEW_VARS)
+        second = env_file.read_text()
+        assert first == second
+
+
+class TestBenchmarksAuthUpsertIntegration:
+    """End-to-end checks that ``kaggle benchmarks auth`` upserts rather than appends."""
+
+    def test_rerunning_auth_replaces_existing_keys(self, api, mock_token, tmp_path):
+        env_file = tmp_path / ".env"
+        api.benchmarks_auth_cli(no_confirm=True, env_file=str(env_file))
+        first = env_file.read_text()
+        api.benchmarks_auth_cli(no_confirm=True, env_file=str(env_file))
+        second = env_file.read_text()
+        # Same token response, so the file should be byte-stable across reruns.
+        assert first == second
+        # Exactly one occurrence of each managed key.
+        assert second.count("MODEL_PROXY_URL=") == 1
+        assert second.count("MODEL_PROXY_API_KEY=") == 1
+        assert second.count("MODEL_PROXY_EXPIRY_TIME=") == 1
+
+    def test_rerun_with_new_token_replaces_stale_value(self, api, tmp_path):
+        # First run: original token.
+        api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.return_value = (
+            _make_token_response(token="kaggle-benchmarks:first")
+        )
+        env_file = tmp_path / ".env"
+        api.benchmarks_auth_cli(no_confirm=True, env_file=str(env_file))
+
+        # Second run: refreshed token.
+        api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.return_value = (
+            _make_token_response(token="kaggle-benchmarks:second")
+        )
+        api.benchmarks_auth_cli(no_confirm=True, env_file=str(env_file))
+
+        content = env_file.read_text()
+        assert "MODEL_PROXY_API_KEY=kaggle-benchmarks:second\n" in content
+        assert "kaggle-benchmarks:first" not in content
+        assert content.count("MODEL_PROXY_API_KEY=") == 1
+
+    def test_preserves_user_added_keys_and_comments(self, api, mock_token, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "# my notes\n"
+            "MY_SECRET=hunter2\n"
+            "MODEL_PROXY_URL=https://stale.example.com\n"
+        )
+        api.benchmarks_auth_cli(no_confirm=True, env_file=str(env_file))
+        content = env_file.read_text()
+        assert "# my notes\n" in content
+        assert "MY_SECRET=hunter2\n" in content
+        assert "stale.example.com" not in content
+        assert content.count("MODEL_PROXY_URL=") == 1
+
+    def test_init_rerun_is_idempotent(self, api, mock_token, tmp_path):
+        env_file = str(tmp_path / ".env")
+        example_file = str(tmp_path / "example_task.py")
+        api.benchmarks_init_cli(no_confirm=True, env_file=env_file, example_file=example_file)
+        first = (tmp_path / ".env").read_text()
+        api.benchmarks_init_cli(no_confirm=True, env_file=env_file, example_file=example_file)
+        second = (tmp_path / ".env").read_text()
+        assert first == second
+        for key in (
+            "MODEL_PROXY_URL=",
+            "MODEL_PROXY_API_KEY=",
+            "MODEL_PROXY_EXPIRY_TIME=",
+            "LLM_DEFAULT=",
+            "LLM_DEFAULT_EVAL=",
+            "LLMS_AVAILABLE=",
+        ):
+            assert second.count(key) == 1
+
+
+# ============================================================
 # Expiry Formatting
 # ============================================================
 

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -2151,6 +2151,35 @@ class TestBenchmarksUpsert:
         assert "stale.example.com" not in content
         assert content.count("MODEL_PROXY_URL=") == 1
 
+    def test_first_rerun_after_upgrade_refreshes_stale_duplicates(self, api, tmp_path):
+        """Migration scenario: a user who ran the old append-based CLI ends up
+        with several stacked ``MODEL_PROXY_API_KEY=`` lines in their ``.env``,
+        and ``python-dotenv`` was picking the first (oldest) one. The first
+        rerun on the new code must refresh every duplicate to the fresh
+        token so the value the SDK loads is the live one."""
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "MODEL_PROXY_API_KEY=expired-oldest\n"
+            "OTHER=keep\n"
+            "MODEL_PROXY_API_KEY=expired-middle\n"
+            "MODEL_PROXY_API_KEY=expired-newest\n"
+        )
+        api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.return_value = (
+            _make_token_response(token="kaggle-benchmarks:fresh")
+        )
+        api.benchmarks_auth_cli(no_confirm=True, env_file=str(env_file))
+
+        content = env_file.read_text()
+        # No stale value of any vintage survives.
+        for stale in ("expired-oldest", "expired-middle", "expired-newest"):
+            assert stale not in content
+        # And what dotenv loads (the first occurrence) is the fresh token.
+        from dotenv import dotenv_values
+
+        assert dotenv_values(str(env_file))["MODEL_PROXY_API_KEY"] == "kaggle-benchmarks:fresh"
+        # Unrelated keys remain untouched.
+        assert "OTHER=keep\n" in content
+
     def test_init_rerun_is_idempotent(self, api, mock_token, tmp_path):
         env_file = str(tmp_path / ".env")
         example_file = str(tmp_path / "example_task.py")

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -2153,16 +2153,15 @@ class TestBenchmarksUpsert:
 
     def test_first_rerun_after_upgrade_refreshes_stale_duplicates(self, api, tmp_path):
         """Migration scenario: a user who ran the old append-based CLI ends up
-        with several stacked ``MODEL_PROXY_API_KEY=`` lines in their ``.env``,
-        and ``python-dotenv`` was picking the first (oldest) one. The first
-        rerun on the new code must refresh every duplicate to the fresh
-        token so the value the SDK loads is the live one."""
+        with several stacked ``MODEL_PROXY_API_KEY=`` lines in their ``.env``.
+        The first rerun on the new code must rewrite every duplicate to the
+        fresh value so no stale token lingers in the file."""
         env_file = tmp_path / ".env"
         env_file.write_text(
-            "MODEL_PROXY_API_KEY=expired-oldest\n"
+            "MODEL_PROXY_API_KEY=stale-1\n"
             "OTHER=keep\n"
-            "MODEL_PROXY_API_KEY=expired-middle\n"
-            "MODEL_PROXY_API_KEY=expired-newest\n"
+            "MODEL_PROXY_API_KEY=stale-2\n"
+            "MODEL_PROXY_API_KEY=stale-3\n"
         )
         api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.return_value = (
             _make_token_response(token="kaggle-benchmarks:fresh")
@@ -2170,14 +2169,11 @@ class TestBenchmarksUpsert:
         api.benchmarks_auth_cli(no_confirm=True, env_file=str(env_file))
 
         content = env_file.read_text()
-        # No stale value of any vintage survives.
-        for stale in ("expired-oldest", "expired-middle", "expired-newest"):
+        for stale in ("stale-1", "stale-2", "stale-3"):
             assert stale not in content
-        # And what dotenv loads (the first occurrence) is the fresh token.
         from dotenv import dotenv_values
 
         assert dotenv_values(str(env_file))["MODEL_PROXY_API_KEY"] == "kaggle-benchmarks:fresh"
-        # Unrelated keys remain untouched.
         assert "OTHER=keep\n" in content
 
     def test_init_rerun_is_idempotent(self, api, mock_token, tmp_path):


### PR DESCRIPTION
`kaggle b auth` and `kaggle b init` opened `.env` in append mode, so
every rerun stacked a fresh copy of `MODEL_PROXY_*` (and `LLM_*`)
onto the bottom of the file. Two problems: the user's `.env` grew
without bound, and any value the user had hand-edited got silently
overridden by the appended copy below it (python-dotenv reads the
last occurrence). Switch to `dotenv.set_key(..., quote_mode="never")`
so each managed key is refreshed in place, preserving comments, blank
lines, and unrelated keys.

Migration note: users with stacked duplicates from prior runs keep
those lines, but `set_key` rewrites every occurrence to the fresh
value, so no stale token lingers in the file after the first rerun
on this code.

---

Task: [limagoog-20260529183140-af82f3a6](https://agents.dev.kaggle.net/tasks/limagoog-20260529183140-af82f3a6)
Context: https://chat.kaggle.net/kaggle/pl/46qfted3gbyqdkcpt447cusich

