### PR TITLE
Fix dataset metadata column/file description updates and docs

### DIFF
--- a/docs/datasets_metadata.md
+++ b/docs/datasets_metadata.md
@@ -74,7 +74,7 @@ The following metadata is currently supported:
     * `schema`: File schema (definition below):
       * `fields`: Array of fields in the dataset.  Please note that this needs to include ALL of the fields in the data in order or they will not be matched up correctly.  A later version of the API will fix this bug.
         * `name`: Field name
-        * `title`: Field description
+        * `description`: Field description (Note: `title` is also accepted for backward compatibility, but `description` is preferred)
         * `type`: Field type. A best-effort list of types will be kept at the bottom of this page, but new types may be added that are not documented here.
   * `keywords`: Contains an array of strings that correspond to an existing tag on Kaggle.  If a specified tag doesn't exist, the upload will continue, but that specific tag won't be added.  
 * `kaggle datasets version` (create a new version for an existing Dataset):
@@ -88,7 +88,7 @@ The following metadata is currently supported:
     * `schema`: File schema (definition below):
       * `fields`: Array of fields in the dataset.  Please note that this needs to include ALL of the fields in the data in order or they will not be matched up correctly.  A later version of the API will fix this bug.
         * `name`: Field name
-        * `title`: Field description
+        * `description`: Field description (Note: `title` is also accepted for backward compatibility, but `description` is preferred)
         * `type`: Field type. A best-effort list of types will be kept at the bottom of this page, but new types may be added that are not documented here.
   * `keywords`: Contains an array of strings that correspond to an existing tag on Kaggle.  If a specified tag doesn't exist, the upload will continue, but that specific tag won't be added.  
 * `kaggle datasets metadata --update` (update metadata for an existing Dataset) supports all fields mentioned above for `kaggle datasets version`, and additionally:

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -160,7 +160,12 @@ from kagglesdk.datasets.types.dataset_enums import (
     DatasetFileTypeGroup,
     DatasetLicenseGroup,
 )
