### PR TITLE
Expand Kaggle CLI skill references

### DIFF
--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -1,44 +1,95 @@
 ---
 name: kaggle-cli
 description: >
-  How to use the kaggle CLI — managing datasets, competitions, notebooks,
-  models, and benchmarks. Activate this skill when the user asks about
-  kaggle CLI commands, workflows, or troubleshooting.
+  Use the local Kaggle CLI skill for command guidance, workflows, and
+  troubleshooting across competitions, datasets, kernels/notebooks, models,
+  model variations and versions, inbox file uploads, forums/discussions,
+  benchmarks, configuration, OAuth/API-token authentication, and accelerator
+  quota. Activate this skill when the user asks about kaggle CLI commands,
+  examples, flags, metadata files, download/upload flows, submissions,
+  benchmark tasks, or Kaggle CLI behavior.
 ---
 
 # Kaggle CLI
 
-The `kaggle` command-line tool provides access to Kaggle's platform features.
+Use this skill to answer or operate on the `kaggle` command-line tool. Treat
+this skill and its references as the available command guide.
 
-## Installation
+## Quick Start
 
 ```bash
 pip install kaggle
+kaggle --help
 ```
 
-## Authentication
+Authentication options:
 
 ```bash
-# Browser-based OAuth login
 kaggle auth login
-
-# Or set KAGGLE_API_TOKEN environment variable
-# Or place token in ~/.kaggle/access_token
+# or set KAGGLE_API_TOKEN
+# or place an access token in ~/.kaggle/access_token
+# or use legacy ~/.kaggle/kaggle.json credentials
 ```
 
-## Command Groups
+## Command Tree
 
-```
+```text
 kaggle
-├── competitions (alias: c)  — Join and submit to competitions
-├── datasets (alias: d)      — Create, download, and manage datasets
-├── kernels (alias: k)       — Run and manage notebooks/scripts
-├── models (alias: m)        — Upload and version models
-└── benchmarks (alias: b)    — Benchmark LLM models on tasks
+├── competitions | c
+│   ├── list, files, download, submit, submissions, leaderboard
+│   ├── team-submissions, episodes, replay, logs, pages
+│   └── topics {list, show}, topic-messages
+├── datasets | d
+│   ├── list, files, download, init, create, version
+│   ├── metadata, status, delete
+│   └── topics {list, show}
+├── kernels | k
+│   └── list, files, init, push|update, pull|get, output, status, logs, delete
+├── models | m
+│   ├── list, init, create, get, update, delete
+│   ├── topics {list, show}
+│   └── variations | instances | v | i
+│       ├── get, init, create, files, list, update, delete
+│       └── versions | v {list, create, download, files, delete}
+├── files {upload}
+├── forums | f {list, topics {list, show}}
+├── benchmarks | b
+│   ├── auth, init
+│   ├── tasks | t {push, run, list, status, download, log|logs, models, delete, publish}
+│   └── topics {list, show}
+├── config {view, set, unset}
+├── auth {login, print-access-token, revoke}
+└── quota
 ```
 
-## Specific Tasks
+Note: the CLI accepts aliases such as `kernels get` for `kernels pull` and
+`kernels update` for `kernels push`. Do not recommend
+`models variations versions init`; use `models variations init` for variation
+metadata instead.
 
-For detailed reference on specific command groups, see:
+## Reference Map
 
-- [Benchmarks](references/benchmarks.md) — Push tasks, run against LLM models, check status, download results
+Read only the reference needed for the user's task:
+
+- [Competitions](references/competitions.md) - competition discovery, files, downloads, submissions, leaderboards, simulations, pages, topics.
+- [Datasets](references/datasets.md) - dataset search, files, downloads, metadata, create/version/status/delete, topics.
+- [Kernels](references/kernels.md) - notebook/script discovery, metadata, push/pull, outputs, status, logs, delete.
+- [Models](references/models.md) - model records, metadata, create/get/update/delete, model topics.
+- [Model Variations](references/model_variations.md) - create and manage framework-specific model variations.
+- [Model Variation Versions](references/model_variations_versions.md) - create, list, download, inspect, and delete variation versions.
+- [Files](references/files.md) - inbox uploads, resumable uploads, directory compression behavior.
+- [Forums](references/forums.md) - global discussion forums, topics, and comments.
+- [Benchmarks](references/benchmarks.md) - benchmark auth/init, task push/run/status/download/log/model flows, benchmark topics.
+- [Configuration](references/configuration.md) - config file, default path, proxy, default competition.
+- [Authentication](references/auth.md) - OAuth login, access token printing, revocation, token/key sources.
+- [Quota](references/quota.md) - weekly GPU/TPU accelerator quota.
+
+## Operating Guidance
+
+- Read only the reference needed for the user's task.
+- Prefer `kaggle <group> --help` or `kaggle <group> <command> --help` when a flag
+  is uncertain in the installed CLI.
+- For metadata files, prefer the relevant `init` command to generate a starter
+  file before editing it.
+- Do not invent commands that are not listed in this skill. If live `--help`
+  output differs, report it as a version-specific difference.

--- a/skills/references/auth.md
+++ b/skills/references/auth.md
@@ -1,0 +1,137 @@
+# Authentication CLI Reference
+
+Use `kaggle auth` to run OAuth login, print an OAuth access token, or revoke the
+active OAuth refresh token. The CLI also supports non-command authentication via
+`KAGGLE_API_TOKEN`, `~/.kaggle/access_token`, and legacy API key credentials.
+
+## Prerequisites
+
+- Python 3.11+ with the `kaggle` package installed.
+- A Kaggle account.
+- Browser access for the default OAuth login flow, or use `--no-launch-browser`
+  to print a URL.
+
+## Command Hierarchy
+
+```text
+kaggle auth
+├── login
+├── print-access-token
+└── revoke
+```
+
+## Authentication Sources
+
+The CLI authentication flow tries these sources:
+
+1. Access token sources such as `KAGGLE_API_TOKEN` or
+   `~/.kaggle/access_token`.
+2. Legacy API key config from environment/config values `username` and `key`.
+3. OAuth credentials created by `kaggle auth login`.
+
+If none succeed, the CLI prints auth help and exits.
+
+Some commands are allowed logged out, including help/version and selected
+public dataset file/download flows.
+
+## `kaggle auth login`
+
+Runs Kaggle OAuth login.
+
+**Usage:**
+
+```bash
+kaggle auth login [options]
+```
+
+**Options:**
+
+- `--no-launch-browser`: Do not launch a browser; print an auth URL instead.
+- `--force`: Re-run login even if already logged in.
+
+**Examples:**
+
+```bash
+kaggle auth login
+kaggle auth login --no-launch-browser
+kaggle auth login --force
+```
+
+**Purpose:** Store OAuth credentials for the active Kaggle account.
+
+**Behavior details:**
+
+- If credentials already exist and `--force` is not set, the command prints the
+  current account and exits with instructions to use `--force`.
+- The OAuth flow requests the default scope `resources.admin:*`.
+
+## `kaggle auth print-access-token`
+
+Prints an access token for the active OAuth account.
+
+**Usage:**
+
+```bash
+kaggle auth print-access-token [options]
+```
+
+**Options:**
+
+- `--expiration <DURATION>`: Override token duration.
+
+**Examples:**
+
+```bash
+kaggle auth print-access-token
+```
+
+**Purpose:** Emit a token that can be placed in `KAGGLE_API_TOKEN` or another
+supported token source.
+
+**Behavior details:**
+
+- Requires OAuth credentials from `kaggle auth login`.
+- If no OAuth credentials exist, the command tells the user to run
+  `kaggle auth login`.
+- Some CLI help examples use short forms such as `6h`. For automation, omit
+  `--expiration` unless the accepted duration format has been verified with
+  the installed CLI.
+
+## `kaggle auth revoke`
+
+Revokes the active OAuth refresh token.
+
+**Usage:**
+
+```bash
+kaggle auth revoke [options]
+```
+
+**Options:**
+
+- `--reason <TEXT>`: Reason sent to the server.
+
+**Examples:**
+
+```bash
+kaggle auth revoke
+kaggle auth revoke --reason "rotating credentials"
+```
+
+**Purpose:** Invalidate the active OAuth credential.
+
+**Behavior details:**
+
+- If no OAuth credentials exist, the command prints `There is no token to
+  revoke.` and exits successfully.
+- If no reason is provided, the default reason is
+  `Manually revoked by user with kaggle-cli`.
+
+## Legacy And Token Auth Notes
+
+- `KAGGLE_API_TOKEN` can authenticate without a legacy username/key pair when
+  the token introspection succeeds.
+- Legacy config can come from `~/.kaggle/kaggle.json` or environment variables
+  such as `KAGGLE_USERNAME` and `KAGGLE_KEY`.
+- Prefer `kaggle auth login` for OAuth credentials or `KAGGLE_API_TOKEN` for
+  non-interactive authentication.

--- a/skills/references/benchmarks.md
+++ b/skills/references/benchmarks.md
@@ -5,7 +5,7 @@ This reference covers how to use the `kaggle` CLI to manage Kaggle Benchmark tas
 ## Prerequisites
 
 - Python 3.11+
-- `kaggle` CLI installed (`pip install kaggle` or `pip install -e .` from source)
+- `kaggle` CLI installed (`pip install kaggle`)
 - Valid Kaggle credentials: `KAGGLE_API_TOKEN` env var, `~/.kaggle/access_token` file, or OAuth via `kaggle auth login`
 
 ## Command Hierarchy
@@ -14,23 +14,32 @@ This reference covers how to use the `kaggle` CLI to manage Kaggle Benchmark tas
 kaggle benchmarks (alias: kaggle b)
 ├── auth              — Fetch Model Proxy credentials
 ├── init              — Fetch credentials + setup local dev environment
-└── tasks (alias: t)  — Manage benchmark tasks
-    ├── push          — Upload a task from a .py file
-    ├── run           — Run a task against model(s)
-    ├── list          — List your benchmark tasks
-    ├── status        — Show task details and per-model run status
-    ├── download      — Download completed run outputs
-    ├── log / logs    — View execution logs for runs
-    ├── models        — List available benchmark models
-    ├── delete        — Delete a task (not yet supported by server)
-    └── publish       — Publish a task (make it public)
+├── tasks (alias: t)  — Manage benchmark tasks
+│   ├── push          — Upload a task from a .py file
+│   ├── run           — Run a task against model(s)
+│   ├── list          — List your benchmark tasks
+│   ├── status        — Show task details and per-model run status
+│   ├── download      — Download completed run outputs
+│   ├── log / logs    — View execution logs for runs
+│   ├── models        — List available benchmark models
+│   ├── delete        — Delete a task (not yet supported by server)
+│   └── publish       — Publish a task (make it public)
+└── topics            — List or show benchmark discussion topics
 ```
 
 ## Setup & Authentication
 
