### PR TITLE
Improve benchmark task error messages in kaggle CLI

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -271,7 +271,7 @@ kaggle benchmarks tasks status <TASK> [options]
 
 Prints the task's metadata (slug, creation status, creation time, URL) followed by a table of all runs. Each run row shows the model name, run state, start time, and end time. Any errored runs display their error messages below the table.
 
-If task creation itself failed, the `Status:` line renders a friendly description of the failure (e.g. `Failed — Notebook finished but produced no output. Did you forget to call .run() or .evaluate()?`) and an `Error:` line is appended below it with the server-provided creation error message.
+If task creation itself failed, the `Status:` line shows the failure *kind* — the cleaned creation-state enum, titlecased (e.g. `Kernel_Without_Run`, `No_Model_Specified`, `Validation_Failed`, `Errored`) — and an `Error:` line is appended below it with the server-provided `creation_error_message` explaining what went wrong.
 
 ---
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -271,6 +271,8 @@ kaggle benchmarks tasks status <TASK> [options]
 
 Prints the task's metadata (slug, creation status, creation time, URL) followed by a table of all runs. Each run row shows the model name, run state, start time, and end time. Any errored runs display their error messages below the table.
 
+If task creation itself failed, the `Status:` line renders a friendly description of the failure (e.g. `Failed — Notebook finished but produced no output. Did you forget to call .run() or .evaluate()?`) and an `Error:` line is appended below it with the server-provided creation error message.
+
 ---
 
 ### `kaggle benchmarks tasks download`

--- a/skills/references/benchmarks.md
+++ b/skills/references/benchmarks.md
@@ -277,14 +277,14 @@ kaggle b t status my-task -m gemini-2.5-pro -m claude-sonnet-4
 **Output format:**
 ```
 Task:     my-task
-Status:   COMPLETED
+Status:   Completed
 Created:  2026-04-28 18:13:04
 Task URL: https://www.kaggle.com/...
 
 Model                     Status      Started               Ended
 --------------------------------------------------------------------------
-gemini-2.5-pro            COMPLETED   2026-04-28 18:13:04   2026-04-28 18:14:00
-claude-sonnet-4           ERRORED     2026-04-28 18:13:04   2026-04-28 18:13:04
+gemini-2.5-pro            Completed   2026-04-28 18:13:04   2026-04-28 18:14:00
+claude-sonnet-4           Errored     2026-04-28 18:13:04   2026-04-28 18:13:04
 
 Errors:
   [claude-sonnet-4]
@@ -294,6 +294,17 @@ Errors:
 ```
 
 If no runs exist: `No runs yet. Use 'kaggle b t run my-task' to start one.`
+
+**Task creation failures:** When the task itself failed to be created
+(e.g. notebook produced no output, no model specified, validation error),
+the `Status:` line shows a friendly description of the failure and an
+`Error:` line is appended below it with the server-provided message —
+for example:
+
+```
+Status:   Failed — Notebook finished but produced no output. Did you forget to call .run() or .evaluate()?
+Error:    <server message>
+```
 
 ### `kaggle benchmarks tasks download`
 

--- a/skills/references/benchmarks.md
+++ b/skills/references/benchmarks.md
@@ -296,15 +296,20 @@ Errors:
 If no runs exist: `No runs yet. Use 'kaggle b t run my-task' to start one.`
 
 **Task creation failures:** When the task itself failed to be created
-(e.g. notebook produced no output, no model specified, validation error),
-the `Status:` line shows a friendly description of the failure and an
-`Error:` line is appended below it with the server-provided message —
-for example:
+(e.g. `KERNEL_WITHOUT_RUN`, `NO_MODEL_SPECIFIED`, `VALIDATION_FAILED`,
+`ERRORED`), the `Status:` line shows the failure *kind* (titlecased
+enum) and an `Error:` line is appended below it with the server-provided
+`creation_error_message` — for example:
 
 ```
-Status:   Failed — Notebook finished but produced no output. Did you forget to call .run() or .evaluate()?
-Error:    <server message>
+Status:   Kernel_Without_Run
+Error:    Notebook finished but produced no output. Did you forget to call .run() or .evaluate()?
 ```
+
+The `kaggle b t run` command applies the same pattern when refusing to
+schedule runs against a non-completed task: the raised error includes
+`status: <KIND>` and, if present, an `Error: <message>` line with the
+server's explanation.
 
 ### `kaggle benchmarks tasks download`
 

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -6993,10 +6993,21 @@ class KaggleApi:
         s = s.replace("BenchmarkTaskRunState.BENCHMARK_TASK_RUN_STATE_", "")
         return s
 
