### PR TITLE
Tag benchmarks token requests with CLI source for analytics

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -7223,8 +7223,13 @@ class KaggleApi:
 
     # -- Public CLI methods --
 
-    def _fetch_model_proxy_env(self):
+    def _fetch_model_proxy_env(self, source):
         with self.build_kaggle_client() as kaggle:
+            # Tag this request so kaggle-analytics can distinguish
+            # `kaggle benchmarks init` from `kaggle benchmarks auth` — both hit
+            # the same endpoint via this helper and would otherwise be
+            # indistinguishable in request logs.
+            kaggle.http_client()._session.headers["X-Kaggle-CLI-Source"] = f"benchmarks-{source}"
             request = ApiCreateDefaultModelProxyTokenRequest()
             try:
                 response = kaggle.models.model_proxy_api_client.create_default_model_proxy_token(request)
@@ -7347,13 +7352,13 @@ class KaggleApi:
             print(f"Syntax reference has been written to {ref_file}.")
 
     def benchmarks_auth_cli(self, no_confirm=False, env_file=".env"):
-        env_vars = self._fetch_model_proxy_env()
+        env_vars = self._fetch_model_proxy_env(source="auth")
         self._write_benchmarks_env(env_vars, no_confirm, env_file)
 
     def benchmarks_init_cli(self, no_confirm=False, env_file=".env", example_file="example_task.py"):
         print("Initializing Kaggle Benchmarks environment")
         print(f"  Target:  {os.path.abspath(env_file)}\n")
-        env_vars = self._fetch_model_proxy_env()
+        env_vars = self._fetch_model_proxy_env(source="init")
         env_vars.update(
             {
                 "LLM_DEFAULT": "google/gemini-3-flash-preview",

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -2084,6 +2084,13 @@ class TestBenchmarksAuth:
         out = capsys.readouterr().out
         assert "custom.env" in out
 
+    def test_sets_source_header_for_analytics(self, api, mock_token, tmp_path):
+        """The token request carries ``X-Kaggle-CLI-Source: benchmarks-auth`` so
+        kaggle-analytics can separate it from `kaggle benchmarks init`."""
+        api.benchmarks_auth_cli(no_confirm=True, env_file=str(tmp_path / ".env"))
+        headers = api._mock_client.http_client.return_value._session.headers
+        headers.__setitem__.assert_any_call("X-Kaggle-CLI-Source", "benchmarks-auth")
+
     def test_friendly_error_on_404_lists_both_causes(self, api, tmp_path):
         """404 maps to a message listing both beta-access and stale-CLI as possibilities."""
         api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.side_effect = HTTPError(
@@ -2209,6 +2216,17 @@ class TestBenchmarksInit:
         api.benchmarks_init_cli(no_confirm=True, env_file=env_file, example_file=example_file)
         content = (tmp_path / "my_task.py").read_text()
         assert "import kaggle_benchmarks as kbench" in content
+
+    def test_sets_source_header_for_analytics(self, api, mock_token, tmp_path):
+        """The token request carries ``X-Kaggle-CLI-Source: benchmarks-init`` so
+        kaggle-analytics can separate it from `kaggle benchmarks auth`."""
+        api.benchmarks_init_cli(
+            no_confirm=True,
+            env_file=str(tmp_path / ".env"),
+            example_file=str(tmp_path / "example_task.py"),
+        )
+        headers = api._mock_client.http_client.return_value._session.headers
+        headers.__setitem__.assert_any_call("X-Kaggle-CLI-Source", "benchmarks-init")
 
     def test_aborted_on_no_confirm(self, api, mock_token, capsys, tmp_path):
         env_file = str(tmp_path / ".env")


### PR DESCRIPTION
`kaggle benchmarks init` and `kaggle benchmarks auth` both hit
`POST /api/v1/models/proxy/token` via the same helper, so they're
indistinguishable in `kaggle-analytics.webtier.requests_pii`. This
adds an `X-Kaggle-CLI-Source` header (`benchmarks-init` or
`benchmarks-auth`) on that call so we can measure adoption and
failure rates (e.g. the phone-verification gate) of each entrypoint
separately. The analytics query that consumes the header will be
updated once the new value shows up in logs.

---

Task: [nanliao-20260605164334-8a65440f](https://agents.dev.kaggle.net/tasks/nanliao-20260605164334-8a65440f)
Context: https://chat.kaggle.net/kaggle/pl/r8kmegd7dfdd3fzib7qwu4rs9r