-### Initialize a Benchmark Project
+### `kaggle benchmarks init`
 
 The `init` command fetches Model Proxy credentials, writes default environment variables, generates a starter example task file, and a syntax reference document.
+
+**Usage:**
+
+```bash
+kaggle benchmarks init [options]
+```
+
+**Examples:**
 
 ```bash
 # Initialize with defaults (always writes .env, example_task.py, kaggle_benchmarks_reference.md)
@@ -44,6 +53,9 @@ kaggle b init -y
 - `-y, --yes`: Skip confirmation prompt
 - `--env-file <FILE>`: Path to write env vars (default: `.env`)
 - `--example-file <FILE>`: Path to write example task (default: `example_task.py`)
+
+**Purpose:** Prepare a local benchmark project with Model Proxy credentials,
+default env vars, and starter benchmark files.
 
 **Environment variables written (appended to the env file):**
 - `MODEL_PROXY_URL` — Model Proxy endpoint
@@ -61,9 +73,22 @@ kaggle b init -y
 
 If either file already exists, it is skipped without overwriting.
 
-### Fetch Only Auth Credentials
+### `kaggle benchmarks auth`
 
 If you just need the Model Proxy token (without the extra env vars and example files):
+
+**Usage:**
+
+```bash
+kaggle benchmarks auth [options]
+```
+
+**Options:**
+
+- `-y, --yes`: Skip confirmation prompt.
+- `--env-file <FILE>`: Path to append Model Proxy credential variables.
+
+**Examples:**
 
 ```bash
 # Refresh only the 3 credential variables (MODEL_PROXY_URL, MODEL_PROXY_API_KEY, MODEL_PROXY_EXPIRY_TIME)
@@ -72,6 +97,9 @@ kaggle b auth -y
 # Or write to a custom env file:
 # kaggle b auth -y --env-file custom.env
 ```
+
+**Purpose:** Refresh only the Model Proxy credential variables without creating
+starter task files.
 
 ## Core Workflow: Push → Run → Status → Download
 
@@ -91,12 +119,12 @@ Task files are Python scripts using the `kaggle-benchmarks` library. They must:
 import kaggle_benchmarks as kbench
 
 # %%
-@kbench.task(name="my-test-task")
-def my_test_task(llm):
+@kbench.task(name="sample-task")
+def sample_task(llm):
     response = llm.prompt("What is 2 + 2?")
     kbench.assertions.assert_in("4", response, expectation="Should contain 4")
 
-my_test_task.run(kbench.llm)
+sample_task.run(kbench.llm)
 ```
 
 **Task name defaults:** If you omit the `name=` argument from `@kbench.task()`, the task name defaults to the function name, title-cased with underscores replaced by spaces. For example, `@kbench.task()` on a function named `my_eval` produces the task name `"My Eval"`, which is slugified to `my-eval`.
@@ -108,7 +136,17 @@ my_test_task.run(kbench.llm)
 - The task name is normalized to a URL-safe slug (e.g. `"My Test Task"` → `my-test-task`)
 - The slug used in the CLI must match a `@task` decorator in the file
 
-### Step 2: Push the Task
+### `kaggle benchmarks tasks push`
+
+Pushes a benchmark task file to Kaggle.
+
+**Usage:**
+
+```bash
+kaggle benchmarks tasks push <TASK> -f <FILE> [options]
+```
+
+**Examples:**
 
 ```bash
 # Push and wait for server-side creation to complete (recommended)
@@ -134,6 +172,7 @@ kaggle b t push my-task -f task.py --wait -d kaggle/titanic -d user/my-dataset
 - `-v, --verbose`: Enable verbose polling logs.
 - `-d, --kaggle-dataset <DATASET>`: Attach Kaggle dataset to the task's backing notebook (format: `owner/dataset-slug`). Repeat for multiple datasets (e.g. `-d kaggle/titanic -d user/my-dataset`). Mounted at `/kaggle/input/<dataset-slug>/` by default. If a naming conflict occurs, the fully qualified mount path `/kaggle/input/<owner>/<dataset-slug>/` is used instead.
 
+**Purpose:** Create or version a benchmark task from a local `.py` file.
 
 **What happens:**
 1. Validates the file is a `.py` file and exists
@@ -154,7 +193,17 @@ kaggle b t push my-task -f task.py --wait -d kaggle/titanic -d user/my-dataset
 - Invalid or inaccessible Kaggle dataset: `Failed to push task: Failed to attach the following data sources (not found or inaccessible): <dataset>`
 
 
-### Step 3: Run the Task Against Models
+### `kaggle benchmarks tasks run`
+
+Runs a benchmark task against one or more models.
+
+**Usage:**
+
+```bash
+kaggle benchmarks tasks run <TASK> [options]
+```
+
+**Examples:**
 
 ```bash
 # Run with interactive model selection (paginated picker)
@@ -179,6 +228,8 @@ kaggle b t run my-task -m gemini-2.5-pro --wait 30 --poll-interval 5
 - `--poll-interval <SECONDS>`: Maximum seconds between status polls (default: `60`). Polling starts at 5s and increases by 50% each iteration until reaching this value.
 - `-v, --verbose`: Enable verbose polling logs.
 
+**Purpose:** Schedule benchmark runs and optionally wait for completion.
+
 **Interactive model selection:**
 - Shows numbered list of available models
 - Enter comma-separated numbers (e.g. `1,3,5`) to select specific models
@@ -191,7 +242,26 @@ kaggle b t run my-task -m gemini-2.5-pro --wait 30 --poll-interval 5
 - Task not ready: `ValueError: Task 'my-task' is not ready to run (status: QUEUED). Only completed tasks can be run.`
 - Timeout: `Timed out waiting for runs after 30 seconds.`
 
-### Step 4: Check Status
+### `kaggle benchmarks tasks status`
+
+Shows task details and per-model run status.
+
+**Usage:**
+
+```bash
+kaggle benchmarks tasks status <TASK> [options]
+```
+
+**Arguments:**
+
+- `<TASK>` (positional, required): Task name/slug.
+
+**Options:**
+
+- `-m, --model <MODEL>`: Filter status to a specific model. Repeat for
+  multiple models.
+
+**Examples:**
 
 ```bash
 # Full status for a task
@@ -201,6 +271,8 @@ kaggle b t status my-task
 kaggle b t status my-task -m gemini-2.5-pro
 kaggle b t status my-task -m gemini-2.5-pro -m claude-sonnet-4
 ```
+
+**Purpose:** Check task creation state and model run progress or errors.
 
 **Output format:**
 ```
@@ -223,7 +295,21 @@ Errors:
 
 If no runs exist: `No runs yet. Use 'kaggle b t run my-task' to start one.`
 
-### Step 5: Download Results
+### `kaggle benchmarks tasks download`
+
+Downloads completed or errored run outputs.
+
+**Usage:**
+
+```bash
+kaggle benchmarks tasks download <TASK> [options]
+```
+
+**Arguments:**
+
+- `<TASK>` (positional, required): Task name/slug.
+
+**Examples:**
 
 ```bash
 # Download all terminal run outputs (completed and errored)
@@ -245,6 +331,8 @@ kaggle b t download my-task --include-source
 - `-s, --include-source`: Also download the kernel session's source notebooks (`__notebook__.ipynb`, `__notebook_source__.ipynb`)
 - `-f, --force`: Force re-download of already completed runs, overwriting local files
 
+**Purpose:** Retrieve benchmark output artifacts for local inspection.
+
 **Output directory structure:**
 ```
 <output>/<task>/<version>/<model>/<run_id>/    (version is "unset" if unavailable)
@@ -261,7 +349,17 @@ kaggle b t download my-task --include-source
 - No downloadable runs (all still in progress): `No downloadable runs yet — N run(s) still in progress. Use 'kaggle b t status my-task' to check progress.`
 - No runs at all: `No runs found for task 'my-task'. Use 'kaggle b t run my-task' to start one.`
 
-### Step 6: View Logs
+### `kaggle benchmarks tasks log`
+
+Views logs for benchmark task runs.
+
+**Usage:**
+
+```bash
+kaggle benchmarks tasks log <TASK> [options]
+```
+
+**Examples:**
 
 ```bash
 # Show logs for all runs of a task
@@ -282,6 +380,8 @@ kaggle b t logs my-task -m gemini-2.5-pro -m claude-sonnet-4
 
 **Aliases:** `log`, `logs`
 
+**Purpose:** Inspect per-run execution logs for debugging.
+
 **Behavior details:**
 - Each run's logs are printed with a header including run state: `═══ Logs for gemini-2.5-pro (Run 456) [COMPLETED] ═══`
 - Each run ends with a line count footer: `═══ (42 lines) ═══`
@@ -293,7 +393,22 @@ kaggle b t logs my-task -m gemini-2.5-pro -m claude-sonnet-4
 
 ## Additional Commands
 
