### PR TITLE
fix(auth): resolve token expiration duration parsing issues

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -1343,10 +1343,33 @@ class KaggleApi:
             print(response.token)
 
     def _parse_duration(self, duration_str: str) -> relativedelta:
+        if not duration_str:
+            raise ValueError("Invalid duration format. Please use one of the following formats: 1h, 30s, 2h30s, 2:30")
         try:
-            delta = relativedelta(**{duration_str[-1]: int(duration_str[:-1])})  # type: ignore[arg-type]
-            return delta
-        except ValueError:
+            if ":" in duration_str:
+                parts = duration_str.split(":")
+                if len(parts) == 2:
+                    return relativedelta(hours=int(parts[0]), minutes=int(parts[1]))
+                raise ValueError()
+
+            pattern = re.compile(r"(\d+)([hmsdw])")
+            matches = pattern.findall(duration_str)
+            reconstructed = "".join(f"{val}{unit}" for val, unit in matches)
+            if not matches or reconstructed != duration_str:
+                raise ValueError()
+
+            unit_map = {
+                "s": "seconds",
+                "m": "minutes",
+                "h": "hours",
+                "d": "days",
+                "w": "weeks",
+            }
+            kwargs: Dict[str, int] = {}
+            for val_str, unit in matches:
+                kwargs[unit_map[unit]] = kwargs.get(unit_map[unit], 0) + int(val_str)
+            return relativedelta(**kwargs)  # type: ignore[arg-type]
+        except (ValueError, TypeError, IndexError):
             raise ValueError("Invalid duration format. Please use one of the following formats: 1h, 30s, 2h30s, 2:30")
 
     def auth_revoke_token(self, reason: str):

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -1348,7 +1348,7 @@ class KaggleApi:
         try:
             if ":" in duration_str:
                 parts = duration_str.split(":")
-                if len(parts) == 2:
+                if len(parts) == 2 and len(parts[1]) == 2:
                     return relativedelta(hours=int(parts[0]), minutes=int(parts[1]))
                 raise ValueError()
 
@@ -1356,6 +1356,10 @@ class KaggleApi:
             matches = pattern.findall(duration_str)
             reconstructed = "".join(f"{val}{unit}" for val, unit in matches)
             if not matches or reconstructed != duration_str:
+                raise ValueError()
+
+            units = [unit for _, unit in matches]
+            if len(units) != len(set(units)):
                 raise ValueError()
 
             unit_map = {
@@ -1367,7 +1371,7 @@ class KaggleApi:
             }
             kwargs: Dict[str, int] = {}
             for val_str, unit in matches:
-                kwargs[unit_map[unit]] = kwargs.get(unit_map[unit], 0) + int(val_str)
+                kwargs[unit_map[unit]] = int(val_str)
             return relativedelta(**kwargs)  # type: ignore[arg-type]
         except (ValueError, TypeError, IndexError):
             raise ValueError("Invalid duration format. Please use one of the following formats: 1h, 30s, 2h30s, 2:30")

--- a/src/kaggle/test/test_authenticate.py
+++ b/src/kaggle/test/test_authenticate.py
@@ -81,6 +81,8 @@ class TestDurationParser(unittest.TestCase):
         self.assertEqual(self.api._parse_duration("30s"), relativedelta(seconds=30))
         self.assertEqual(self.api._parse_duration("2h30s"), relativedelta(hours=2, seconds=30))
         self.assertEqual(self.api._parse_duration("2:30"), relativedelta(hours=2, minutes=30))
+        self.assertEqual(self.api._parse_duration("02:30"), relativedelta(hours=2, minutes=30))
+        self.assertEqual(self.api._parse_duration("1h30m20s"), relativedelta(hours=1, minutes=30, seconds=20))
 
     def test_parse_duration_invalid(self):
         with self.assertRaises(ValueError):
