### PR TITLE
Fix(benchmarks): hint when cached download lacks source notebooks

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -344,6 +344,14 @@ Already-downloaded runs (where the output directory exists) are automatically sk
 
 When `--include-source` is used, the downloaded zip also contains the kernel session's source files (e.g., `__notebook__.ipynb` and `__notebook_source__.ipynb`).
 
+If you re-run with `-s` after a previous download that omitted source notebooks, the cached directories are not re-fetched and the `-s` flag is effectively ignored. The CLI detects this and prints a tip after the summary:
+
+```
+Tip: 2 cached run(s) lack source notebooks. Re-run with -f -s to fetch them.
+```
+
+Use `-f -s` together to force re-download and backfill the source notebooks into the cached runs.
+
 ---
 
 ### `kaggle benchmarks tasks log`

--- a/skills/references/benchmarks.md
+++ b/skills/references/benchmarks.md
@@ -257,6 +257,7 @@ kaggle b t download my-task --include-source
 - Progress is rendered as a table with `Model | File | Size | Progress` columns. `Size` is the extracted on-disk size of the run's output directory.
 - Already-downloaded runs are skipped (use `--force` to re-download) and shown as a `Cached` row in the table
 - Corrupt zips show as a `Bad zip` row; the raw `.zip` is kept on disk and the next run is processed
+- If `-s` is passed but a cached run's directory lacks source notebooks (`__notebook__.ipynb` / `__notebook_source__.ipynb`), the cached row is left untouched and a tip is printed after the summary: `Tip: N cached run(s) lack source notebooks. Re-run with -f -s to fetch them.` — use `-f -s` together to backfill source notebooks into existing cached runs.
 - No downloadable runs (all still in progress): `No downloadable runs yet — N run(s) still in progress. Use 'kaggle b t status my-task' to check progress.`
 - No runs at all: `No runs found for task 'my-task'. Use 'kaggle b t run my-task' to start one.`
 

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -7581,7 +7581,7 @@ class KaggleApi:
                 outdir = os.path.join(output, task, version, slug, str(r.id))
                 row_prefix = f"{slug:<{model_col}} {display_file:<{file_col}}"
 
-                if os.path.isdir(outdir) and not force:
+                if os.path.isdir(outdir) and os.listdir(outdir) and not force:
                     size_str = self._format_size(self._dir_size(outdir))
                     print(f"{row_prefix} {size_str:<{size_col}} {'Cached':<{prog_col}}")
                     cached += 1

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -7574,7 +7574,7 @@ class KaggleApi:
             print(f"{'Model':<{model_col}} {'File':<{file_col}} {'Size':<{size_col}} {'Progress':<{prog_col}}")
             print(f"{'─' * model_col} {'─' * file_col} {'─' * size_col} {'─' * prog_col}")
 
-            downloaded, cached = 0, 0
+            downloaded, cached, cached_without_source = 0, 0, 0
             for r, display_file in zip(downloadable, display_files):
                 slug = self._normalize_model_slug(r.model_version_slug)
                 # Hierarchical layout: {output}/{task}/{version}/{model}/{run_id}/
@@ -7585,6 +7585,14 @@ class KaggleApi:
                     size_str = self._format_size(self._dir_size(outdir))
                     print(f"{row_prefix} {size_str:<{size_col}} {'Cached':<{prog_col}}")
                     cached += 1
+                    # If the caller asked for source notebooks with -s but the cached dir
+                    # was built without them, count it so we can emit a tip at the end.
+                    # Skip detection requires --force to re-download.
+                    if include_source and not any(
+                        os.path.exists(os.path.join(outdir, n))
+                        for n in ("__notebook__.ipynb", "__notebook_source__.ipynb")
+                    ):
+                        cached_without_source += 1
                     continue
 
                 dl_request = ApiDownloadBenchmarkTaskRunOutputRequest()
@@ -7632,6 +7640,15 @@ class KaggleApi:
 
             parts = [f"{n} run(s) {label}" for n, label in ((downloaded, "downloaded"), (cached, "cached")) if n]
             print(f"\nDone: {', '.join(parts) or '0 runs downloaded'}.")
+
+            # Tip: -s alone won't backfill source notebooks into already-cached dirs.
+            # The check that gates re-download (os.path.isdir(outdir)) doesn't peek inside,
+            # so the cached row stays untouched even though it lacks the requested files.
+            if cached_without_source:
+                print(
+                    f"\nTip: {cached_without_source} cached run(s) lack source notebooks. "
+                    f"Re-run with -f -s to fetch them."
+                )
 
     @staticmethod
     def _format_size(n) -> str:

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -1216,7 +1216,7 @@ class TestDownload:
         output = capsys.readouterr().out
 
         assert "Cached" in output
-        assert "1 cached run(s) lack source notebooks" in output or "lack source notebooks" in output
+        assert "1 cached run(s) lack source notebooks" in output
         assert "-f -s" in output
         # Without -f, the cached dir was not touched: no download API call
         api._mock_benchmarks.download_benchmark_task_run_output.assert_not_called()

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -1184,9 +1184,11 @@ class TestDownload:
         _setup_runs_response(api, [_make_run(run_id=42)])
         self._mock_download(api)
         outdir = str(tmp_path / "out")
-        # Pre-create the output directory to simulate a previous download
+        # Pre-create the output directory with a file to simulate a previous download
         existing = os.path.join(outdir, "my-task", "1", "gemini-pro", "42")
         os.makedirs(existing)
+        with open(os.path.join(existing, "result.run.json"), "w") as f:
+            f.write("{}")
 
         api.benchmarks_tasks_download_cli("my-task", output=outdir)
 
