### PR TITLE
Add CLI telemetry beacon for benchmarks init/auth outcomes

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -7379,7 +7379,10 @@ class KaggleApi:
 
     # -- Public CLI methods --
 
-    def _fetch_model_proxy_env(self, source):
+    def _fetch_model_proxy_env(self, beacon_source=None):
+        """Fetch model-proxy env vars. When ``beacon_source`` is set, fire a
+        telemetry beacon on each outcome — see
+        ``_send_benchmarks_telemetry_beacon`` for why."""
         with self.build_kaggle_client() as kaggle:
             # Tag this request so kaggle-analytics can distinguish
             # `kaggle benchmarks init` from `kaggle benchmarks auth` — both hit
@@ -7391,7 +7394,10 @@ class KaggleApi:
                 response = kaggle.models.model_proxy_api_client.create_default_model_proxy_token(request)
             except HTTPError as e:
                 status = e.response.status_code if e.response is not None else None
-                self._send_benchmarks_telemetry_beacon(kaggle, source, f"failed:{status}" if status else "failed")
+                if beacon_source:
+                    self._send_benchmarks_telemetry_beacon(
+                        kaggle, beacon_source, f"failed:{status}" if status else "failed"
+                    )
                 if status == 404:
                     raise ValueError(
                         "Endpoint not found (404). Possible causes:\n"
@@ -7410,9 +7416,11 @@ class KaggleApi:
                     ) from None
                 raise
             except Exception:
-                self._send_benchmarks_telemetry_beacon(kaggle, source, "failed")
+                if beacon_source:
+                    self._send_benchmarks_telemetry_beacon(kaggle, beacon_source, "failed")
                 raise