+    _STATE_LABELS = {
+        "KERNEL_WITHOUT_RUN": "Failed — No run output",
+        "NO_MODEL_SPECIFIED": "Failed — No model specified",
+        "VALIDATION_FAILED": "Failed — Validation error",
+        "ERRORED": "Failed",
+        "COMPLETED": "Completed",
+        "QUEUED": "Queued",
+        "RUNNING": "Running",
+    }
+
     @staticmethod
     def _format_state(state) -> str:
-        """Render an enum state in Titlecase (e.g. ``Completed``)."""
-        return KaggleApi._clean_enum_str(state).title()
+        """Render an enum state with a friendly label, falling back to Titlecase."""
+        raw = KaggleApi._clean_enum_str(state)
+        return KaggleApi._STATE_LABELS.get(raw, raw.replace("_", " ").title())
 
     @staticmethod
     def _ansi(code: str, text: str, stream=None) -> str:
@@ -7799,6 +7810,8 @@ class KaggleApi:
             version = task_info.slug.version_number or "unset"
             print(f"Version:  {version}")
             print(f"Status:   {self._format_state(task_info.creation_state)}")
+            if task_info.creation_error_message:
+                print(f"Error:    {task_info.creation_error_message}")
             print(f"Created:  {self._format_time(task_info.create_time)}")
             print(f"Public:   {getattr(task_info, 'is_public', False)}")
             url = getattr(task_info, "url", None)

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -6994,10 +6994,10 @@ class KaggleApi:
         return s
 
     _STATE_LABELS = {
-        "KERNEL_WITHOUT_RUN": "Failed — No run output",
-        "NO_MODEL_SPECIFIED": "Failed — No model specified",
-        "VALIDATION_FAILED": "Failed — Validation error",
-        "ERRORED": "Failed",
+        "KERNEL_WITHOUT_RUN": "Failed — Notebook finished but produced no output. Did you forget to call .run() or .evaluate()?",
+        "NO_MODEL_SPECIFIED": "Failed — No model found in output. Pass a model via kbench.llm in your .run() call.",
+        "VALIDATION_FAILED": "Failed — Task name or description exceeds the allowed length.",
+        "ERRORED": "Failed — Notebook encountered an error. Check the notebook log for details.",
         "COMPLETED": "Completed",
         "QUEUED": "Queued",
         "RUNNING": "Running",

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -6993,21 +6993,10 @@ class KaggleApi:
         s = s.replace("BenchmarkTaskRunState.BENCHMARK_TASK_RUN_STATE_", "")
         return s
 
-    _STATE_LABELS = {
-        "KERNEL_WITHOUT_RUN": "Failed — Notebook finished but produced no output. Did you forget to call .run() or .evaluate()?",
-        "NO_MODEL_SPECIFIED": "Failed — No model found in output. Pass a model via kbench.llm in your .run() call.",
-        "VALIDATION_FAILED": "Failed — Task name or description exceeds the allowed length.",
-        "ERRORED": "Failed — Notebook encountered an error. Check the notebook log for details.",
-        "COMPLETED": "Completed",
-        "QUEUED": "Queued",
-        "RUNNING": "Running",
-    }
-
     @staticmethod
     def _format_state(state) -> str:
-        """Render an enum state with a friendly label, falling back to Titlecase."""
-        raw = KaggleApi._clean_enum_str(state)
-        return KaggleApi._STATE_LABELS.get(raw, raw.replace("_", " ").title())
+        """Render an enum state in Titlecase (e.g. ``Completed``, ``Kernel_Without_Run``)."""
+        return KaggleApi._clean_enum_str(state).title()
 
     @staticmethod
     def _ansi(code: str, text: str, stream=None) -> str:
@@ -7698,8 +7687,8 @@ class KaggleApi:
                     f"Task '{task}' is not ready to run (status: {self._clean_enum_str(state)}). "
                     f"Only completed tasks can be run."
                 )
-                if state == self._TASK_CREATION_ERRORED:
-                    error_msg += f"\n  Task Info: {task_info}"
+                if task_info.creation_error_message:
+                    error_msg += f"\n  Error: {task_info.creation_error_message}"
                 raise ValueError(error_msg)
 
             if not models:

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -1114,7 +1114,7 @@ class TestFormatState:
             (COMPLETED, "Completed"),
             (QUEUED, "Queued"),
             (RUNNING, "Running"),