@@ -1199,6 +1201,23 @@ class TestDownload:
         assert "/42/42.zip" not in output
         # No download API call should have been made
         api._mock_benchmarks.download_benchmark_task_run_output.assert_not_called()
+
+    def test_download_re_fetches_empty_existing_dir(self, api, capsys, tmp_path):
+        """An empty leftover output directory should not count as cached; re-download instead."""
+        _setup_runs_response(api, [_make_run(run_id=42)])
+        self._mock_download(api)
+        outdir = str(tmp_path / "out")
+        # Empty leftover dir from a prior interrupted run
+        existing = os.path.join(outdir, "my-task", "1", "gemini-pro", "42")
+        os.makedirs(existing)
+
+        with patch("zipfile.ZipFile"), patch("os.remove"), patch("os.rename"):
+            api.benchmarks_tasks_download_cli("my-task", output=outdir)
+
+        output = capsys.readouterr().out
+        assert "Cached" not in output
+        # The empty dir triggers a fresh download
+        api._mock_benchmarks.download_benchmark_task_run_output.assert_called_once()
 
     def test_download_cached_dir_without_source_prints_tip_when_s_passed(self, api, capsys, tmp_path):
         """When -s is passed but the cached dir lacks source notebooks, hint that -f -s is needed."""
@@ -1246,9 +1265,11 @@ class TestDownload:
         )
         self._mock_download(api)
         outdir = str(tmp_path / "out")
-        # Pre-create only run 2 to simulate a previous download
+        # Pre-create only run 2 with a file to simulate a previous download
         existing = os.path.join(outdir, "my-task", "1", "old-model", "2")
         os.makedirs(existing)
+        with open(os.path.join(existing, "result.run.json"), "w") as f:
+            f.write("{}")
 
         with patch("zipfile.ZipFile"), patch("os.remove"), patch("os.rename"):
             api.benchmarks_tasks_download_cli("my-task", output=outdir)

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -1200,6 +1200,44 @@ class TestDownload:
         # No download API call should have been made
         api._mock_benchmarks.download_benchmark_task_run_output.assert_not_called()
 
+    def test_download_cached_dir_without_source_prints_tip_when_s_passed(self, api, capsys, tmp_path):
+        """When -s is passed but the cached dir lacks source notebooks, hint that -f -s is needed."""
+        _setup_runs_response(api, [_make_run(run_id=42)])
+        self._mock_download(api)
+        outdir = str(tmp_path / "out")
+        # Cached dir exists but has no __notebook__.ipynb / __notebook_source__.ipynb
+        existing = os.path.join(outdir, "my-task", "1", "gemini-pro", "42")
+        os.makedirs(existing)
+        # Drop a placeholder file so the dir isn't empty, but not a source notebook
+        with open(os.path.join(existing, "result.run.json"), "w") as f:
+            f.write("{}")
+
+        api.benchmarks_tasks_download_cli("my-task", output=outdir, include_source=True)
+        output = capsys.readouterr().out
+
+        assert "Cached" in output
+        assert "1 cached run(s) lack source notebooks" in output or "lack source notebooks" in output
+        assert "-f -s" in output
+        # Without -f, the cached dir was not touched: no download API call
+        api._mock_benchmarks.download_benchmark_task_run_output.assert_not_called()
+
+    def test_download_cached_dir_with_source_does_not_print_tip(self, api, capsys, tmp_path):
+        """When the cached dir already contains source notebooks, no tip is shown."""
+        _setup_runs_response(api, [_make_run(run_id=42)])
+        self._mock_download(api)
+        outdir = str(tmp_path / "out")
+        existing = os.path.join(outdir, "my-task", "1", "gemini-pro", "42")
+        os.makedirs(existing)
+        # Simulate a previous -s download by dropping the source notebook
+        with open(os.path.join(existing, "__notebook__.ipynb"), "w") as f:
+            f.write("{}")
+
+        api.benchmarks_tasks_download_cli("my-task", output=outdir, include_source=True)
+        output = capsys.readouterr().out
+
+        assert "Cached" in output
+        assert "lack source notebooks" not in output
+
     def test_download_summary_counts(self, api, capsys, tmp_path):
         """Download summary shows correct downloaded and cached counts."""
         _setup_runs_response(


### PR DESCRIPTION
  ## Summary

  If you've previously run `kaggle b t download <task>` **without** `-s` and
  later realize you want the source notebooks, running the command again with
  `-s` silently does nothing — the cached output directory already exists, so
  the loop short-circuits before the `-s` flag is ever forwarded to the
  download API. You have to discover on your own that `-f -s` is needed to
  backfill.

  This adds a one-line tip after the summary when:
  - the user passed `-s` (`--include-source`), **and**
  - the cached directory exists but lacks `__notebook__.ipynb` /
    `__notebook_source__.ipynb`.

  ## Before / After

  **Before** (`-s` on an already-cached run silently does nothing):
  ```
  $ kaggle b t download hello -s
  ... gemini-3-flash-preview/291356/   2.40KB     Cached
  Done: 1 run(s) cached.

  $ ls hello/3/gemini-3-flash-preview/291356/
  hello.task.json  *.run.json                       # no source notebook!
  ```

  **After** (tip points to the workaround):
  ```
  $ kaggle b t download hello -s
  ... gemini-3-flash-preview/291356/   2.40KB     Cached
  Done: 1 run(s) cached.

  Tip: 1 cached run(s) lack source notebooks. Re-run with -f -s to fetch them.

  $ kaggle b t download hello -s -f
  ... gemini-3-flash-preview/291356/   43.58KB    Done
  Done: 1 run(s) downloaded.

  $ ls hello/3/gemini-3-flash-preview/291356/
  __notebook__.ipynb  hello.task.json  *.run.json   # source notebook present
  ```