-            self._send_benchmarks_telemetry_beacon(kaggle, source, "ok")
+            if beacon_source:
+                self._send_benchmarks_telemetry_beacon(kaggle, beacon_source, "ok")
         return {
             "MODEL_PROXY_URL": response.base_uri,
             "MODEL_PROXY_API_KEY": response.token,
@@ -7423,13 +7431,13 @@ class KaggleApi:
         """Fire-and-forget request whose only purpose is to land a tagged
         User-Agent in webtier request logs.
 
-        Why: the model-proxy token endpoint backing ``benchmarks init`` /
-        ``benchmarks auth`` can fail at three layers — a 404 from the feature-
-        flag gate and a 403 from the auth middleware both bounce upstream of
-        the handler, so they never reach ``kaggle_logs.ApiRequests`` and are
-        invisible to server-side analytics. Those two are the most common
-        onboarding failures, so we beacon every attempt (success and failure)
-        from the CLI to recover a usable success/failure ratio in webtier logs.
+        Why: the model-proxy token endpoint backing ``benchmarks init`` can
+        fail at three layers — a 404 from the feature-flag gate and a 403
+        from the auth middleware both bounce upstream of the handler, so
+        they never reach ``kaggle_logs.ApiRequests`` and are invisible to
+        server-side analytics. Those two are the most common onboarding
+        failures, so we beacon every attempt (success and failure) from the
+        CLI to recover a usable success/failure ratio in webtier logs.
 
         This is a stop-gap; replace with a proper telemetry endpoint when one
         exists. Any failure of the beacon itself must be swallowed so it
@@ -7542,13 +7550,13 @@ class KaggleApi:
             print(f"Syntax reference has been written to {ref_file}.")
 
     def benchmarks_auth_cli(self, no_confirm=False, env_file=".env"):
-        env_vars = self._fetch_model_proxy_env(source="auth")
+        env_vars = self._fetch_model_proxy_env()
         self._write_benchmarks_env(env_vars, no_confirm, env_file)
 
     def benchmarks_init_cli(self, no_confirm=False, env_file=".env", example_file="example_task.py"):
         print("Initializing Kaggle Benchmarks environment")
         print(f"  Target:  {os.path.abspath(env_file)}\n")
-        env_vars = self._fetch_model_proxy_env(source="init")
+        env_vars = self._fetch_model_proxy_env(beacon_source="init")
         env_vars.update(
             {
                 "LLM_DEFAULT": "google/gemini-3-flash-preview",

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -7391,6 +7391,7 @@ class KaggleApi:
                 response = kaggle.models.model_proxy_api_client.create_default_model_proxy_token(request)
             except HTTPError as e:
                 status = e.response.status_code if e.response is not None else None
+                self._send_benchmarks_telemetry_beacon(kaggle, source, f"failed:{status}" if status else "failed")
                 if status == 404:
                     raise ValueError(
                         "Endpoint not found (404). Possible causes:\n"
@@ -7408,11 +7409,44 @@ class KaggleApi:
                         "     Regenerate at https://www.kaggle.com/settings/api and replace ~/.kaggle/access_token (or kaggle.json)."
                     ) from None
                 raise
+            except Exception:
+                self._send_benchmarks_telemetry_beacon(kaggle, source, "failed")
+                raise
+            self._send_benchmarks_telemetry_beacon(kaggle, source, "ok")
         return {
             "MODEL_PROXY_URL": response.base_uri,
             "MODEL_PROXY_API_KEY": response.token,
             "MODEL_PROXY_EXPIRY_TIME": response.expiry_time.isoformat() + "Z" if response.expiry_time else "",
         }
+
+    def _send_benchmarks_telemetry_beacon(self, kaggle_client, source, outcome):
+        """Fire-and-forget request whose only purpose is to land a tagged
+        User-Agent in webtier request logs.
+
+        Why: the model-proxy token endpoint backing ``benchmarks init`` /
+        ``benchmarks auth`` can fail at three layers — a 404 from the feature-
+        flag gate and a 403 from the auth middleware both bounce upstream of
+        the handler, so they never reach ``kaggle_logs.ApiRequests`` and are
+        invisible to server-side analytics. Those two are the most common
+        onboarding failures, so we beacon every attempt (success and failure)
+        from the CLI to recover a usable success/failure ratio in webtier logs.
+
+        This is a stop-gap; replace with a proper telemetry endpoint when one
+        exists. Any failure of the beacon itself must be swallowed so it
+        cannot mask the user's real error.
+        """
+        try:
+            http_client = kaggle_client.http_client()
+            http_client._init_session()
+            session = http_client._session
+            endpoint = http_client._endpoint
+            env = http_client._env
+            base = endpoint if env == KaggleEnv.PROD else f"{endpoint}/api"
+            beacon_url = f"{base}/v1/hello"
+            ua = f"kaggle-cli/{kaggle.__version__} benchmarks-{source}-{outcome}"
+            session.get(beacon_url, headers={"User-Agent": ua}, timeout=2)
+        except Exception:
+            pass
 
     def _write_benchmarks_env(self, env_vars, no_confirm, env_file, quiet=False):
         env_file_abs = os.path.abspath(env_file)

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -7379,10 +7379,7 @@ class KaggleApi:
 
     # -- Public CLI methods --
 
-    def _fetch_model_proxy_env(self, beacon_source=None):
-        """Fetch model-proxy env vars. When ``beacon_source`` is set, fire a
-        telemetry beacon on each outcome — see
-        ``_send_benchmarks_telemetry_beacon`` for why."""
+    def _fetch_model_proxy_env(self, source):
         with self.build_kaggle_client() as kaggle:
             # Tag this request so kaggle-analytics can distinguish
             # `kaggle benchmarks init` from `kaggle benchmarks auth` — both hit
@@ -7394,10 +7391,7 @@ class KaggleApi:
                 response = kaggle.models.model_proxy_api_client.create_default_model_proxy_token(request)
             except HTTPError as e:
                 status = e.response.status_code if e.response is not None else None
-                if beacon_source:
-                    self._send_benchmarks_telemetry_beacon(
-                        kaggle, beacon_source, f"failed:{status}" if status else "failed"
-                    )
+                self._send_benchmarks_telemetry_beacon(kaggle, source, f"failed:{status}" if status else "failed")
                 if status == 404:
                     raise ValueError(
                         "Endpoint not found (404). Possible causes:\n"
@@ -7416,11 +7410,9 @@ class KaggleApi:
                     ) from None
                 raise
             except Exception:
-                if beacon_source:
-                    self._send_benchmarks_telemetry_beacon(kaggle, beacon_source, "failed")
+                self._send_benchmarks_telemetry_beacon(kaggle, source, "failed")
                 raise
-            if beacon_source:
-                self._send_benchmarks_telemetry_beacon(kaggle, beacon_source, "ok")
+            self._send_benchmarks_telemetry_beacon(kaggle, source, "ok")
         return {
             "MODEL_PROXY_URL": response.base_uri,
             "MODEL_PROXY_API_KEY": response.token,
@@ -7431,13 +7423,17 @@ class KaggleApi:
         """Fire-and-forget request whose only purpose is to land a tagged
         User-Agent in webtier request logs.
 
-        Why: the model-proxy token endpoint backing ``benchmarks init`` can
-        fail at three layers — a 404 from the feature-flag gate and a 403
-        from the auth middleware both bounce upstream of the handler, so
-        they never reach ``kaggle_logs.ApiRequests`` and are invisible to
-        server-side analytics. Those two are the most common onboarding
-        failures, so we beacon every attempt (success and failure) from the
-        CLI to recover a usable success/failure ratio in webtier logs.
+        Why: the model-proxy token endpoint backing ``benchmarks init`` and
+        ``benchmarks auth`` can fail at three layers — a 404 from the
+        feature-flag gate and a 403 from the auth middleware both bounce
+        upstream of the handler, so they never reach
+        ``kaggle_logs.ApiRequests`` and are invisible to server-side
+        analytics. Those two are the most common onboarding failures, so we
+        beacon every attempt (success and failure) from the CLI to recover a
+        usable success/failure ratio in webtier logs. The
+        ``X-Kaggle-CLI-Source`` header set on the token call only reaches
+        analytics when the request itself makes it to the handler — the
+        beacon is what covers the upstream-bounce case.
 
         This is a stop-gap; replace with a proper telemetry endpoint when one
         exists. Any failure of the beacon itself must be swallowed so it
@@ -7550,13 +7546,13 @@ class KaggleApi:
             print(f"Syntax reference has been written to {ref_file}.")
 
     def benchmarks_auth_cli(self, no_confirm=False, env_file=".env"):
-        env_vars = self._fetch_model_proxy_env()
+        env_vars = self._fetch_model_proxy_env(source="auth")
         self._write_benchmarks_env(env_vars, no_confirm, env_file)
 
     def benchmarks_init_cli(self, no_confirm=False, env_file=".env", example_file="example_task.py"):
         print("Initializing Kaggle Benchmarks environment")
         print(f"  Target:  {os.path.abspath(env_file)}\n")
-        env_vars = self._fetch_model_proxy_env(beacon_source="init")
+        env_vars = self._fetch_model_proxy_env(source="init")
         env_vars.update(
             {
                 "LLM_DEFAULT": "google/gemini-3-flash-preview",

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -2278,6 +2278,146 @@ class TestBenchmarksInit:
 
 
 # ============================================================
+# Telemetry beacon (init / auth → webtier UA tag)
+# ============================================================
+
+
+class TestBenchmarksTelemetryBeacon:
+    """The CLI fires a tagged-User-Agent beacon on every ``benchmarks init`` /
+    ``benchmarks auth`` attempt so server-side analytics can count outcomes
+    that the model-proxy token handler never sees (FF-gate 404, auth-middleware
+    403). See ``_send_benchmarks_telemetry_beacon`` for the rationale."""
+
+    @pytest.mark.parametrize(
+        "source,cli_method",
+        [
+            ("auth", "benchmarks_auth_cli"),
+            ("init", "benchmarks_init_cli"),
+        ],
+    )
+    def test_beacon_fires_on_success(self, api, mock_token, tmp_path, source, cli_method):
+        with patch.object(api, "_send_benchmarks_telemetry_beacon") as beacon:
+            kwargs = {"no_confirm": True, "env_file": str(tmp_path / ".env")}
+            if cli_method == "benchmarks_init_cli":
+                kwargs["example_file"] = str(tmp_path / "example_task.py")
+            getattr(api, cli_method)(**kwargs)
+        outcomes = [c.args[2] for c in beacon.call_args_list]
+        sources = [c.args[1] for c in beacon.call_args_list]
+        assert "ok" in outcomes
+        assert all(s == source for s in sources)
+
+    @pytest.mark.parametrize(
+        "source,cli_method",
+        [
+            ("auth", "benchmarks_auth_cli"),
+            ("init", "benchmarks_init_cli"),
+        ],
+    )
+    @pytest.mark.parametrize("status_code", [403, 404, 500])
+    def test_beacon_fires_with_status_on_http_error(
+        self, api, tmp_path, source, cli_method, status_code
+    ):
+        api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.side_effect = HTTPError(
+            response=MagicMock(status_code=status_code)
+        )
+        kwargs = {"no_confirm": True, "env_file": str(tmp_path / ".env")}
+        if cli_method == "benchmarks_init_cli":
+            kwargs["example_file"] = str(tmp_path / "example_task.py")
+        with patch.object(api, "_send_benchmarks_telemetry_beacon") as beacon:
+            # 403/404 are translated to ValueError; everything else stays HTTPError.
+            expected_exc = ValueError if status_code in (403, 404) else HTTPError
+            with pytest.raises(expected_exc):
+                getattr(api, cli_method)(**kwargs)
+        assert beacon.called
+        last = beacon.call_args_list[-1]
+        assert last.args[1] == source
+        assert last.args[2] == f"failed:{status_code}"
+
+    @pytest.mark.parametrize(
+        "source,cli_method",
+        [
+            ("auth", "benchmarks_auth_cli"),
+            ("init", "benchmarks_init_cli"),
+        ],
+    )
+    def test_beacon_fires_when_http_error_has_no_response(self, api, tmp_path, source, cli_method):
+        """HTTPError with ``response=None`` (e.g. mid-flight network glitch) — we
+        still fire a beacon, just without a status code."""
+        api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.side_effect = HTTPError(
+            response=None
+        )
+        kwargs = {"no_confirm": True, "env_file": str(tmp_path / ".env")}
+        if cli_method == "benchmarks_init_cli":
+            kwargs["example_file"] = str(tmp_path / "example_task.py")
+        with patch.object(api, "_send_benchmarks_telemetry_beacon") as beacon:
+            with pytest.raises(HTTPError):
+                getattr(api, cli_method)(**kwargs)
+        assert beacon.called
+        last = beacon.call_args_list[-1]
+        assert last.args[1] == source
+        assert last.args[2] == "failed"
+
+    @pytest.mark.parametrize(
+        "source,cli_method",
+        [
+            ("auth", "benchmarks_auth_cli"),
+            ("init", "benchmarks_init_cli"),
+        ],
+    )
+    def test_beacon_fires_on_connection_error(self, api, tmp_path, source, cli_method):
+        api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.side_effect = (
+            ConnectionError("DNS lookup failed")
+        )
+        kwargs = {"no_confirm": True, "env_file": str(tmp_path / ".env")}
+        if cli_method == "benchmarks_init_cli":
+            kwargs["example_file"] = str(tmp_path / "example_task.py")
+        with patch.object(api, "_send_benchmarks_telemetry_beacon") as beacon:
+            with pytest.raises(ConnectionError, match="DNS lookup failed"):
+                getattr(api, cli_method)(**kwargs)
+        assert beacon.called
+        last = beacon.call_args_list[-1]
+        assert last.args[1] == source
+        assert last.args[2] == "failed"
+
+    def test_beacon_helper_swallows_exceptions(self, api):
+        """Direct unit test on the helper: a broken session must not raise."""
+        kaggle_client = MagicMock()
+        kaggle_client.http_client.side_effect = RuntimeError("kaboom")
+        api._send_benchmarks_telemetry_beacon(kaggle_client, "init", "ok")  # must not raise
+
+    def test_beacon_helper_sends_get_with_tagged_user_agent(self, api):
+        """Direct unit test on the helper: the GET URL is path /api/v1/hello
+        on non-prod envs, with a UA encoding source + outcome + CLI version."""
+        from kagglesdk.kaggle_env import KaggleEnv
+        import kaggle as kaggle_pkg
+
+        http_client = MagicMock()
+        http_client._endpoint = "http://localhost"
+        http_client._env = KaggleEnv.LOCAL
+        kaggle_client = MagicMock()
+        kaggle_client.http_client.return_value = http_client
+        api._send_benchmarks_telemetry_beacon(kaggle_client, "init", "failed:404")
+        http_client._session.get.assert_called_once()
+        args, kwargs = http_client._session.get.call_args
+        assert args[0] == "http://localhost/api/v1/hello"
+        expected_ua = f"kaggle-cli/{kaggle_pkg.__version__} benchmarks-init-failed:404"
+        assert kwargs["headers"]["User-Agent"] == expected_ua
+
+    def test_beacon_helper_prod_endpoint_uses_no_api_prefix(self, api):
+        """On PROD the base is api.kaggle.com which doesn't take the /api/ prefix."""
+        from kagglesdk.kaggle_env import KaggleEnv
+
+        http_client = MagicMock()
+        http_client._endpoint = "https://api.kaggle.com"
+        http_client._env = KaggleEnv.PROD
+        kaggle_client = MagicMock()
+        kaggle_client.http_client.return_value = http_client
+        api._send_benchmarks_telemetry_beacon(kaggle_client, "auth", "ok")
+        args, _ = http_client._session.get.call_args
+        assert args[0] == "https://api.kaggle.com/v1/hello"
+
+
+# ============================================================
 # Upsert behavior (auth/init reruns)
 # ============================================================
 

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -2278,46 +2278,55 @@ class TestBenchmarksInit:
 
 
 # ============================================================
-# Telemetry beacon (init → webtier UA tag)
+# Telemetry beacon (init / auth → webtier UA tag)
 # ============================================================
 
 
-class TestBenchmarksInitTelemetryBeacon:
-    """``benchmarks init`` fires a tagged-User-Agent beacon on every attempt so
-    server-side analytics can count outcomes that the model-proxy token handler
-    never sees (FF-gate 404, auth-middleware 403). See
-    ``_send_benchmarks_telemetry_beacon`` for the rationale."""
-
-    def _init(self, api, tmp_path):
+def _invoke_benchmarks_cli(api, source, tmp_path):
+    """Drive either ``benchmarks_init_cli`` or ``benchmarks_auth_cli`` with the
+    minimum scaffolding each one needs."""
+    if source == "init":
         api.benchmarks_init_cli(
             no_confirm=True,
             env_file=str(tmp_path / ".env"),
             example_file=str(tmp_path / "example_task.py"),
         )
+    else:
+        api.benchmarks_auth_cli(no_confirm=True, env_file=str(tmp_path / ".env"))
 
-    def test_beacon_fires_on_success(self, api, mock_token, tmp_path):
+
+class TestBenchmarksTelemetryBeacon:
+    """``benchmarks init`` and ``benchmarks auth`` each fire a tagged-User-Agent
+    beacon on every attempt so server-side analytics can count outcomes that
+    the model-proxy token handler never sees (FF-gate 404, auth-middleware
+    403). See ``_send_benchmarks_telemetry_beacon`` for the rationale."""
+
+    @pytest.mark.parametrize("source", ["init", "auth"])
+    def test_beacon_fires_on_success(self, api, mock_token, tmp_path, source):
         with patch.object(api, "_send_benchmarks_telemetry_beacon") as beacon:
-            self._init(api, tmp_path)
+            _invoke_benchmarks_cli(api, source, tmp_path)
         outcomes = [c.args[2] for c in beacon.call_args_list]
         sources = [c.args[1] for c in beacon.call_args_list]
         assert "ok" in outcomes
-        assert all(s == "init" for s in sources)
+        assert all(s == source for s in sources)
 
+    @pytest.mark.parametrize("source", ["init", "auth"])
     @pytest.mark.parametrize("status_code", [403, 404, 500])
-    def test_beacon_fires_with_status_on_http_error(self, api, tmp_path, status_code):
+    def test_beacon_fires_with_status_on_http_error(self, api, tmp_path, source, status_code):
         api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.side_effect = HTTPError(
             response=MagicMock(status_code=status_code)
         )
         with patch.object(api, "_send_benchmarks_telemetry_beacon") as beacon:
             expected_exc = ValueError if status_code in (403, 404) else HTTPError
             with pytest.raises(expected_exc):
-                self._init(api, tmp_path)
+                _invoke_benchmarks_cli(api, source, tmp_path)
         assert beacon.called
         last = beacon.call_args_list[-1]
-        assert last.args[1] == "init"
+        assert last.args[1] == source
         assert last.args[2] == f"failed:{status_code}"
 
-    def test_beacon_fires_when_http_error_has_no_response(self, api, tmp_path):
+    @pytest.mark.parametrize("source", ["init", "auth"])
+    def test_beacon_fires_when_http_error_has_no_response(self, api, tmp_path, source):
         """HTTPError with ``response=None`` (e.g. mid-flight network glitch) — we
         still fire a beacon, just without a status code."""
         api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.side_effect = HTTPError(
@@ -2325,29 +2334,24 @@ class TestBenchmarksInitTelemetryBeacon:
         )
         with patch.object(api, "_send_benchmarks_telemetry_beacon") as beacon:
             with pytest.raises(HTTPError):
-                self._init(api, tmp_path)
+                _invoke_benchmarks_cli(api, source, tmp_path)
         assert beacon.called
         last = beacon.call_args_list[-1]
-        assert last.args[1] == "init"
+        assert last.args[1] == source
         assert last.args[2] == "failed"
 
-    def test_beacon_fires_on_connection_error(self, api, tmp_path):
+    @pytest.mark.parametrize("source", ["init", "auth"])
+    def test_beacon_fires_on_connection_error(self, api, tmp_path, source):
         api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.side_effect = ConnectionError(
             "DNS lookup failed"
         )
         with patch.object(api, "_send_benchmarks_telemetry_beacon") as beacon:
             with pytest.raises(ConnectionError, match="DNS lookup failed"):
-                self._init(api, tmp_path)
+                _invoke_benchmarks_cli(api, source, tmp_path)
         assert beacon.called
         last = beacon.call_args_list[-1]
-        assert last.args[1] == "init"
+        assert last.args[1] == source
         assert last.args[2] == "failed"
-
-    def test_auth_does_not_fire_beacon(self, api, mock_token, tmp_path):
-        """``benchmarks auth`` is out of scope for this PR; it must not beacon."""
-        with patch.object(api, "_send_benchmarks_telemetry_beacon") as beacon:
-            api.benchmarks_auth_cli(no_confirm=True, env_file=str(tmp_path / ".env"))
-        beacon.assert_not_called()
 
     def test_beacon_helper_swallows_exceptions(self, api):
         """Direct unit test on the helper: a broken session must not raise."""
@@ -2382,7 +2386,7 @@ class TestBenchmarksInitTelemetryBeacon:
         http_client._env = KaggleEnv.PROD
         kaggle_client = MagicMock()
         kaggle_client.http_client.return_value = http_client
-        api._send_benchmarks_telemetry_beacon(kaggle_client, "init", "ok")
+        api._send_benchmarks_telemetry_beacon(kaggle_client, "auth", "ok")
         args, _ = http_client._session.get.call_args
         assert args[0] == "https://api.kaggle.com/v1/hello"
 

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -2314,9 +2314,7 @@ class TestBenchmarksTelemetryBeacon:
         ],
     )
     @pytest.mark.parametrize("status_code", [403, 404, 500])
-    def test_beacon_fires_with_status_on_http_error(
-        self, api, tmp_path, source, cli_method, status_code
-    ):
+    def test_beacon_fires_with_status_on_http_error(self, api, tmp_path, source, cli_method, status_code):
         api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.side_effect = HTTPError(
             response=MagicMock(status_code=status_code)
         )
@@ -2365,8 +2363,8 @@ class TestBenchmarksTelemetryBeacon:
         ],
     )
     def test_beacon_fires_on_connection_error(self, api, tmp_path, source, cli_method):