-from kagglesdk.datasets.types.dataset_types import DatasetSettings, SettingsLicense, DatasetCollaborator, DatasetSettingsFile
+from kagglesdk.datasets.types.dataset_types import (
+    DatasetSettings,
+    SettingsLicense,
+    DatasetCollaborator,
+    DatasetSettingsFile,
+)
 from kagglesdk.kaggle_object import KaggleObject
 from kagglesdk.kernels.types.kernels_api_service import (
     ApiListKernelsRequest,

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -160,7 +160,7 @@ from kagglesdk.datasets.types.dataset_enums import (
     DatasetFileTypeGroup,
     DatasetLicenseGroup,
 )
-from kagglesdk.datasets.types.dataset_types import DatasetSettings, SettingsLicense, DatasetCollaborator
+from kagglesdk.datasets.types.dataset_types import DatasetSettings, SettingsLicense, DatasetCollaborator, DatasetSettingsFile
 from kagglesdk.kaggle_object import KaggleObject
 from kagglesdk.kernels.types.kernels_api_service import (
     ApiListKernelsRequest,
@@ -3092,7 +3092,31 @@ class KaggleApi:
                 if metadata.get("collaborators")
                 else []
             )
-            update_settings.data = metadata.get("data")
+            resources = metadata.get("resources")
+            data = metadata.get("data")
+            if resources and not data:
+                converted_data = []
+                for r in resources:
+                    file_entry = {}
+                    if "path" in r:
+                        file_entry["name"] = r["path"]
+                    if "description" in r:
+                        file_entry["description"] = r["description"]
+                    if "schema" in r and "fields" in r["schema"]:
+                        columns = []
+                        for f in r["schema"]["fields"]:
+                            col = {}
+                            if "name" in f:
+                                col["name"] = f["name"]
+                            col["description"] = f.get("description") or f.get("title") or ""
+                            if "type" in f:
+                                col["type"] = f["type"]
+                            columns.append(col)
+                        file_entry["columns"] = columns
+                    converted_data.append(file_entry)
+                update_settings.data = [DatasetSettingsFile.from_dict(d) for d in converted_data]
+            elif data:
+                update_settings.data = [DatasetSettingsFile.from_dict(d) for d in data]
             # This *should* be a list of sources, but we store them as a single string in dataset version metadata,
             # so we treat it as a different / special property than Data Package's "sources" for now:
             # https://specs.frictionlessdata.io//data-package/#sources
@@ -6413,7 +6437,9 @@ class KaggleApi:
         """
         processed_column = ApiDatasetColumn()
         processed_column.name = self.get_or_fail(column, "name")
-        processed_column.description = self.get_or_default(column, "description", "")
+        processed_column.description = self.get_or_default(
+            column, "description", self.get_or_default(column, "title", "")
+        )
 
         if "type" in column:
             original_type = column["type"].lower()

--- a/tests/test_dataset_metadata_update.py
+++ b/tests/test_dataset_metadata_update.py
@@ -7,17 +7,20 @@ import shutil
 
 # Ensure parent directory is in path for imports
 import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from kaggle.api.kaggle_api_extended import KaggleApi
 from kagglesdk.datasets.types.dataset_types import DatasetSettings, DatasetSettingsFile, DatasetSettingsFileColumn
 from kagglesdk.datasets.types.dataset_api_service import ApiUpdateDatasetMetadataRequest
+
 
 def _make_api():
     api = KaggleApi.__new__(KaggleApi)
     api.already_printed_version_warning = True
     api.config_values = {"username": "owner"}
     return api
+
 
 class TestDatasetMetadataUpdate(unittest.TestCase):
     def setUp(self):
@@ -36,11 +39,9 @@ class TestDatasetMetadataUpdate(unittest.TestCase):
                 {
                     "name": "file.csv",
                     "description": "file desc",
-                    "columns": [
-                        {"name": "col1", "description": "col1 desc", "type": "string"}
-                    ]
+                    "columns": [{"name": "col1", "description": "col1 desc", "type": "string"}],
                 }
-            ]
+            ],
         }
         meta_file = os.path.join(self.temp_dir, "dataset-metadata.json")
         with open(meta_file, "w") as f:
@@ -79,11 +80,11 @@ class TestDatasetMetadataUpdate(unittest.TestCase):
                     "schema": {
                         "fields": [
                             {"name": "col1", "description": "col1 desc", "type": "string"},
-                            {"name": "col2", "title": "col2 desc", "type": "integer"} # test title fallback
+                            {"name": "col2", "title": "col2 desc", "type": "integer"},  # test title fallback
                         ]
-                    }
+                    },
                 }
-            ]
+            ],
         }
         meta_file = os.path.join(self.temp_dir, "dataset-metadata.json")
         with open(meta_file, "w") as f:
@@ -110,7 +111,7 @@ class TestDatasetMetadataUpdate(unittest.TestCase):
         self.assertEqual(call_args.settings.data[0].columns[0].name, "col1")
         self.assertEqual(call_args.settings.data[0].columns[0].description, "col1 desc")
         self.assertEqual(call_args.settings.data[0].columns[1].name, "col2")
-        self.assertEqual(call_args.settings.data[0].columns[1].description, "col2 desc") # title mapped to description
+        self.assertEqual(call_args.settings.data[0].columns[1].description, "col2 desc")  # title mapped to description
 
     def test_process_column_description(self):
         col_dict = {"name": "col", "description": "desc", "type": "string"}
@@ -126,6 +127,7 @@ class TestDatasetMetadataUpdate(unittest.TestCase):
         col_dict = {"name": "col", "description": "desc", "title": "ignored", "type": "string"}
         processed = self.api.process_column(col_dict)
         self.assertEqual(processed.description, "desc")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_dataset_metadata_update.py
+++ b/tests/test_dataset_metadata_update.py
@@ -1,0 +1,131 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import os
+import json
+import tempfile
+import shutil
+
+# Ensure parent directory is in path for imports
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from kaggle.api.kaggle_api_extended import KaggleApi
+from kagglesdk.datasets.types.dataset_types import DatasetSettings, DatasetSettingsFile, DatasetSettingsFileColumn
+from kagglesdk.datasets.types.dataset_api_service import ApiUpdateDatasetMetadataRequest
+
+def _make_api():
+    api = KaggleApi.__new__(KaggleApi)
+    api.already_printed_version_warning = True
+    api.config_values = {"username": "owner"}
+    return api
+
+class TestDatasetMetadataUpdate(unittest.TestCase):
+    def setUp(self):
+        self.api = _make_api()
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_metadata_update_with_data(self, mock_build):
+        # Prepare metadata file with 'data'
+        metadata = {
+            "title": "New Title",
+            "data": [
+                {
+                    "name": "file.csv",
+                    "description": "file desc",
+                    "columns": [
+                        {"name": "col1", "description": "col1 desc", "type": "string"}
+                    ]
+                }
+            ]
+        }
+        meta_file = os.path.join(self.temp_dir, "dataset-metadata.json")
+        with open(meta_file, "w") as f:
+            json.dump(metadata, f)
+
+        mock_kaggle = MagicMock()
+        mock_response = MagicMock()
+        mock_response.errors = []
+        mock_kaggle.datasets.dataset_api_client.update_dataset_metadata.return_value = mock_response
+        mock_build.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_build.return_value.__exit__ = MagicMock(return_value=False)
+
+        self.api.dataset_metadata_update("owner/dataset", self.temp_dir)
+
+        # Assertions
+        mock_kaggle.datasets.dataset_api_client.update_dataset_metadata.assert_called_once()
+        call_args = mock_kaggle.datasets.dataset_api_client.update_dataset_metadata.call_args[0][0]
+        self.assertIsInstance(call_args, ApiUpdateDatasetMetadataRequest)
+        self.assertEqual(call_args.settings.title, "New Title")
+        self.assertEqual(len(call_args.settings.data), 1)
+        self.assertEqual(call_args.settings.data[0].name, "file.csv")
+        self.assertEqual(call_args.settings.data[0].description, "file desc")
+        self.assertEqual(len(call_args.settings.data[0].columns), 1)
+        self.assertEqual(call_args.settings.data[0].columns[0].name, "col1")
+        self.assertEqual(call_args.settings.data[0].columns[0].description, "col1 desc")
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_metadata_update_with_resources(self, mock_build):
+        # Prepare metadata file with 'resources'
+        metadata = {
+            "title": "New Title",
+            "resources": [
+                {
+                    "path": "file.csv",
+                    "description": "file desc",
+                    "schema": {
+                        "fields": [
+                            {"name": "col1", "description": "col1 desc", "type": "string"},
+                            {"name": "col2", "title": "col2 desc", "type": "integer"} # test title fallback
+                        ]
+                    }
+                }
+            ]
+        }
+        meta_file = os.path.join(self.temp_dir, "dataset-metadata.json")
+        with open(meta_file, "w") as f:
+            json.dump(metadata, f)
+
+        mock_kaggle = MagicMock()
+        mock_response = MagicMock()
+        mock_response.errors = []
+        mock_kaggle.datasets.dataset_api_client.update_dataset_metadata.return_value = mock_response
+        mock_build.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_build.return_value.__exit__ = MagicMock(return_value=False)
+
+        self.api.dataset_metadata_update("owner/dataset", self.temp_dir)
+
+        # Assertions
+        mock_kaggle.datasets.dataset_api_client.update_dataset_metadata.assert_called_once()
+        call_args = mock_kaggle.datasets.dataset_api_client.update_dataset_metadata.call_args[0][0]
+        self.assertIsInstance(call_args, ApiUpdateDatasetMetadataRequest)
+        self.assertEqual(call_args.settings.title, "New Title")
+        self.assertEqual(len(call_args.settings.data), 1)
+        self.assertEqual(call_args.settings.data[0].name, "file.csv")
+        self.assertEqual(call_args.settings.data[0].description, "file desc")
+        self.assertEqual(len(call_args.settings.data[0].columns), 2)
+        self.assertEqual(call_args.settings.data[0].columns[0].name, "col1")
+        self.assertEqual(call_args.settings.data[0].columns[0].description, "col1 desc")
+        self.assertEqual(call_args.settings.data[0].columns[1].name, "col2")
+        self.assertEqual(call_args.settings.data[0].columns[1].description, "col2 desc") # title mapped to description
+
+    def test_process_column_description(self):
+        col_dict = {"name": "col", "description": "desc", "type": "string"}
+        processed = self.api.process_column(col_dict)
+        self.assertEqual(processed.description, "desc")
+
+    def test_process_column_title_fallback(self):
+        col_dict = {"name": "col", "title": "desc", "type": "string"}
+        processed = self.api.process_column(col_dict)
+        self.assertEqual(processed.description, "desc")
+
+    def test_process_column_both_prefer_description(self):
+        col_dict = {"name": "col", "description": "desc", "title": "ignored", "type": "string"}
+        processed = self.api.process_column(col_dict)
+        self.assertEqual(processed.description, "desc")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR resolves several issues related to dataset metadata column/file descriptions not updating or being documented inconsistently.

### Changes:
- Corrected documentation in `docs/datasets_metadata.md` to use `description` instead of `title` for fields.
- Added `title` fallback support in column processing for backward compatibility.
- Updated `dataset_metadata_update` to support both `resources` and `data` formats in `dataset-metadata.json`.
- Fixed `TypeError` in metadata update when `data` is provided by converting dicts to SDK objects (`DatasetSettingsFile`).

### Fixes:
- Fixes #995
- Fixes #843
- Fixes #447
- Fixes #248

TAG=agy
CONV=58dca970-f47e-41b6-a98d-3786c7b8a256