@@ -91,6 +93,10 @@ class TestDurationParser(unittest.TestCase):
             self.api._parse_duration("abc")
         with self.assertRaises(ValueError):
             self.api._parse_duration("")
+        with self.assertRaises(ValueError):
+            self.api._parse_duration("2:3")
+        with self.assertRaises(ValueError):
+            self.api._parse_duration("1h2h")
 
 
 if __name__ == "__main__":

--- a/src/kaggle/test/test_authenticate.py
+++ b/src/kaggle/test/test_authenticate.py
@@ -5,6 +5,7 @@ from kaggle.api.kaggle_api_extended import KaggleApi
 import os
 import unittest
 from unittest.mock import patch
+from dateutil.relativedelta import relativedelta
 
 
 class TestAuthenticate(unittest.TestCase):
@@ -69,6 +70,27 @@ class TestAuthenticate(unittest.TestCase):
                 os.environ["KAGGLE_USERNAME"] = username_env
             if key_env is not None:
                 os.environ["KAGGLE_KEY"] = key_env
+
+
+class TestDurationParser(unittest.TestCase):
+    def setUp(self):
+        self.api = KaggleApi.__new__(KaggleApi)
+
+    def test_parse_duration_valid(self):
+        self.assertEqual(self.api._parse_duration("1h"), relativedelta(hours=1))
+        self.assertEqual(self.api._parse_duration("30s"), relativedelta(seconds=30))
+        self.assertEqual(self.api._parse_duration("2h30s"), relativedelta(hours=2, seconds=30))
+        self.assertEqual(self.api._parse_duration("2:30"), relativedelta(hours=2, minutes=30))
+
+    def test_parse_duration_invalid(self):
+        with self.assertRaises(ValueError):
+            self.api._parse_duration("5x")
+        with self.assertRaises(ValueError):
+            self.api._parse_duration("99z")
+        with self.assertRaises(ValueError):
+            self.api._parse_duration("abc")
+        with self.assertRaises(ValueError):
+            self.api._parse_duration("")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

This PR fixes a bug in `KaggleApi._parse_duration` where token expiration durations such as `"1h"`, `"30s"`, `"2:30"`, and `"2h30s"` could raise unhandled exceptions instead of parsing correctly.

## Problem

The previous implementation of `_parse_duration` attempted to construct a `relativedelta` using shorthand keys directly:

```python
delta = relativedelta(**{duration_str[-1]: int(duration_str[:-1])})
```

This is incorrect because `relativedelta` expects full keyword names such as `hours`, `minutes`, and `seconds`.

Additionally, the implementation did not correctly support documented formats such as:

* `2:30`
* `2h30s`

and could raise unexpected exceptions for invalid inputs.

## Solution

Implemented a more robust duration parser that:

1. Parses colon-separated durations in `H:MM` format.
2. Maps duration units (`s`, `m`, `h`, `d`, `w`) to the corresponding `relativedelta` keyword arguments.
3. Supports multi-component durations such as `2h30s`.
4. Improves validation and returns a consistent `ValueError` for invalid duration strings.
5. Adds unit test coverage for both valid and invalid inputs.

## Verification & Testing

### Automated Tests

Added test coverage in:

```text
src/kaggle/test/test_authenticate.py
```

Run tests:

```bash
$env:KAGGLE_USERNAME="dummy_user"
$env:KAGGLE_KEY="dummy_key"

python -m unittest src/kaggle/test/test_authenticate.py
```

Result:

```text
.....
----------------------------------------------------------------------
Ran 5 tests

OK
```

### Lint & Type Checks

Verified the modified files pass formatting and static analysis checks:

* Black:

  ```bash
  black --check --diff src/kaggle/api/kaggle_api_extended.py src/kaggle/test/test_authenticate.py
  ```

* Mypy:

  ```bash
  mypy src/kaggle/api/kaggle_api_extended.py src/kaggle/test/test_authenticate.py
  ```

Both checks pass successfully.
