### PR TITLE
fix(tests): resolve infinite loop in test_kernels_d_status

### DIFF
--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -255,10 +255,11 @@ class TestKaggleApi(unittest.TestCase):
             # on localhost and cancel the active event. That will exit the loop, but you may
             # need to clean up other active kernels to get it to run again.
             count = 0
-            while status_result.status == "running" or status_result.status == "queued" or count >= max_status_tries:
+            while (status_result.status == "running" or status_result.status == "queued") and count < max_status_tries:
                 time.sleep(5)
                 status_result = api.kernels_status(self.kernel_slug)
                 print(status_result.status)
+                count += 1
             if count >= max_status_tries:
                 self.fail(f"Could not get kernel status in allowed trys. Status: {status_result.status}")
             end_time = time.time()

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -13,6 +13,7 @@ from requests import HTTPError
 sys.path.insert(0, "..")
 
 from kaggle import api
+from kagglesdk.kernels.types.kernels_enums import KernelWorkerStatus
 
 ApiException = IOError
 # Unit test names include a letter to sort them in run order.
@@ -255,7 +256,7 @@ class TestKaggleApi(unittest.TestCase):
             # on localhost and cancel the active event. That will exit the loop, but you may
             # need to clean up other active kernels to get it to run again.
             count = 0
-            while (status_result.status == "running" or status_result.status == "queued") and count < max_status_tries:
+            while (status_result.status == KernelWorkerStatus.RUNNING or status_result.status == KernelWorkerStatus.QUEUED) and count < max_status_tries:
                 time.sleep(5)
                 status_result = api.kernels_status(self.kernel_slug)
                 print(status_result.status)

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -256,7 +256,9 @@ class TestKaggleApi(unittest.TestCase):
             # on localhost and cancel the active event. That will exit the loop, but you may
             # need to clean up other active kernels to get it to run again.
             count = 0
-            while (status_result.status == KernelWorkerStatus.RUNNING or status_result.status == KernelWorkerStatus.QUEUED) and count < max_status_tries:
+            while (
+                status_result.status == KernelWorkerStatus.RUNNING or status_result.status == KernelWorkerStatus.QUEUED
+            ) and count < max_status_tries:
                 time.sleep(5)
                 status_result = api.kernels_status(self.kernel_slug)
                 print(status_result.status)


### PR DESCRIPTION
## Description

This PR fixes a logic error in `test_kernels_d_status` that could cause the test to loop indefinitely.

## Problem

The polling loop used the condition:

```python
while status_result.status == "running" or status_result.status == "queued" or count >= max_status_tries:
```

Because the retry limit check was combined with `or`, the loop could continue executing even after `count` reached `max_status_tries`. In some cases, this prevented the timeout logic below the loop from being reached, causing the test to hang instead of failing.

## Solution

Updated the loop condition to:

```python
while (status_result.status == "running" or status_result.status == "queued") and count < max_status_tries:
```

This ensures that polling continues only while the kernel is still running or queued and the retry limit has not been exceeded.