-### List Tasks
+### `kaggle benchmarks tasks list`
+
+**Usage:**
+
+```bash
+kaggle benchmarks tasks list [options]
+```
+
+**Options:**
+
+- `--name-regex <REGEX>`: Filter task names by regular expression.
+- `--status <STATUS>`: Filter by creation status: `queued`, `running`, `completed`, `errored`.
+- `--page-size <SIZE>`: Tasks per page in the interactive pager. Defaults to 20.
+- `--all`: Print every task at once and skip the interactive pager.
+
+**Examples:**
 
 ```bash
 # List all your tasks
@@ -307,30 +422,86 @@ kaggle b t list --status completed
 
 # Combine filters
 kaggle b t list --name-regex "^math" --status errored
+
+# Use a smaller interactive page size
+kaggle b t list --page-size 5
+
+# Print all tasks without the pager
+kaggle b t list --all
 ```
 
-**Status filter values:** `queued`, `running`, `completed`, `errored`
+**Purpose:** Review owned benchmark tasks and filter by task name or creation state.
 
-**Output:** Aligned table with columns: Task, Version (or `unset`), Status, Created
+**Output:** Aligned table with columns: Task, Version (or `unset`), Status, Created.
 
-### List Available Models
+### `kaggle benchmarks tasks models`
+
+Lists available benchmark models.
+
+**Usage:**
+
+```bash
+kaggle benchmarks tasks models
+```
+
+**Options:**
+
+- No visible options.
+
+**Examples:**
 
 ```bash
 kaggle b t models
 ```
 
+**Purpose:** Find model slugs accepted by `kaggle benchmarks tasks run`.
+
 **Output:** Table with columns: Slug, Display Name
 
-### Delete a Task
+### `kaggle benchmarks tasks delete`
+
+Deletes a benchmark task when server support is available.
+
+**Usage:**
+
+```bash
+kaggle benchmarks tasks delete <TASK> [options]
+```
+
+**Arguments:**
+
+- `<TASK>` (positional, required): Task name/slug.
+
+**Options:**
+
+- `-y, --yes`: Skip confirmation.
+
+**Examples:**
 
 ```bash
 kaggle b t delete my-task
 kaggle b t delete my-task -y   # skip confirmation
 ```
 
+**Purpose:** Request task deletion. Current server behavior does not support it.
+
 **Note:** Delete is not yet supported by the server. Currently prints: `Delete is not supported by the server yet.`
 