-            (ERRORED, "Failed"),
+            (ERRORED, "Failed — Notebook encountered an error. Check the notebook log for details."),
         ],
     )
     def test_known_creation_states(self, state, expected):
@@ -1123,10 +1123,16 @@ class TestFormatState:
     @pytest.mark.parametrize(
         "raw, expected",
         [
-            ("KERNEL_WITHOUT_RUN", "Failed — No run output"),
-            ("NO_MODEL_SPECIFIED", "Failed — No model specified"),
-            ("VALIDATION_FAILED", "Failed — Validation error"),
-            ("ERRORED", "Failed"),
+            (
+                "KERNEL_WITHOUT_RUN",
+                "Failed — Notebook finished but produced no output. Did you forget to call .run() or .evaluate()?",
+            ),
+            (
+                "NO_MODEL_SPECIFIED",
+                "Failed — No model found in output. Pass a model via kbench.llm in your .run() call.",
+            ),
+            ("VALIDATION_FAILED", "Failed — Task name or description exceeds the allowed length."),
+            ("ERRORED", "Failed — Notebook encountered an error. Check the notebook log for details."),
             ("COMPLETED", "Completed"),
             ("QUEUED", "Queued"),
             ("RUNNING", "Running"),

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -1086,6 +1086,61 @@ class TestStatus:
         assert "gemini-1" in output
         assert "gemini-2" in output
 
+    def test_status_shows_creation_error_message(self, api, capsys):
+        """Failed task creation surfaces creation_error_message in the header."""
+        task = _make_task(state=ERRORED)
+        task.creation_error_message = "Kernel produced no run output"
+        api._mock_benchmarks.get_benchmark_task.return_value = task
+        _setup_runs_response(api, [])
+        api.benchmarks_tasks_status_cli("my-task")
+        output = capsys.readouterr().out
+        assert "Error:    Kernel produced no run output" in output
+
+    def test_status_omits_error_when_empty(self, api, capsys):
+        """No Error line when creation_error_message is empty."""
+        api._mock_benchmarks.get_benchmark_task.return_value = _make_task()
+        _setup_runs_response(api, [])
+        api.benchmarks_tasks_status_cli("my-task")
+        output = capsys.readouterr().out
+        assert "Error:" not in output
+
+
+class TestFormatState:
+    """``KaggleApi._format_state`` enum-to-label rendering."""
+
+    @pytest.mark.parametrize(
+        "state, expected",
+        [
+            (COMPLETED, "Completed"),
+            (QUEUED, "Queued"),
+            (RUNNING, "Running"),
+            (ERRORED, "Failed"),
+        ],
+    )
+    def test_known_creation_states(self, state, expected):
+        assert KaggleApi._format_state(state) == expected
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            ("KERNEL_WITHOUT_RUN", "Failed — No run output"),
+            ("NO_MODEL_SPECIFIED", "Failed — No model specified"),
+            ("VALIDATION_FAILED", "Failed — Validation error"),
+            ("ERRORED", "Failed"),
+            ("COMPLETED", "Completed"),
+            ("QUEUED", "Queued"),
+            ("RUNNING", "Running"),
+        ],
+    )
+    def test_known_labels(self, raw, expected):
+        assert KaggleApi._format_state(raw) == expected
+
+    def test_unknown_state_falls_back_to_titlecase(self):
+        assert KaggleApi._format_state("SOMETHING_NEW") == "Something New"
+
+    def test_unknown_state_single_word(self):
+        assert KaggleApi._format_state("PENDING") == "Pending"
+
 
 # ============================================================
 # Download

--- a/src/kaggle/test/test_benchmarks_cli.py
+++ b/src/kaggle/test/test_benchmarks_cli.py
@@ -566,11 +566,25 @@ class TestRun:
         with pytest.raises(ValueError, match="--poll-interval must be a positive integer"):
             api.benchmarks_tasks_run_cli("my-task", ["gemini-pro"], poll_interval=interval)
 
