### PR TITLE
Add machine_shape to kernels_initialize metadata template and docs

### DIFF
--- a/docs/kernels_metadata.md
+++ b/docs/kernels_metadata.md
@@ -12,6 +12,7 @@ Here's a basic example for `kernel-metadata.json`:
   "is_private": "false",
   "enable_gpu": "false",
   "enable_internet": "false",
+  "machine_shape": "",
   "dataset_sources": ["timoboz/my-awesome-dataset"],
   "competition_sources": [],
   "kernel_sources": [],
@@ -34,6 +35,7 @@ We currently support the following metadata fields for kernels.
 * `is_private`: Whether or not the kernel should be private. If not specified, will be `true`.
 * `enable_gpu`: Whether or not the kernel should run on a GPU. If not specified, will be `false`.
 * `enable_internet`: Whether or not the kernel should be able to access the internet. If not specified, will be `false`.
+* `machine_shape`: The accelerator/GPU type to use (e.g., `NvidiaTeslaT4`, `NvidiaTeslaP100`, or `Tpu1VmV38`).
 * `dataset_sources`: A list of dataset sources, specified as `"username/dataset-slug"`
 * `competition_sources`: A list of competition sources, specified as `"competition-slug"`
 * `kernel_sources`: A list of kernel sources, specified as `"username/kernel-slug"`

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -4265,6 +4265,7 @@ class KaggleApi:
             "enable_gpu": "false",
             "enable_tpu": "false",
             "enable_internet": "true",
+            "machine_shape": "",
             "dataset_sources": [],
             "competition_sources": [],
             "kernel_sources": [],

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -230,6 +230,9 @@ class TestKaggleApi(unittest.TestCase):
         try:
             self.kernel_metadata_path = api.kernels_initialize(kernel_directory)
             self.assertTrue(os.path.exists(self.kernel_metadata_path))
+            with open(self.kernel_metadata_path) as f:
+                metadata = json.load(f)
+                self.assertIn("machine_shape", metadata)
         except ApiException as e:
             self.fail(f"kernels_initialize failed: {e}")
 


### PR DESCRIPTION
## Summary

When running `kaggle kernels init`, the generated `kernel-metadata.json` template does not include a `machine_shape` field. This means users have no way to discover that they can specify an accelerator type (e.g., `NvidiaTeslaT4`, `NvidiaTeslaP100`, `Tpu1VmV38`) via the metadata file — even though the push path already supports reading it (added in #907).

This PR adds `machine_shape` to the initialized template and documents it, completing the metadata-based workflow for specifying accelerators.

## Motivation

PR #856 added `machine_shape` to `kernels pull --metadata` output, and PR #907 added the `--accelerator` CLI flag plus a fallback to read `machine_shape` from the metadata file during push. However, the `kernels init` template was never updated to include the field. As a result:

- Users who run `kaggle kernels init` and then edit the generated file have no indication that `machine_shape` is a supported option.
- The only way to discover it is to read the source code, use the `--accelerator` CLI flag, or pull an existing kernel that already has it set.
- The `docs/kernels_metadata.md` documentation also didn't mention `machine_shape`.

## Changes

1. **`src/kaggle/api/kaggle_api_extended.py`**: Added `"machine_shape": ""` to the default metadata dictionary in `kernels_initialize()`.
2. **`docs/kernels_metadata.md`**: Added `machine_shape` to the example JSON and documented the field with example values.
3. **`tests/unit_tests.py`**: Updated `test_kernels_b_initialize` to verify `machine_shape` is present in the initialized metadata file.

## Testing

- Ran the full pytest suite — all pre-existing tests pass (4 pre-existing failures in `test_benchmarks_cli.py` are unrelated).
- Ran `test_kernels_b_initialize` individually — passes.
- Verified `black` formatting and `mypy` type checking pass with no new issues.