-### Publish a Task
+### `kaggle benchmarks tasks publish`
+
+Publishes a benchmark task.
+
+**Usage:**
+
+```bash
+kaggle benchmarks tasks publish <TASK> [options]
+```
+
+**Arguments:**
+
+- `<TASK>` (positional, required): Task name/slug.
+
+**Examples:**
 
 ```bash
 # Publish a task and its backing notebook (default)
@@ -343,11 +514,80 @@ kaggle b t publish my-task --no-publish-backing-notebook
 **Options:**
 - `--no-publish-backing-notebook`: Do not publish the backing notebook (it is published by default).
 
+**Purpose:** Make a benchmark task public, optionally without publishing its
+backing notebook.
+
 **Notes:**
 - Idempotent: re-publishing an already-public task prints a message and returns successfully.
 - Unpublishing is not supported through this command.
 - If task not found, raises `ValueError: Task 'my-task' not found. Check the task name and try again. Use 'kaggle b t list' to see your tasks.`
 
+### `kaggle benchmarks topics list`
+
+Lists discussion topics for a benchmark.
+
+**Usage:**
+
+```bash
+kaggle benchmarks topics list [BENCHMARK] [options]
+```
+
+**Arguments:**
+
+- `[BENCHMARK]`: Benchmark reference.
+
+**Options:**
+
+- `--sort-by <SORT>`: One of `hot`, `top`, `new`, `recent`, `active`, `relevance`.
+- `-s, --search <TERM>`: Search text.
+- `--page-size <SIZE>`: Number of topics to return.
+- `--page-token <TOKEN>`: Page token.
+- `-v, --csv`: Print CSV.
+- `-q, --quiet`: Suppress extra output.
+
+**Examples:**
+
+```bash
+kaggle benchmarks topics list my-benchmark
+kaggle b topics list my-benchmark --sort-by recent --page-size 50
+```
+
+**Purpose:** Browse benchmark discussions before opening a specific topic.
+
+`kaggle benchmarks topics` without `list` works as a shortcut for
+listing topics.
+
+### `kaggle benchmarks topics show`
+
+Shows a benchmark discussion topic and comments in tree form.
+
+**Usage:**
+
+```bash
+kaggle benchmarks topics show <TOPIC_REF> [TOPIC_ID] [options]
+```
+
+**Arguments:**
+
+- `<TOPIC_REF>`: Topic reference, or benchmark reference when using the
+  two-argument form.
+- `[TOPIC_ID]`: Optional topic ID for the two-argument form.
+
+**Options:**
+
+- `--page-size <SIZE>`: Number of comments to return.
+- `--page-token <TOKEN>`: Page token.
+- `-v, --csv`: Print CSV.
+- `-q, --quiet`: Suppress extra output.
+
+**Examples:**
+
+```bash
+kaggle benchmarks topics show my-benchmark/12345
+kaggle benchmarks topics show my-benchmark 12345
+```
+
+**Purpose:** Read a benchmark discussion topic and its comments.
 
 ## Task Name Normalization
 

--- a/skills/references/competitions.md
+++ b/skills/references/competitions.md
@@ -1,0 +1,452 @@
+# Competitions CLI Reference
+
+Use `kaggle competitions` or alias `kaggle c` to discover competitions, inspect
+and download competition files, submit predictions or code-kernel output, inspect
+submissions and leaderboards, and browse competition discussion topics.
+
+## Prerequisites
+
+- Python 3.11+ with the `kaggle` package installed.
+- Kaggle credentials for most commands. Some file listing/download flows may
+  work logged out when the competition permits public access.
+- For commands that omit `<COMPETITION>`, set a default with:
+
+```bash
+kaggle config set -n competition -v titanic
+```
+
+## Command Hierarchy
+
+```text
+kaggle competitions (alias: kaggle c)
+├── list
+├── files
+├── download
+├── submit
+├── submissions
+├── leaderboard
+├── team-submissions
+├── episodes
+├── replay
+├── logs
+├── pages
+├── topics
+│   ├── list
+│   └── show
+└── topic-messages
+```
+
+## `kaggle competitions list`
+
+Lists available competitions.
+
+**Usage:**
+
+```bash
+kaggle competitions list [options]
+```
+
+**Options:**
+
+- `--group <GROUP>`: Competition group.
+- `--category <CATEGORY>`: Competition category.
+- `--sort-by <SORT>`: Sort order.
+- `-p, --page <PAGE>`: Page number.
+- `--page-size <SIZE>`: Number of items on a page.
+- `--page-token <TOKEN>`: Page token.
+- `-s, --search <TERM>`: Search text.
+- `-v, --csv`: Print CSV instead of table.
+
+**Examples:**
+
+```bash
+kaggle competitions list
+kaggle competitions list --category gettingStarted --sort-by latestDeadline
+kaggle c list -s titanic -v
+```
+
+**Purpose:** Find competition slugs to use with other commands.
+
+## `kaggle competitions files`
+
+Lists data files for a competition.
+
+**Usage:**
+
+```bash
+kaggle competitions files [COMPETITION] [options]
+```
+
+**Arguments:**
+
+- `[COMPETITION]`: Competition URL suffix. Uses configured default when omitted.
+
+**Options:**
+
+- `--page-token <TOKEN>`: Page token.
+- `--page-size <SIZE>`: Page size, default 20.
+- `-v, --csv`: Print CSV.
+- `-q, --quiet`: Suppress extra output.
+
+**Examples:**
+
+```bash
+kaggle competitions files titanic
+kaggle c files titanic --page-size 3 -v -q
+```
+
+**Purpose:** Inspect available files before downloading.
+
+## `kaggle competitions download`
+
+Downloads one or all competition data files.
+
+**Usage:**
+
+```bash
+kaggle competitions download [COMPETITION] [options]
+```
+
+**Options:**
+
+- `-f, --file <NAME>`: Download one file. Downloads all files when omitted.
+- `-p, --path <PATH>`: Download directory.
+- `-w, --wp`: Download to current working path.
+- `-o, --force`: Force download even if local file looks current.
+- `-q, --quiet`: Suppress progress output.
+
+**Examples:**
+
+```bash
+kaggle competitions download titanic
+kaggle competitions download titanic -f train.csv -p data
+kaggle c download -w -o -q
+```
+
+**Purpose:** Retrieve competition data for local training or analysis.
+
+## `kaggle competitions submit`
+
+Creates a competition submission from a local file or a kernel output file.
+
+**Usage:**
+
+```bash
+kaggle competitions submit [COMPETITION] -m <MESSAGE> [options]
+```
+
+**Options:**
+
+- `-f, --file <FILE>`: Local submission file, or output file name for code competitions.
+- `-k, --kernel <KERNEL>`: Kernel name for code competition submissions.
+- `-m, --message <MESSAGE>`: Required submission description.
+- `-v, --version <VERSION>`: Kernel version for code competitions.
+- `--sandbox`: Mark as sandbox submission for competition hosts/admins.
+- `-q, --quiet`: Suppress progress output.
+
+**Examples:**
+
+```bash
+kaggle competitions submit titanic -f submission.csv -m "baseline"
+kaggle c submit lux-ai -k user/agent -f submission.tar.gz -m "agent run" -v 3
+```
+
+**Purpose:** Submit predictions or code-kernel output to a competition.
+
+**Notes:** `--sandbox` is intended for competition hosts/admins. Code competition
+submission uses `-k`, `-f`, and optional `-v`.
+
+## `kaggle competitions submissions`
+
+Shows your submissions for a competition.
+
+**Usage:**
+
+```bash
+kaggle competitions submissions [COMPETITION] [options]
+```
+
+**Options:**
+
+- `--page-size <SIZE>`: Page size.
+- `--page-token <TOKEN>`: Page token.
+- `-v, --csv`: Print CSV.
+- `-q, --quiet`: Suppress extra output.
+
+**Examples:**
+
+```bash
+kaggle competitions submissions titanic -v
+```
+
+**Purpose:** Review submission status and scores.
+
+## `kaggle competitions leaderboard`
+
+Views or downloads competition leaderboard data.
+
+**Usage:**
+
+```bash
+kaggle competitions leaderboard [COMPETITION] [options]
+```
+
+**Options:**
+
+- `-s, --show`: Show top leaderboard rows.
+- `-d, --download`: Download the full leaderboard.
+- `-p, --path <PATH>`: Download directory.
+- `--page-size <SIZE>`: Page size.
+- `--page-token <TOKEN>`: Page token.
+- `-v, --csv`: Print CSV.
+- `-q, --quiet`: Suppress extra output.
+
+**Examples:**
+
+```bash
+kaggle competitions leaderboard titanic --show
+kaggle c leaderboard titanic --download -p leaderboards
+```
+
+**Purpose:** Inspect ranking data from the competition leaderboard.
+
+## `kaggle competitions team-submissions`
+
+Lists a team's public submissions.
+
+**Usage:**
+
+```bash
+kaggle competitions team-submissions <TEAM_ID> [options]
+```
+
+**Arguments:**
+
+- `<TEAM_ID>`: Team ID. Find team IDs from the competition leaderboard display.
+
+**Options:**
+
+- `-v, --csv`: Print CSV.
+- `-q, --quiet`: Suppress extra output.
+
+**Examples:**
+
+```bash
+kaggle competitions team-submissions 12345
+```
+
+**Purpose:** For simulation competitions, lists every active public submission;
+for regular competitions, lists the team's public leaderboard submission.
+
+## Simulation Competition Commands
+
+### `kaggle competitions episodes`
+
+Lists episodes for a submission in a simulation competition.
+
+**Usage:**
+
+```bash
+kaggle competitions episodes <SUBMISSION_ID> [options]
+```
+
+**Arguments:**
+
+- `<SUBMISSION_ID>`: Submission ID. Find it with
+  `kaggle competitions submissions <competition>`.
+
+**Options:**
+
+- `-v, --csv`: Print CSV.
+- `-q, --quiet`: Suppress extra output.
+
+**Examples:**
+
+```bash
+kaggle competitions episodes 12345678
+```
+
+**Purpose:** Inspect simulation match episodes associated with a submission.
+
+### `kaggle competitions replay`
+
+Downloads the replay for a simulation episode.
+
+**Usage:**
+
+```bash
+kaggle competitions replay <EPISODE_ID> [options]
+```
+
+**Arguments:**
+
+- `<EPISODE_ID>`: Episode ID from `kaggle competitions episodes <submission_id>`.
+
+**Options:**
+
+- `-p, --path <PATH>`: Destination folder.
+- `-q, --quiet`: Suppress extra output.
+
+**Examples:**
+
+```bash
+kaggle competitions replay 987654 -p replays
+```
+
+**Purpose:** Download the replay artifact for local review.
+
+### `kaggle competitions logs`
+
+Downloads logs for a specific agent in a simulation episode.
+
+**Usage:**
+
+```bash
+kaggle competitions logs <EPISODE_ID> <AGENT_INDEX> [options]
+```
+
+**Arguments:**
+
+- `<EPISODE_ID>`: Episode ID from `kaggle competitions episodes <submission_id>`.
+- `<AGENT_INDEX>`: Zero-based position of the agent in the episode.
+
+**Options:**
+
+- `-p, --path <PATH>`: Destination folder.
+- `-q, --quiet`: Suppress extra output.
+
+**Examples:**
+
+```bash
+kaggle competitions logs 987654 0 -p logs
+```
+
+**Purpose:** Download per-agent episode logs for debugging.
+
+## `kaggle competitions pages`
+
+Lists pages for a competition.
+
+**Usage:**
+
+```bash
+kaggle competitions pages [COMPETITION] [options]
+```
+
+**Options:**
+
+- `-v, --csv`: Print CSV.
+- `-q, --quiet`: Suppress extra output.
+- `--content`: Show full page content.
+- `--page-name <NAME>`: Filter to a specific page, such as `description`,
+  `rules`, or `evaluation`.
+
+**Examples:**
+
+```bash
+kaggle competitions pages titanic
+kaggle competitions pages titanic --page-name rules --content
+```
+
+**Purpose:** Inspect competition page metadata or retrieve page content.
+
+## Competition Discussion Commands
+
+### `kaggle competitions topics list`
+
+Lists discussion topics for a competition.
+
+**Usage:**
+
+```bash
+kaggle competitions topics list [COMPETITION] [options]
+```
+
+**Arguments:**
+
+- `[COMPETITION]`: Competition slug. If omitted, the default competition from
+  config may be used.
+
+**Options:**
+
+- `-s, --sort-by <SORT>`: One of `hot`, `top`, `new`, `recent`, `active`, `relevance`.
+- `-p, --page <PAGE>`: Page number.
+- `-v, --csv`: Print CSV.
+- `-q, --quiet`: Suppress extra output.
+
+**Examples:**
+
+```bash
+kaggle competitions topics list titanic
+kaggle competitions topics list titanic --sort-by recent -p 2
+```
+
+**Purpose:** Browse competition discussions before opening a specific topic.
+
+`kaggle competitions topics` without `list` works as a shortcut for
+listing topics.
+
+### `kaggle competitions topics show`
+
+Shows a topic and comments in tree form.
+
+**Usage:**
+
+```bash
+kaggle competitions topics show <TOPIC_REF> [TOPIC_ID] [options]
+```
+
+**Arguments:**
+
+- `<TOPIC_REF>`: Topic reference. It may be `<forum-or-entity>/<topic-id>` or
+  an entity reference when using the two-argument form.
+- `[TOPIC_ID]`: Optional topic ID for the two-argument form.
+
+**Options:**
+
+- `--page-size <SIZE>`: Number of comments to return.
+- `--page-token <TOKEN>`: Page token.
+- `-v, --csv`: Print CSV.
+- `-q, --quiet`: Suppress extra output.
+
+**Examples:**
+
+```bash
+kaggle competitions topics show titanic/12345
+kaggle competitions topics show titanic 12345
+```
+
+**Purpose:** Read a competition discussion topic and its comments.
+
+### `kaggle competitions topic-messages`
+
+Lists messages in a competition discussion topic.
+
+**Usage:**
+
+```bash
+kaggle competitions topic-messages [COMPETITION] <TOPIC_ID> [options]
+```
+
+**Arguments:**
+
+- `[COMPETITION]`: Competition slug. If omitted, the default competition from
+  config may be used.
+- `<TOPIC_ID>`: Discussion topic ID.
+
+**Options:**
+
+- `-s, --sort-by <SORT>`: One of `hot`, `new`, `old`, `top`.
+- `-n, --page-size <SIZE>`: Max top-level messages to return; `-1` for all.
+- `-v, --csv`: Print CSV.
+- `-q, --quiet`: Suppress extra output.
+
+**Examples:**
+
+```bash
+kaggle competitions topic-messages titanic 12345
+kaggle competitions topic-messages titanic 12345 --sort-by old -n 50
+```
+
+**Purpose:** Use the deprecated hidden alias to list comments for a competition
+topic when older workflows still call `topic-messages`.

--- a/skills/references/configuration.md
+++ b/skills/references/configuration.md
@@ -1,0 +1,122 @@
+# Configuration CLI Reference
+
+Use `kaggle config` to view, set, and unset local Kaggle CLI configuration. The
+CLI reads config from a JSON file plus `KAGGLE_` environment variables.
+
+## Prerequisites
+
+- Python 3.11+ with the `kaggle` package installed.
+- Write access to the Kaggle config directory when setting or unsetting values.
+
+## Command Hierarchy
+
+```text
+kaggle config
+├── view
+├── set
+└── unset
+```
+
+## Configuration File Location
+
+- If `KAGGLE_CONFIG_DIR` is set, the CLI uses that directory.
+- Otherwise it normally uses `~/.kaggle`.
+- On Linux, when `~/.kaggle` does not exist, it follows the XDG config path:
+  `${XDG_CONFIG_HOME:-~/.config}/kaggle`.
+- The config file name is `kaggle.json`.
+- Newly created config files are chmodded to `0600`.
+- Environment variables beginning with `KAGGLE_` are merged into config values
+  after file values are read.
+
+## `kaggle config view`
+
+Prints current config values.
+
+**Usage:**
+
+```bash
+kaggle config view
+```
+
+**Options:**
+
+- None.
+
+**Examples:**
+
+```bash
+kaggle config view
+```
+
+**Purpose:** Inspect configured username, auth method, path, proxy, and default
+competition.
+
+## `kaggle config set`
+
+Sets a configuration value.
+
+**Usage:**
+
+```bash
+kaggle config set -n <NAME> -v <VALUE>
+```
+
+**Options:**
+
+- `-n, --name <NAME>`: Config key.
+- `-v, --value <VALUE>`: Config value.
+
+**Common names:**
+
+- `competition`: Default competition slug.
+- `path`: Default download folder.
+- `proxy`: Proxy for HTTP requests.
+
+**Examples:**
+
+```bash
+kaggle config set -n competition -v titanic
+kaggle config set -n path -v /tmp/kaggle-downloads
+kaggle config set -n proxy -v http://proxy.example:8080
+```
+
+**Purpose:** Persist default values used by other commands.
+
+## `kaggle config unset`
+
+Removes a configuration value from the config file.
+
+**Usage:**
+
+```bash
+kaggle config unset -n <NAME>
+```
+
+**Options:**
+
+- `-n, --name <NAME>`: Config key to remove.
+
+**Examples:**
+
+```bash
+kaggle config unset -n competition
+```
+
+**Purpose:** Clear a persisted default and return to fallback behavior.
+
+## Behavior Details
+
+- `set` updates both the in-memory config and the JSON config file.
+- `unset` removes a key only from the config file; environment variables can
+  still provide a value on the next load.
+- Download commands use configured `path` as the base default when no explicit
+  path is provided.
+- Competition commands that accept optional competition slugs can use configured
+  `competition` as the default.
+
+## Notes
+
+- CLI help text names `competition`, `path`, and `proxy` as valid config names.
+  Authentication-related keys may also appear in config output.
+- If the config file is world-readable on non-Windows systems, the CLI prints a
+  permissions warning.

--- a/skills/references/datasets.md
+++ b/skills/references/datasets.md
@@ -1,0 +1,346 @@
+# Datasets CLI Reference
+
+Use `kaggle datasets` or alias `kaggle d` to search datasets, list and download
+files, initialize metadata, create datasets, create versions, update metadata,
+check creation status, delete datasets, and browse dataset discussions.
+
+## Prerequisites
+
+- Python 3.11+ with the `kaggle` package installed.
+- Kaggle credentials for create, version, metadata update, delete, and most
+  authenticated list/download scenarios.
+- For create/version flows, prepare a folder with `dataset-metadata.json`. Use
+  `kaggle datasets init -p <FOLDER>` to generate a starter file.
+
+## Command Hierarchy
+
+```text
+kaggle datasets (alias: kaggle d)
+├── list
+├── files
+├── download
+├── init
+├── create
+├── version
+├── metadata
+├── status
+├── delete
+└── topics
+    ├── list
+    └── show
+```
+
+## `kaggle datasets list`
+
+Lists available datasets.
+
+**Usage:**
+
+```bash
+kaggle datasets list [options]
+```
+
+**Options:**
+
+- `--sort-by <SORT>`: Sort order.
+- `--size <SIZE>`: Deprecated. Use `--max-size` and `--min-size`.
+- `--file-type <TYPE>`: File type filter.
+- `--license <LICENSE>`: License filter.
+- `--tags <TAGS>`: Comma-separated tag ids.
+- `-s, --search <TERM>`: Search text.
+- `-m, --mine`: Only your datasets.
+- `--user <USER>`: Datasets owned by a user or organization.
+- `-p, --page <PAGE>`: Page number.
+- `--max-size <BYTES>`: Maximum dataset size.
+- `--min-size <BYTES>`: Minimum dataset size.
+- `-v, --csv`: Print CSV.
+
+**Examples:**
+
+```bash
+kaggle datasets list
+kaggle datasets list -s "bird observation" --file-type csv
+kaggle d list --user kaggle --sort-by votes -v
+```
+
+**Purpose:** Find dataset handles in `<owner>/<dataset-slug>` format.
+
+## `kaggle datasets files`
+
+Lists files in a dataset.
+
+**Usage:**
+
+```bash
+kaggle datasets files [DATASET] [options]
+```
+
+**Arguments:**
+
+- `[DATASET]`: Dataset handle in `<owner>/<dataset-name>` format.
+
+**Options:**
+
+- `--page-token <TOKEN>`: Page token.
+- `--page-size <SIZE>`: Page size, default 20.
+- `-v, --csv`: Print CSV.
+
+**Examples:**
+
+```bash
+kaggle datasets files kaggle/titanic --page-size 7
+```
+
+**Purpose:** Inspect files before downloading.
+
+## `kaggle datasets download`
+
+Downloads dataset files.
+
+**Usage:**
+
+```bash
+kaggle datasets download [DATASET] [options]
+```
+
+**Options:**
+
+- `-f, --file <NAME>`: Download one file. Downloads all files when omitted.
+- `-p, --path <PATH>`: Download directory.
+- `-w, --wp`: Download to current working path.
+- `--unzip`: Unzip the downloaded archive and delete the zip.
+- `-o, --force`: Force download even if local file looks current.
+- `-q, --quiet`: Suppress progress output.
+
+**Examples:**
+
+```bash
+kaggle datasets download kaggle/titanic
+kaggle d download kaggle/titanic -f train.csv -p data --unzip
+```
+
+**Purpose:** Retrieve dataset files for local work.
+
+## `kaggle datasets init`
+
+Creates a starter `dataset-metadata.json`.
+
+**Usage:**
+
+```bash
+kaggle datasets init [options]
+```
+
+**Options:**
+
+- `-p, --path <FOLDER>`: Folder to write metadata to. Defaults to current directory.
+
+**Examples:**
+
+```bash
+kaggle datasets init -p my-dataset
+```
+
+**Purpose:** Bootstrap metadata before creating a dataset.
+
+## `kaggle datasets create`
+
+Creates a new dataset from local files and metadata.
+
+**Usage:**
+
+```bash
+kaggle datasets create [options]
+```
+
+**Options:**
+
+- `-p, --path <FOLDER>`: Folder containing files and `dataset-metadata.json`.
+- `-u, --public`: Create publicly. Default is private.
+- `-q, --quiet`: Suppress progress output.
+- `-t, --keep-tabular`: Do not convert tabular files to CSV.
+- `-r, --dir-mode <skip|zip|tar>`: Directory handling. Default `skip`.
+
+**Examples:**
+
+```bash
+kaggle datasets create -p my-dataset -u -q -t -r skip
+```
+
+**Purpose:** Upload local files and metadata to create a Kaggle dataset.
+
+## `kaggle datasets version`
+
+Creates a new version of an existing dataset.
+
+**Usage:**
+
+```bash
+kaggle datasets version -m <MESSAGE> [options]
+```
+
+**Options:**
+
+- `-m, --message <MESSAGE>`: Required version notes.
+- `-p, --path <FOLDER>`: Folder containing updated files and metadata.
+- `-q, --quiet`: Suppress progress output.
+- `-t, --keep-tabular`: Do not convert tabular files to CSV.
+- `-r, --dir-mode <skip|zip|tar>`: Directory handling. Default `skip`.
+- `-d, --delete-old-versions`: Delete old versions of this dataset.
+
+**Examples:**
+
+```bash
+kaggle datasets version -p my-dataset -m "Updated data" -q -t -r skip
+```
+
+**Purpose:** Publish updated dataset files or metadata as a new version.
+
+## `kaggle datasets metadata`
+
+Downloads or updates dataset metadata.
+
+**Usage:**
+
+```bash
+kaggle datasets metadata [DATASET] [options]
+```
+
+**Options:**
+
+- `--update`: Update server metadata from local metadata.
+- `-p, --path <PATH>`: Metadata folder. Defaults to current directory.
+
+**Examples:**
+
+```bash
+kaggle datasets metadata kaggle/titanic -p metadata
+kaggle datasets metadata kaggle/titanic --update -p metadata
+```
+
+**Purpose:** Retrieve or update `dataset-metadata.json`.
+
+**Notes:** Metadata update also supports selected dataset metadata fields and
+dataset cover image files supported by the CLI.
+
+## `kaggle datasets status`
+
+Gets creation status for a dataset.
+
+**Usage:**
+
+```bash
+kaggle datasets status [DATASET] [options]
+```
+
+**Options:**
+
+- `--format <FORMAT>`: Plain status by default. `json`,
+  `json(current_version_number)`, and field selection are supported.
+
+**Examples:**
+
+```bash
+kaggle datasets status owner/dataset
+kaggle d status owner/dataset --format json
+```
+
+**Purpose:** Check whether dataset creation/versioning is complete.
+
+## `kaggle datasets delete`
+
+Deletes a dataset.
+
+**Usage:**
+
+```bash
+kaggle datasets delete <DATASET> [options]
+```
+
+**Options:**
+
+- `-y, --yes`: Skip confirmation.
+
+**Examples:**
+
+```bash
+kaggle datasets delete owner/dataset -y
+```
+
+**Purpose:** Remove a dataset from Kaggle.
+
+## Dataset Discussion Commands
+
+### `kaggle datasets topics list`
+
+Lists discussion topics for a dataset.
+
+**Usage:**
+
+```bash
+kaggle datasets topics list [DATASET] [options]
+```
+
+**Arguments:**
+
+- `[DATASET]`: Dataset handle in `<owner>/<dataset-slug>` format.
+
+**Options:**
+
+- `--sort-by <SORT>`: One of `hot`, `top`, `new`, `recent`, `active`, `relevance`.
+- `-s, --search <TERM>`: Search text.
+- `--page-size <SIZE>`: Number of topics to return.
+- `--page-token <TOKEN>`: Page token.
+- `-v, --csv`: Print CSV.
+- `-q, --quiet`: Suppress extra output.
+
+**Examples:**
+
+```bash
+kaggle datasets topics list zillow/zecon
+kaggle datasets topics list zillow/zecon --sort-by recent --page-size 50
+```
+
+**Purpose:** Browse dataset discussions before opening a specific topic.
+
+`kaggle datasets topics` without `list` works as a shortcut for listing
+topics.
+
+### `kaggle datasets topics show`
+
+Shows a dataset discussion topic and comments in tree form.
+
+**Usage:**
+
+```bash
+kaggle datasets topics show <TOPIC_REF> [TOPIC_ID] [options]
+```
+
+**Arguments:**
+
+- `<TOPIC_REF>`: Topic reference, or dataset handle when using the two-argument
+  form.
+- `[TOPIC_ID]`: Optional topic ID for the two-argument form.
+
+**Options:**
+
+- `--page-size <SIZE>`: Number of comments to return.
+- `--page-token <TOKEN>`: Page token.
+- `-v, --csv`: Print CSV.
+- `-q, --quiet`: Suppress extra output.
+
+**Examples:**
+
+```bash
+kaggle datasets topics show zillow/zecon/12345
+kaggle datasets topics show zillow/zecon 12345
+```
+
+**Purpose:** Read a dataset discussion topic and its comments.
+
+## Error Scenarios And Notes
+
+- Dataset handles should be `<owner>/<dataset-slug>`.
+- Create/version commands require local metadata in the upload folder.
+- Directory uploads follow `--dir-mode`; `skip` ignores directories, `zip`
+  compresses them, and `tar` uploads an uncompressed archive.

--- a/skills/references/files.md
+++ b/skills/references/files.md
@@ -1,0 +1,70 @@
+# Files CLI Reference
+
+Use `kaggle files` to upload local files or directories to a Kaggle inbox path.
+This command is separate from dataset/model/kernel uploads and uses the inbox
+file API.
+
+## Prerequisites
+
+- Python 3.11+ with the `kaggle` package installed.
+- Kaggle credentials.
+- Local filesystem paths to upload.
+
+## Command Hierarchy
+
+```text
+kaggle files
+└── upload | u
+```
+
+## `kaggle files upload`
+
+Uploads one or more local paths to the server inbox.
+
+**Usage:**
+
+```bash
+kaggle files upload [options] <LOCAL_PATH> [LOCAL_PATH ...]
+```
+
+**Arguments:**
+
+- `<LOCAL_PATH>`: One or more local files or directories. Each path creates a
+  separate inbox file.
+
+**Options:**
+
+- `-i, --inbox-path <PATH>`: Virtual path on the server where uploaded files are stored.
+- `--no-resume`: Skip resumable uploads.
+- `--no-compress`: Do not zip directories; upload directories as tar archives.
+
+**Examples:**
+
+```bash
+kaggle files upload report.csv
+kaggle files upload -i experiments/run-1 output.csv metrics.json
+kaggle files upload --no-resume --no-compress local-directory
+kaggle files u -i scratch data.zip
+```
+
+**Purpose:** Upload arbitrary local files to an inbox location.
+
+## Behavior Details
+
+- The command accepts up to `MAX_NUM_INBOX_FILES_TO_UPLOAD`, currently 1000
+  local paths.
+- Each provided local path is uploaded independently.
+- Directory paths are compressed by default as zip archives.
+- With `--no-compress`, directory paths are uploaded using tar mode.
+- Uploads use resumable upload machinery unless `--no-resume` is set.
+- After uploading each blob, the CLI creates an inbox file and prints
+  `Inbox file created: <name>`.
+
+## Error Scenarios And Notes
+
+- Paths that fail upload are skipped by the upload helper; successfully uploaded
+  paths still proceed to inbox file creation.
+- This command does not create Kaggle Datasets. Use `kaggle datasets create` or
+  `kaggle datasets version` for dataset uploads.
+- This command does not accept `-q/--quiet`; progress/noise behavior comes from
+  the upload behavior.

--- a/skills/references/forums.md
+++ b/skills/references/forums.md
@@ -1,0 +1,127 @@
+# Forums CLI Reference
+
+Use `kaggle forums` or alias `kaggle f` to list Kaggle discussion forums, list
+topics in forums, and show a topic with comments in tree form.
+
+## Prerequisites
+
+- Python 3.11+ with the `kaggle` package installed.
+- Kaggle credentials may be needed for user-specific forum groups such as owned,
+  bookmarked, upvoted, or drafts.
+
+## Command Hierarchy
+
+```text
+kaggle forums (alias: kaggle f)
+├── list
+└── topics
+    ├── list
+    └── show
+```
+
+`kaggle forums` without a subcommand works as a shortcut for
+`kaggle forums list`.
+
+## `kaggle forums list`
+
+Lists discussion forums.
+
+**Usage:**
+
+```bash
+kaggle forums list [options]
+```
+
+**Options:**
+
+- `-v, --csv`: Print CSV.
+- `-q, --quiet`: Suppress extra output.
+
+**Examples:**
+
+```bash
+kaggle forums
+kaggle forums list -v
+kaggle f list -q
+```
+
+**Purpose:** Find forum slugs such as `getting-started` or `product-feedback`.
+
+## `kaggle forums topics list`
+
+Lists topics in a forum or broader topic category/group.
+
+**Usage:**
+
+```bash
+kaggle forums topics list [FORUM] [options]
+```
+
+**Arguments:**
+
+- `[FORUM]`: Forum slug. Use `kaggle forums` to list available forums.
+
+**Options:**
+
+- `--group <GROUP>`: Topic group filter. Use live `--help` output when unsure
+  which group names the installed CLI accepts.
+- `--category <CATEGORY>`: Topic category filter. Use live `--help` output when
+  unsure which category names the installed CLI accepts.
+- `--sort-by <SORT>`: One of `hot`, `top`, `new`, `recent`, `active`, `relevance`.
+- `-s, --search <TERM>`: Search text.
+- `--page-size <SIZE>`: Page size.
+- `--page-token <TOKEN>`: Page token.
+- `-v, --csv`: Print CSV.
+- `-q, --quiet`: Suppress extra output.
+
+**Examples:**
+
+```bash
+kaggle forums topics list getting-started
+kaggle f topics list --category datasets --sort-by recent
+kaggle forums topics list product-feedback -s "api" -v
+```
+
+**Purpose:** Browse discussion topics across global forums and resource-linked
+categories.
+
+`kaggle forums topics` without `list` works as a shortcut for listing
+topics.
+
+## `kaggle forums topics show`
+
+Displays a topic and all comments in tree form.
+
+**Usage:**
+
+```bash
+kaggle forums topics show <TOPIC_REF> [TOPIC_ID] [options]
+```
+
+**Arguments:**
+
+- `<TOPIC_REF>`: Topic reference in `<forum-name>/<topic-id>` form, or a topic id.
+- `[TOPIC_ID]`: Optional topic id when using two-argument form.
+
+**Options:**
+
+- `--page-size <SIZE>`: Page size.
+- `--page-token <TOKEN>`: Page token.
+- `-v, --csv`: CSV output where supported.
+- `-q, --quiet`: Suppress extra output.
+
+**Examples:**
+
+```bash
+kaggle forums topics show getting-started/12345
+kaggle f topics show getting-started 12345
+```
+
+**Purpose:** Read a discussion topic and comments from the CLI.
+
+## Notes
+
+- Resource-specific topics also exist under `competitions`, `datasets`,
+  `models`, and `benchmarks`.
+- For entity topics, use the entity command so default entity context and
+  resource-specific validation are applied.

--- a/skills/references/kernels.md
+++ b/skills/references/kernels.md
@@ -1,0 +1,273 @@
+# Kernels CLI Reference
+
+Use `kaggle kernels` or alias `kaggle k` to list kernels, inspect output files,
+initialize metadata, push notebook/script code, pull code, download output,
+inspect run status, stream logs, and delete kernels.
+
+## Prerequisites
+
+- Python 3.11+ with the `kaggle` package installed.
+- Kaggle credentials for push/pull/output/status/logs/delete.
+- For push flows, prepare a folder containing `kernel-metadata.json`. Use
+  `kaggle kernels init -p <FOLDER>` to generate a starter file.
+
+## Command Hierarchy
+
+```text
+kaggle kernels (alias: kaggle k)
+├── list
+├── files
+├── init
+├── push | update
+├── pull | get
+├── output
+├── status
+├── logs
+└── delete
+```
+
+Note: `get` is an alias for `pull`; `update` is an alias for `push`.
+
+## `kaggle kernels list`
+
+Lists available kernels.
+
+**Usage:**
+
+```bash
+kaggle kernels list [options]
+```
+
+**Options:**
+
+- `-m, --mine`: Only your kernels.
+- `-p, --page <PAGE>`: Page number.
+- `--page-size <SIZE>`: Page size, default 20.
+- `-s, --search <TERM>`: Search text.
+- `--parent <KERNEL>`: Children of a parent kernel.
+- `--competition <SLUG>`: Kernels for a competition.
+- `--dataset <OWNER/SLUG>`: Kernels for a dataset.
+- `--user <USER>`: Kernels by user.
+- `--language <LANG>`: `all`, `python`, `r`, `sqlite`, `julia`.
+- `--kernel-type <TYPE>`: `all`, `script`, `notebook`.
+- `--output-type <TYPE>`: `all`, `visualization`, `data`.
+- `--sort-by <SORT>`: Sort order.
+- `-v, --csv`: Print CSV.
+
+**Examples:**
+
+```bash
+kaggle kernels list
+kaggle kernels list --user kaggle --language python --sort-by dateRun
+kaggle k list -m -v
+```
+
+**Purpose:** Find kernel handles in `<owner>/<kernel-slug>` format.
+
+## `kaggle kernels files`
+
+Lists output files for a kernel.
+
+**Usage:**
+
+```bash
+kaggle kernels files [KERNEL] [options]
+```
+
+**Options:**
+
+- `--page-size <SIZE>`: Page size.
+- `--page-token <TOKEN>`: Page token.
+- `-v, --csv`: Print CSV.
+
+**Examples:**
+
+```bash
+kaggle kernels files kerneler/sqlite-global-default -v --page-size 1
+```
+
+**Purpose:** Inspect generated output before downloading.
+
+## `kaggle kernels init`
+
+Creates a starter `kernel-metadata.json`.
+
+**Usage:**
+
+```bash
+kaggle kernels init [options]
+```
+
+**Options:**
+
+- `-p, --path <FOLDER>`: Folder where metadata will be written.
+
+**Examples:**
+
+```bash
+kaggle kernels init -p my-kernel
+```
+
+**Purpose:** Bootstrap local metadata for `kaggle kernels push`.
+
+## `kaggle kernels push`
+
+Pushes code to a kernel and runs it.
+
+**Usage:**
+
+```bash
+kaggle kernels push [options]
+```
+
+**Options:**
+
+- `-p, --path <FOLDER>`: Folder containing files and `kernel-metadata.json`.
+- `-t, --timeout <SECONDS>`: Limit run time, bounded by Kaggle's maximum.
+- `--accelerator <ACCELERATOR>`: Accelerator type for the kernel run.
+
+**Examples:**
+
+```bash
+kaggle kernels push -p my-kernel --timeout 3600 --accelerator gpu
+kaggle kernels update -p my-kernel
+```
+
+**Purpose:** Upload local notebook/script code and create a new kernel version.
+
+## `kaggle kernels pull`
+
+Pulls code from a kernel.
+
+**Usage:**
+
+```bash
+kaggle kernels pull [KERNEL] [options]
+```
+
+**Options:**
+
+- `-p, --path <PATH>`: Download folder.
+- `-w, --wp`: Download to current working path.
+- `-m, --metadata`: Generate metadata when pulling.
+**Examples:**
+
+```bash
+kaggle kernels pull owner/kernel-slug -p pulled
+kaggle kernels get owner/kernel-slug -w -m
+kaggle k pull owner/kernel-slug/3 -w -m
+```
+
+**Purpose:** Retrieve notebook/script source from Kaggle.
+
+**Notes:** Kernel references may include an optional version:
+`<owner>/<kernel-name>/<version>`.
+
+## `kaggle kernels output`
+
+Downloads output from the latest kernel run.
+
+**Usage:**
+
+```bash
+kaggle kernels output [KERNEL] [options]
+```
+
+**Options:**
+
+- `-p, --path <PATH>`: Download folder.
+- `-w, --wp`: Download to current working path.
+- `-o, --force`: Force download.
+- `-q, --quiet`: Suppress progress output.
+- `--file-pattern <REGEX>`: Download only matching output files.
+- `--page-size <SIZE>`: Output files per page.
+- `--page-token <TOKEN>`: Download from one output page.
+
+**Examples:**
+
+```bash
+kaggle kernels output owner/kernel-slug -p output
+kaggle k output owner/kernel-slug --file-pattern ".*\\.png$"
+```
+
+**Purpose:** Retrieve generated files such as submissions, images, or processed
+data.
+
+**Notes:** Without `--page-token`, output download scans available pages so
+`--file-pattern` can match files beyond the first page.
+
+## `kaggle kernels status`
+
+Displays status of the latest kernel run.
+
+**Usage:**
+
+```bash
+kaggle kernels status [KERNEL]
+```
+
+**Options:**
+
+- No visible options. If `[KERNEL]` is omitted, local `kernel-metadata.json`
+  supplies the kernel reference.
+
+**Examples:**
+
+```bash
+kaggle kernels status owner/kernel-slug
+```
+
+**Purpose:** Check whether the latest run is queued, running, complete, or
+errored.
+
+## `kaggle kernels logs`
+
+Prints execution logs from the latest kernel run.
+
+**Usage:**
+
+```bash
+kaggle kernels logs [KERNEL] [options]
+```
+
+**Options:**
+
+- `-f, --follow`: Continuously poll and print new log lines.
+- `--interval <SECONDS>`: Poll interval for follow mode. Default 5.
+
+**Examples:**
+
+```bash
+kaggle kernels logs owner/kernel-slug
+kaggle k logs owner/kernel-slug --follow --interval 10
+```
+
+**Purpose:** Debug kernel execution from CLI logs.
+
+## `kaggle kernels delete`
+
+Deletes a kernel.
+
+**Usage:**
+
+```bash
+kaggle kernels delete <KERNEL> [options]
+```
+
+**Options:**
+
+- `-y, --yes`: Skip confirmation.
+
+**Examples:**
+
+```bash
+kaggle kernels delete owner/kernel-slug -y
+```
+
+**Purpose:** Remove a kernel from Kaggle.
+
+## Error Scenarios And Notes
+
+- Kernel handles are `<owner>/<kernel-name>` or `<owner>/<kernel-name>/<version>`.
+- Push requires a metadata file and valid code file path in that metadata.
+- `logs --follow` polls repeatedly; use `--interval` to avoid excessive calls.

--- a/skills/references/model_variations.md
+++ b/skills/references/model_variations.md
@@ -1,0 +1,206 @@
+# Model Variations CLI Reference
+
+Use `kaggle models variations` to manage framework-specific variations of a
+Kaggle Model. The CLI also accepts legacy aliases
+`kaggle models instances`, `kaggle models v`, and `kaggle models i`.
+
+## Prerequisites
+
+- Python 3.11+ with the `kaggle` package installed.
+- Kaggle credentials for private models and mutation commands.
+- An existing model for create flows.
+- For init/create/update flows, use `model-instance-metadata.json`. Use
+  `kaggle models variations init -p <FOLDER>` to generate a starter file.
+
+## Command Hierarchy
+
+```text
+kaggle models variations (aliases: instances, v, i)
+├── get
+├── init
+├── create
+├── files
+├── list
+├── update
+├── delete
+└── versions | v
+    ├── list
+    ├── create
+    ├── download
+    ├── files
+    └── delete
+```
+
+## `kaggle models variations init`
+
+Creates a starter `model-instance-metadata.json`.
+
+**Usage:**
+
+```bash
+kaggle models variations init [options]
+```
+
+**Options:**
+
+- `-p, --path <FOLDER>`: Folder where metadata will be written.
+
+**Examples:**
+
+```bash
+kaggle models variations init -p my-model/main
+```
+
+**Purpose:** Bootstrap metadata for a model variation.
+
+## `kaggle models variations create`
+
+Creates a new model variation and first version.
+
+**Usage:**
+
+```bash
+kaggle models variations create [options]
+```
+
+**Options:**
+
+- `-p, --path <FOLDER>`: Folder containing files and `model-instance-metadata.json`.
+- `-q, --quiet`: Suppress progress output.
+- `-r, --dir-mode <skip|zip|tar>`: Directory handling. Default `skip`.
+
+**Examples:**
+
+```bash
+kaggle models variations create -p tmp -q -r skip
+```
+
+**Purpose:** Upload variation metadata and files under an existing model.
+
+## `kaggle models variations get`
+
+Gets model variation metadata.
+
+**Usage:**
+
+```bash
+kaggle models variations get <MODEL_VARIATION> [options]
+```
+
+**Arguments:**
+
+- `<MODEL_VARIATION>`: `<owner>/<model>/<framework>/<variation-slug>`.
+
+**Options:**
+
+- `-p, --path <FOLDER>`: Folder to download metadata to.
+
+**Examples:**
+
+```bash
+kaggle models variations get google/gemma/pytorch/7b -p metadata
+```
+
+**Purpose:** Download metadata for a variation.
+
+## `kaggle models variations files`
+
+Lists files for the current version of a model variation.
+
+**Usage:**
+
+```bash
+kaggle models variations files <MODEL_VARIATION> [options]
+```
+
+**Options:**
+
+- `--page-size <SIZE>`: Page size, default 20.
+- `--page-token <TOKEN>`: Page token.
+- `-v, --csv`: Print CSV.
+
+**Examples:**
+
+```bash
+kaggle models variations files google/gemma/pytorch/7b -v --page-size 5
+```
+
+**Purpose:** Inspect files associated with the latest variation version.
+
+## `kaggle models variations list`
+
+Lists variations of a model.
+
+**Usage:**
+
+```bash
+kaggle models variations list <MODEL> [options]
+```
+
+**Options:**
+
+- `--page-size <SIZE>`: Page size, default 20.
+- `--page-token <TOKEN>`: Page token.
+- `-v, --csv`: Print CSV.
+
+**Examples:**
+
+```bash
+kaggle models variations list google/gemma
+```
+
+**Purpose:** See framework-specific variations under a model.
+
+## `kaggle models variations update`
+
+Updates variation metadata.
+
+**Usage:**
+
+```bash
+kaggle models variations update [options]
+```
+
+**Options:**
+
+- `-p, --path <FOLDER>`: Folder containing updated `model-instance-metadata.json`.
+
+**Examples:**
+
+```bash
+kaggle models variations update -p tmp
+```
+
+**Purpose:** Change variation metadata. This does not upload new files or create
+a version; use `models variations versions create` for file updates. The
+variation identity is read from `ownerSlug`, `modelSlug`, `framework`, and
+`instanceSlug` inside `model-instance-metadata.json`.
+
+## `kaggle models variations delete`
+
+Deletes a model variation.
+
+**Usage:**
+
+```bash
+kaggle models variations delete <MODEL_VARIATION> [options]
+```
+
+**Options:**
+
+- `-y, --yes`: Skip confirmation.
+
+**Examples:**
+
+```bash
+kaggle models variations delete owner/model/jax/main -y
+```
+
+**Purpose:** Remove a model variation.
+
+## Notes
+
+- Variation handles use `<owner>/<model-name>/<framework>/<variation-slug>`.
+- `instances` is accepted as a legacy spelling for `variations`.
+- Directory uploads follow `--dir-mode`; `skip` ignores directories, `zip`
+  compresses them, and `tar` uploads an uncompressed archive.

--- a/skills/references/model_variations_versions.md
+++ b/skills/references/model_variations_versions.md
@@ -1,0 +1,156 @@
+# Model Variation Versions CLI Reference
+
+Use `kaggle models variations versions` to manage numbered snapshots of a model
+variation's files. The CLI also accepts nested alias `v` under variations.
+
+## Prerequisites
+
+- Python 3.11+ with the `kaggle` package installed.
+- Kaggle credentials for private model variations and mutation commands.
+- An existing model variation in `<owner>/<model>/<framework>/<variation>` form.
+
+## Command Hierarchy
+
+```text
+kaggle models variations versions (alias under variations: v)
+├── list
+├── create
+├── download
+├── files
+└── delete
+```
+
+Note: do not recommend `kaggle models variations versions init`; use
+`kaggle models variations init` to create variation metadata.
+
+## `kaggle models variations versions list`
+
+Lists versions for a model variation.
+
+**Usage:**
+
+```bash
+kaggle models variations versions list <MODEL_VARIATION> [options]
+```
+
+**Options:**
+
+- `--page-size <SIZE>`: Page size, default 20.
+- `--page-token <TOKEN>`: Page token.
+- `-v, --csv`: Print CSV.
+
+**Examples:**
+
+```bash
+kaggle models variations versions list google/gemma/pytorch/7b -v
+```
+
+**Purpose:** Inspect available numbered versions before selecting one.
+
+## `kaggle models variations versions create`
+
+Creates a new version for a model variation.
+
+**Usage:**
+
+```bash
+kaggle models variations versions create <MODEL_VARIATION> [options]
+```
+
+**Options:**
+
+- `-p, --path <FOLDER>`: Folder containing files for the new version.
+- `-n, --version-notes <NOTES>`: Version notes.
+- `-q, --quiet`: Suppress progress output.
+- `-r, --dir-mode <skip|zip|tar>`: Directory handling. Default `skip`.
+
+**Examples:**
+
+```bash
+kaggle models variations versions create owner/model/jax/main -p tmp -n "Updated files" -q -r skip
+```
+
+**Purpose:** Upload a new file snapshot for an existing variation.
+
+## `kaggle models variations versions download`
+
+Downloads files for a specific variation version.
+
+**Usage:**
+
+```bash
+kaggle models variations versions download <MODEL_VARIATION_VERSION> [options]
+```
+
+**Arguments:**
+
+- `<MODEL_VARIATION_VERSION>`:
+  `<owner>/<model>/<framework>/<variation>/<version-number>`.
+
+**Options:**
+
+- `-p, --path <PATH>`: Download folder.
+- `--untar`: Untar the downloaded archive and delete the tar file.
+- `-f, --force`: Force download.
+- `-q, --quiet`: Suppress progress output.
+
+**Examples:**
+
+```bash
+kaggle models variations versions download google/gemma/pytorch/7b/2 -p models --untar
+```
+
+**Purpose:** Retrieve files for a specific version.
+
+## `kaggle models variations versions files`
+
+Lists files for a specific variation version.
+
+**Usage:**
+
+```bash
+kaggle models variations versions files <MODEL_VARIATION_VERSION> [options]
+```
+
+**Options:**
+
+- `--page-size <SIZE>`: Page size, default 20.
+- `--page-token <TOKEN>`: Page token.
+- `-v, --csv`: Print CSV.
+
+**Examples:**
+
+```bash
+kaggle models variations versions files google/gemma/pytorch/7b/2 -v --page-size 3
+```
+
+**Purpose:** Inspect files inside a numbered version.
+
+## `kaggle models variations versions delete`
+
+Deletes a model variation version.
+
+**Usage:**
+
+```bash
+kaggle models variations versions delete <MODEL_VARIATION_VERSION> [options]
+```
+
+**Options:**
+
+- `-y, --yes`: Skip confirmation.
+
+**Examples:**
+
+```bash
+kaggle models variations versions delete owner/model/jax/main/2 -y
+```
+
+**Purpose:** Remove a specific version snapshot.
+
+## Notes
+
+- Version handles use
+  `<owner>/<model-name>/<framework>/<variation-slug>/<version-number>`.
+- Directory uploads follow `--dir-mode`; `skip` ignores directories, `zip`
+  compresses them, and `tar` uploads an uncompressed archive.

--- a/skills/references/models.md
+++ b/skills/references/models.md
@@ -1,0 +1,250 @@
+# Models CLI Reference
+
+Use `kaggle models` or alias `kaggle m` to list, initialize, create, retrieve,
+update, and delete Kaggle Model records, and to browse model discussion topics.
+Model files normally live under model variations; see the model variation
+references for variation and version upload/download flows.
+
+## Prerequisites
+
+- Python 3.11+ with the `kaggle` package installed.
+- Kaggle credentials for create/update/delete and private model access.
+- For create/update flows, prepare `model-metadata.json`. Use
+  `kaggle models init -p <FOLDER>` to generate a starter file.
+
+## Command Hierarchy
+
+```text
+kaggle models (alias: kaggle m)
+├── list
+├── init
+├── create
+├── get
+├── update
+├── delete
+├── topics
+│   ├── list
+│   └── show
+└── variations | instances | v | i
+```
+
+## `kaggle models list`
+
+Lists public models.
+
+**Usage:**
+
+```bash
+kaggle models list [options]
+```
+
+**Options:**
+
+- `--sort-by <SORT>`: Sort order.
+- `-s, --search <TERM>`: Search text.
+- `--owner <OWNER>`: Models owned by a user or organization.
+- `--page-size <SIZE>`: Page size.
+- `--page-token <TOKEN>`: Page token.
+- `-v, --csv`: Print CSV.
+
+**Examples:**
+
+```bash
+kaggle models list
+kaggle models list --owner google --sort-by downloadCount
+kaggle m list -s gemma -v
+```
+
+**Purpose:** Find model handles in `<owner>/<model-name>` format.
+
+## `kaggle models init`
+
+Creates a starter `model-metadata.json`.
+
+**Usage:**
+
+```bash
+kaggle models init [options]
+```
+
+**Options:**
+
+- `-p, --path <FOLDER>`: Folder where metadata will be written.
+
+**Examples:**
+
+```bash
+kaggle models init -p my-model
+```
+
+**Purpose:** Bootstrap model metadata before creation.
+
+## `kaggle models create`
+
+Creates a new Kaggle Model.
+
+**Usage:**
+
+```bash
+kaggle models create [options]
+```
+
+**Options:**
+
+- `-p, --path <FOLDER>`: Folder containing `model-metadata.json`.
+
+**Examples:**
+
+```bash
+kaggle models create -p my-model
+```
+
+**Purpose:** Create a model record. Files are managed through variations and
+versions.
+
+## `kaggle models get`
+
+Gets model metadata.
+
+**Usage:**
+
+```bash
+kaggle models get <MODEL> [options]
+```
+
+**Arguments:**
+
+- `<MODEL>`: Model handle in `<owner>/<model-name>` format.
+
+**Options:**
+
+- `-p, --path <FOLDER>`: Folder to download model metadata to.
+
+**Examples:**
+
+```bash
+kaggle models get google/gemma -p metadata
+```
+
+**Purpose:** Download metadata for an existing model.
+
+## `kaggle models update`
+
+Updates model metadata.
+
+**Usage:**
+
+```bash
+kaggle models update [options]
+```
+
+**Options:**
+
+- `-p, --path <FOLDER>`: Folder containing updated `model-metadata.json`.
+
+**Examples:**
+
+```bash
+kaggle models update -p my-model
+```
+
+**Purpose:** Change model metadata without changing variation files. The model
+identity is read from `ownerSlug` and `slug` inside `model-metadata.json`.
+
+## `kaggle models delete`
+
+Deletes a model.
+
+**Usage:**
+
+```bash
+kaggle models delete <MODEL> [options]
+```
+
+**Options:**
+
+- `-y, --yes`: Skip confirmation.
+
+**Examples:**
+
+```bash
+kaggle models delete owner/model-slug -y
+```
+
+**Purpose:** Remove a model and its associated resources.
+
+## Model Discussion Commands
+
+### `kaggle models topics list`
+
+Lists discussion topics for a model.
+
+**Usage:**
+
+```bash
+kaggle models topics list [MODEL] [options]
+```
+
+**Arguments:**
+
+- `[MODEL]`: Model handle in `<owner>/<model-slug>` format.
+
+**Options:**
+
+- `--sort-by <SORT>`: One of `hot`, `top`, `new`, `recent`, `active`, `relevance`.
+- `-s, --search <TERM>`: Search text.
+- `--page-size <SIZE>`: Number of topics to return.
+- `--page-token <TOKEN>`: Page token.
+- `-v, --csv`: Print CSV.
+- `-q, --quiet`: Suppress extra output.
+
+**Examples:**
+
+```bash
+kaggle models topics list owner/model-slug
+kaggle models topics list owner/model-slug --sort-by recent --page-size 50
+```
+
+**Purpose:** Browse model discussions before opening a specific topic.
+
+`kaggle models topics` without `list` works as a shortcut for listing
+topics.
+
+### `kaggle models topics show`
+
+Shows a model discussion topic and comments in tree form.
+
+**Usage:**
+
+```bash
+kaggle models topics show <TOPIC_REF> [TOPIC_ID] [options]
+```
+
+**Arguments:**
+
+- `<TOPIC_REF>`: Topic reference, or model handle when using the two-argument
+  form.
+- `[TOPIC_ID]`: Optional topic ID for the two-argument form.
+
+**Options:**
+
+- `--page-size <SIZE>`: Number of comments to return.
+- `--page-token <TOKEN>`: Page token.
+- `-v, --csv`: Print CSV.
+- `-q, --quiet`: Suppress extra output.
+
+**Examples:**
+
+```bash
+kaggle models topics show owner/model-slug/12345
+kaggle models topics show owner/model-slug 12345
+```
+
+**Purpose:** Read a model discussion topic and its comments.
+
+## Notes
+
+- The CLI supports both `models variations` and legacy `models instances`
+  naming. They behave as the same model variation command family.
+- Use `model_variations.md` for creating and managing framework-specific model
+  variations.

--- a/skills/references/quota.md
+++ b/skills/references/quota.md
@@ -1,0 +1,65 @@
+# Quota CLI Reference
+
+Use `kaggle quota` to show the current user's weekly GPU and TPU accelerator
+quota for Kaggle kernels.
+
+## Prerequisites
+
+- Python 3.11+ with the `kaggle` package installed.
+- Kaggle credentials.
+
+## Command Hierarchy
+
+```text
+kaggle quota
+```
+
+## `kaggle quota`
+
+Shows current weekly GPU and TPU accelerator quota.
+
+**Usage:**
+
+```bash
+kaggle quota [options]
+```
+
+**Options:**
+
+- `-v, --csv`: Print CSV instead of table.
+
+**Examples:**
+
+```bash
+kaggle quota
+kaggle quota -v
+```
+
+**Purpose:** Inspect used, remaining, total, and refresh time for GPU/TPU quota.
+
+## Output
+
+Table fields:
+
+- `resource`: `GPU` or `TPU`.
+- `used`: Used time in hours.
+- `remaining`: Remaining time in hours.
+- `total`: Total allowed time in hours.
+- `refreshAt`: Quota refresh timestamp when returned by the server.
+
+CSV header:
+
+```text
+resource,used,remaining,total,refreshAt
+```
+
+## Behavior Details
+
+- Missing GPU or TPU quota entries are skipped.
+- If no quota information is returned, it prints `No quota information available`.
+- Remaining time is clamped at `0.00h` when used time exceeds total time.
+
+## Notes
+
+- This command reports accelerator quota for kernels; it is not a billing or
+  storage quota command.


### PR DESCRIPTION
## Summary
- expand the kaggle-cli skill into a self-contained CLI reference
- add focused references for competitions, datasets, kernels, models, variations, files, forums, config, auth, quota, and benchmarks
- keep SKILL.md concise with a command tree and reference map

## Validation
- checked SKILL.md frontmatter and local reference links
- checked reference coverage and section shape
- ran git diff --check
- verified the skill no longer points to project source/docs/tests outside skills/