-        api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.side_effect = (
-            ConnectionError("DNS lookup failed")
+        api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.side_effect = ConnectionError(
+            "DNS lookup failed"
         )
         kwargs = {"no_confirm": True, "env_file": str(tmp_path / ".env")}
         if cli_method == "benchmarks_init_cli":

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -2278,104 +2278,76 @@ class TestBenchmarksInit:
 
 
 # ============================================================
-# Telemetry beacon (init / auth → webtier UA tag)
+# Telemetry beacon (init → webtier UA tag)
 # ============================================================
 
 
-class TestBenchmarksTelemetryBeacon:
-    """The CLI fires a tagged-User-Agent beacon on every ``benchmarks init`` /
-    ``benchmarks auth`` attempt so server-side analytics can count outcomes
-    that the model-proxy token handler never sees (FF-gate 404, auth-middleware
-    403). See ``_send_benchmarks_telemetry_beacon`` for the rationale."""
+class TestBenchmarksInitTelemetryBeacon:
+    """``benchmarks init`` fires a tagged-User-Agent beacon on every attempt so
+    server-side analytics can count outcomes that the model-proxy token handler
+    never sees (FF-gate 404, auth-middleware 403). See
+    ``_send_benchmarks_telemetry_beacon`` for the rationale."""
 
-    @pytest.mark.parametrize(
-        "source,cli_method",
-        [
-            ("auth", "benchmarks_auth_cli"),
-            ("init", "benchmarks_init_cli"),
-        ],
-    )
-    def test_beacon_fires_on_success(self, api, mock_token, tmp_path, source, cli_method):
+    def _init(self, api, tmp_path):
+        api.benchmarks_init_cli(
+            no_confirm=True,
+            env_file=str(tmp_path / ".env"),
+            example_file=str(tmp_path / "example_task.py"),
+        )
+
+    def test_beacon_fires_on_success(self, api, mock_token, tmp_path):
         with patch.object(api, "_send_benchmarks_telemetry_beacon") as beacon:
-            kwargs = {"no_confirm": True, "env_file": str(tmp_path / ".env")}
-            if cli_method == "benchmarks_init_cli":
-                kwargs["example_file"] = str(tmp_path / "example_task.py")
-            getattr(api, cli_method)(**kwargs)
+            self._init(api, tmp_path)
         outcomes = [c.args[2] for c in beacon.call_args_list]
         sources = [c.args[1] for c in beacon.call_args_list]
         assert "ok" in outcomes
-        assert all(s == source for s in sources)
+        assert all(s == "init" for s in sources)
 
-    @pytest.mark.parametrize(
-        "source,cli_method",
-        [
-            ("auth", "benchmarks_auth_cli"),
-            ("init", "benchmarks_init_cli"),
-        ],
-    )
     @pytest.mark.parametrize("status_code", [403, 404, 500])
-    def test_beacon_fires_with_status_on_http_error(self, api, tmp_path, source, cli_method, status_code):
+    def test_beacon_fires_with_status_on_http_error(self, api, tmp_path, status_code):
         api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.side_effect = HTTPError(
             response=MagicMock(status_code=status_code)
         )
-        kwargs = {"no_confirm": True, "env_file": str(tmp_path / ".env")}
-        if cli_method == "benchmarks_init_cli":
-            kwargs["example_file"] = str(tmp_path / "example_task.py")
         with patch.object(api, "_send_benchmarks_telemetry_beacon") as beacon:
-            # 403/404 are translated to ValueError; everything else stays HTTPError.
             expected_exc = ValueError if status_code in (403, 404) else HTTPError
             with pytest.raises(expected_exc):
-                getattr(api, cli_method)(**kwargs)
+                self._init(api, tmp_path)
         assert beacon.called
         last = beacon.call_args_list[-1]
-        assert last.args[1] == source
+        assert last.args[1] == "init"
         assert last.args[2] == f"failed:{status_code}"
 
-    @pytest.mark.parametrize(
-        "source,cli_method",
-        [
-            ("auth", "benchmarks_auth_cli"),
-            ("init", "benchmarks_init_cli"),
-        ],
-    )
-    def test_beacon_fires_when_http_error_has_no_response(self, api, tmp_path, source, cli_method):
+    def test_beacon_fires_when_http_error_has_no_response(self, api, tmp_path):
         """HTTPError with ``response=None`` (e.g. mid-flight network glitch) — we
         still fire a beacon, just without a status code."""
         api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.side_effect = HTTPError(
             response=None
         )
-        kwargs = {"no_confirm": True, "env_file": str(tmp_path / ".env")}
-        if cli_method == "benchmarks_init_cli":
-            kwargs["example_file"] = str(tmp_path / "example_task.py")
         with patch.object(api, "_send_benchmarks_telemetry_beacon") as beacon:
             with pytest.raises(HTTPError):
-                getattr(api, cli_method)(**kwargs)
+                self._init(api, tmp_path)
         assert beacon.called
         last = beacon.call_args_list[-1]
-        assert last.args[1] == source
+        assert last.args[1] == "init"
         assert last.args[2] == "failed"
 
-    @pytest.mark.parametrize(
-        "source,cli_method",
-        [
-            ("auth", "benchmarks_auth_cli"),
-            ("init", "benchmarks_init_cli"),
-        ],
-    )
-    def test_beacon_fires_on_connection_error(self, api, tmp_path, source, cli_method):
+    def test_beacon_fires_on_connection_error(self, api, tmp_path):
         api._mock_client.models.model_proxy_api_client.create_default_model_proxy_token.side_effect = ConnectionError(
             "DNS lookup failed"
         )
-        kwargs = {"no_confirm": True, "env_file": str(tmp_path / ".env")}
-        if cli_method == "benchmarks_init_cli":
-            kwargs["example_file"] = str(tmp_path / "example_task.py")
         with patch.object(api, "_send_benchmarks_telemetry_beacon") as beacon:
             with pytest.raises(ConnectionError, match="DNS lookup failed"):
-                getattr(api, cli_method)(**kwargs)
+                self._init(api, tmp_path)
         assert beacon.called
         last = beacon.call_args_list[-1]
-        assert last.args[1] == source
+        assert last.args[1] == "init"
         assert last.args[2] == "failed"
+
+    def test_auth_does_not_fire_beacon(self, api, mock_token, tmp_path):
+        """``benchmarks auth`` is out of scope for this PR; it must not beacon."""
+        with patch.object(api, "_send_benchmarks_telemetry_beacon") as beacon:
+            api.benchmarks_auth_cli(no_confirm=True, env_file=str(tmp_path / ".env"))
+        beacon.assert_not_called()
 
     def test_beacon_helper_swallows_exceptions(self, api):
         """Direct unit test on the helper: a broken session must not raise."""
@@ -2410,7 +2382,7 @@ class TestBenchmarksTelemetryBeacon:
         http_client._env = KaggleEnv.PROD
         kaggle_client = MagicMock()
         kaggle_client.http_client.return_value = http_client
-        api._send_benchmarks_telemetry_beacon(kaggle_client, "auth", "ok")
+        api._send_benchmarks_telemetry_beacon(kaggle_client, "init", "ok")
         args, _ = http_client._session.get.call_args
         assert args[0] == "https://api.kaggle.com/v1/hello"
 


### PR DESCRIPTION
The model-proxy token endpoint behind `kaggle benchmarks init` and
`kaggle benchmarks auth` can fail at the FF gate (404) or auth
middleware (403) before reaching the handler, so those outcomes never
land in `kaggle_logs.ApiRequests` — and they're the most common
onboarding failures (per commit b9fef11). The `X-Kaggle-CLI-Source`
header from #1050 only reaches analytics when the request makes it
to the handler, so we also fire a fire-and-forget GET with a tagged
User-Agent on each attempt to recover a usable success/failure ratio
in webtier logs. Stop-gap until a proper telemetry endpoint exists.

---

Task: [nanliao-20260605170846-70d133e3](https://agents.dev.kaggle.net/tasks/nanliao-20260605170846-70d133e3)
Context: https://chat.kaggle.net/kaggle/pl/r8kmegd7dfdd3fzib7qwu4rs9r

