### PR TITLE
Clarify LLMS_AVAILABLE vs. full model set in benchmarks docs

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -77,6 +77,8 @@ In addition to the three credential variables written by `auth`, `init` also wri
 *   `LLM_DEFAULT_EVAL` — Default model slug for evaluation.
 *   `LLMS_AVAILABLE` — Comma-separated list of available model slugs.
 
+> **Note:** `LLMS_AVAILABLE` is a curated subset of models intended for local development and testing — it is **not** the full set of available models, and the Model Proxy token itself is not restricted to these models. To see all available models, use `kaggle benchmarks tasks models`. To run a task against any model (including those not in `LLMS_AVAILABLE`), use `kaggle benchmarks tasks run`, which executes on Kaggle's infrastructure with access to the full model catalog.
+
 `init` also creates two files alongside the example file:
 
 *   **`example_task.py`** (or custom name via `--example-file`) — A starter Python script demonstrating how to define a benchmark task using `@task` decorators and the `kaggle_benchmarks` library.

--- a/skills/references/benchmarks.md
+++ b/skills/references/benchmarks.md
@@ -65,6 +65,8 @@ default env vars, and starter benchmark files.
 - `LLM_DEFAULT_EVAL` — Default eval model slug
 - `LLMS_AVAILABLE` — Comma-separated list of available model slugs
 
+**⚠ Note:** `LLMS_AVAILABLE` is a curated subset of models for local development and testing — it is **not** the full model list, and the Model Proxy token (`MODEL_PROXY_API_KEY`) works for all models, not just those listed. Use `kaggle b t models` to list every available model and `kaggle b t run` to execute against any of them on Kaggle's infrastructure (same models available in notebooks).
+
 **⚠ Note:** Environment variables are **appended** to the env file. When loaded via `dotenv`, the last value wins, so re-running `init` or `auth` is safe. The file may accumulate duplicate entries over time; clean up manually if desired.
 
 **Files generated in the same directory as the example file:**
@@ -687,7 +689,7 @@ kaggle b t run my-task -m gemini-2.5-pro --wait && \
 kaggle b t download my-task -o ./results
 ```
 
-**⚠ Note:** Local runs use the `LLM_DEFAULT` model from your `.env` file. Server runs use whatever model(s) you specify with `-m`. Behavior may differ between models, so always validate against your target model(s) on the server after local iteration.
+**⚠ Note:** Local runs are limited to the models listed in `LLMS_AVAILABLE` (and use `LLM_DEFAULT` by default) — a curated subset for local development. Server runs via `kaggle b t run` have access to the full model catalog (use `kaggle b t models` to list them) and run on Kaggle's infrastructure. Behavior may differ between models, so always validate against your target model(s) on the server after local iteration.
 
 ### Quick Push-Run-Download
 


### PR DESCRIPTION
Users were misreading `LLMS_AVAILABLE` in the generated `.env` as a hard
limit on which models their Model Proxy token can access (see issue
#1059). Add short notes to the `kaggle benchmarks init` sections, and
to the Local Iteration Loop in the skill reference, explaining that
it's a curated local subset and that `kaggle b t models` / `kaggle b t
run` expose the full model catalog on Kaggle's infrastructure.

Fixes #1059

---

Task: [limagoog-20260612163257-ae1407dd](https://agents.dev.kaggle.net/tasks/limagoog-20260612163257-ae1407dd)
Context: https://chat.kaggle.net/kaggle/pl/yspw6y6smtgfjydrs5zn8he1ba

