### PR TITLE
fix: Fix JSON serialization error of `ApiModel` in `print_obj`

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -5896,7 +5896,7 @@ class KaggleApi:
         return upload_file, file_or_folder_name
 
     def print_obj(self, obj, indent=2):
-        pretty = json.dumps(obj, indent=indent)
+        pretty = json.dumps(obj.to_dict(), indent=indent)
         print(pretty)
 
     def download_needed(self, response: Response, outfile: str, quiet: bool = True) -> bool:


### PR DESCRIPTION
When running model-related CLI commands such as:

```bash
kaggle models get kienngx/nemotron-nano-30b-trained
```

The command fails with the following traceback:

```sh
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\PythonicVarun\tmp\.venv\Scripts\kaggle.exe\__main__.py", line 10, in <module>
  File "C:\PythonicVarun\tmp\.venv\Lib\site-packages\kaggle\cli.py", line 75, in main
    out = args.func(**command_args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\PythonicVarun\tmp\.venv\Lib\site-packages\kaggle\api\kaggle_api_extended.py", line 4800, in model_get_cli
    self.print_obj(model)
  File "C:\PythonicVarun\tmp\.venv\Lib\site-packages\kaggle\api\kaggle_api_extended.py", line 5877, in print_obj
    pretty = json.dumps(obj, indent=indent)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Development\Python\Python312\Lib\json\__init__.py", line 238, in dumps
    **kw).encode(obj)
          ^^^^^^^^^^^
  File "C:\Development\Python\Python312\Lib\json\encoder.py", line 202, in encode
    chunks = list(chunks)
             ^^^^^^^^^^^^
  File "C:\Development\Python\Python312\Lib\json\encoder.py", line 439, in _iterencode
    o = _default(o)
        ^^^^^^^^^^^
  File "C:\Development\Python\Python312\Lib\json\encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type ApiModel is not JSON serializable
```

This error occurs because the `kaggle_api_extended.py` helper method in `kaggle_api_extended.py` attempts to pass raw generated models (such as `ApiModel` and `ApiModelInstance`) directly to `json.dumps()`.

https://github.com/Kaggle/kaggle-cli/blob/4fc2429137a7ea82ccdb0befd6819e13cd2cee95/src/kaggle/api/kaggle_api_extended.py#L5898-L5900

## Solution

Updated the `kaggle_api_extended.py` helper method to call `.to_dict()` on the object before serialization:

```python
def print_obj(self, obj, indent=2):
    pretty = json.dumps(obj.to_dict(), indent=indent)
    print(pretty)
```

## Affected Commands

This resolves crashes in the following CLI commands (when running without the `-p`/`--path` option):

- `kaggle models get <model>` (via [kaggle_api_extended.py](https://github.com/Kaggle/kaggle-cli/blob/4fc2429137a7ea82ccdb0befd6819e13cd2cee95/src/kaggle/api/kaggle_api_extended.py))
- `kaggle models instances get <model_instance>` (via [kaggle_api_extended.py](https://github.com/Kaggle/kaggle-cli/blob/4fc2429137a7ea82ccdb0befd6819e13cd2cee95/src/kaggle/api/kaggle_api_extended.py))

Both `ApiModel` and `ApiModelInstance` implement `.to_dict()`, allowing the standard `json.dumps` library to successfully serialize the resulting dict format.