-    def test_run_errored_task_includes_task_info(self, api):
-        """ERRORED task error message includes task info."""
-        api._mock_benchmarks.get_benchmark_task.return_value = _make_task(state=ERRORED)
-        with pytest.raises(ValueError, match="Task Info:"):
+    def test_run_errored_task_surfaces_creation_error_message(self, api):
+        """When task creation failed, run shows status (kind) and Error (server message) separately."""
+        task = _make_task(state=ERRORED)
+        task.creation_error_message = "Notebook produced no run output"
+        api._mock_benchmarks.get_benchmark_task.return_value = task
+        with pytest.raises(ValueError) as exc_info:
             api.benchmarks_tasks_run_cli("my-task", ["gemini-pro"])
+        msg = str(exc_info.value)
+        assert "status: ERRORED" in msg
+        assert "Error: Notebook produced no run output" in msg
+
+    def test_run_errored_task_without_creation_error_message(self, api):
+        """When creation_error_message is empty, no Error line is appended."""
+        api._mock_benchmarks.get_benchmark_task.return_value = _make_task(state=ERRORED)
+        with pytest.raises(ValueError) as exc_info:
+            api.benchmarks_tasks_run_cli("my-task", ["gemini-pro"])
+        msg = str(exc_info.value)
+        assert "status: ERRORED" in msg
+        assert "Error:" not in msg
 
     @pytest.mark.parametrize("status_code", [403, 404], ids=["forbidden", "not_found"])
     def test_run_task_not_found(self, api, status_code):
@@ -1106,7 +1120,11 @@ class TestStatus:
 
 
 class TestFormatState:
-    """``KaggleApi._format_state`` enum-to-label rendering."""
+    """``KaggleApi._format_state`` renders the raw cleaned enum (the error *kind*).
+
+    Explanatory messages belong in ``creation_error_message`` on the task
+    object and are displayed by callers as a separate ``Error:`` line.
+    """
 
     @pytest.mark.parametrize(
         "state, expected",
@@ -1114,7 +1132,7 @@ class TestFormatState:
             (COMPLETED, "Completed"),
             (QUEUED, "Queued"),
             (RUNNING, "Running"),
-            (ERRORED, "Failed — Notebook encountered an error. Check the notebook log for details."),
+            (ERRORED, "Errored"),
         ],
     )
     def test_known_creation_states(self, state, expected):
@@ -1123,29 +1141,17 @@ class TestFormatState:
     @pytest.mark.parametrize(
         "raw, expected",
         [
-            (
-                "KERNEL_WITHOUT_RUN",
-                "Failed — Notebook finished but produced no output. Did you forget to call .run() or .evaluate()?",
-            ),
-            (
-                "NO_MODEL_SPECIFIED",
-                "Failed — No model found in output. Pass a model via kbench.llm in your .run() call.",
-            ),
-            ("VALIDATION_FAILED", "Failed — Task name or description exceeds the allowed length."),
-            ("ERRORED", "Failed — Notebook encountered an error. Check the notebook log for details."),
+            ("KERNEL_WITHOUT_RUN", "Kernel_Without_Run"),
+            ("NO_MODEL_SPECIFIED", "No_Model_Specified"),
+            ("VALIDATION_FAILED", "Validation_Failed"),
+            ("ERRORED", "Errored"),
             ("COMPLETED", "Completed"),
-            ("QUEUED", "Queued"),
-            ("RUNNING", "Running"),
+            ("SOMETHING_NEW", "Something_New"),
+            ("PENDING", "Pending"),
         ],
     )
-    def test_known_labels(self, raw, expected):
+    def test_renders_cleaned_enum(self, raw, expected):
         assert KaggleApi._format_state(raw) == expected
-
-    def test_unknown_state_falls_back_to_titlecase(self):
-        assert KaggleApi._format_state("SOMETHING_NEW") == "Something New"
-
-    def test_unknown_state_single_word(self):
-        assert KaggleApi._format_state("PENDING") == "Pending"
 
 
 # ============================================================


### PR DESCRIPTION
When a benchmark task failed, the CLI hid the server's
`creation_error_message` and rendered the failure as a raw titlecased
enum, so users had no idea what went wrong or how to fix it. Surface the
server message as a separate `Error:` line and apply the same
`status: <KIND>` + `Error: <message>` shape consistently across
`kaggle b t status`, `kaggle b t run`, and the push/run wait paths —
keeping the CLI a thin display layer over the server's classification
and explanation.

---

Task: [limagoog-20260611165119-dba58d70](https://agents.dev.kaggle.net/tasks/limagoog-20260611165119-dba58d70)
Context: https://chat.kaggle.net/kaggle/pl/ki55zezbmfg19b3km7ztp3fsww

