### PR TITLE
fix(cli): avoid success message after cancelled dataset deletion

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -4018,7 +4018,7 @@ class KaggleApi:
         else:
             print("Dataset version creation error: " + result.error)
 
-    def dataset_delete(self, owner_slug: str, dataset_slug: str, no_confirm: bool = False) -> None:
+    def dataset_delete(self, owner_slug: str, dataset_slug: str, no_confirm: bool = False) -> bool:
         """Deletes a dataset.
 
         Args:
@@ -4027,7 +4027,7 @@ class KaggleApi:
             no_confirm (bool): If True, skip confirmation (default is False).
 
         Returns:
-            None:
+            bool: True if deleted, False if cancelled.
         """
 
         if not owner_slug:
@@ -4036,13 +4036,14 @@ class KaggleApi:
         if not no_confirm:
             if not self.confirmation(f"delete the dataset: {owner_slug}/{dataset_slug}"):
                 print("Deletion cancelled")
-                return
+                return False
 
         with self.build_kaggle_client() as kaggle:
             request = ApiDeleteDatasetRequest()
             request.owner_slug = owner_slug
             request.dataset_slug = dataset_slug
             kaggle.datasets.dataset_api_client.delete_dataset(request)
+        return True
 
     def kernels_delete(self, kernel: str, no_confirm: bool = False) -> None:
         """Deletes a kernel.
@@ -4099,8 +4100,8 @@ class KaggleApi:
             raise ValueError("A dataset must be specified")
         owner_slug, dataset_slug, _ = self.split_dataset_string(dataset)
 
-        self.dataset_delete(owner_slug, dataset_slug, no_confirm)
-        print(f'Dataset "{dataset}" deleted successfully.')
+        if self.dataset_delete(owner_slug, dataset_slug, no_confirm):
+            print(f'Dataset "{dataset}" deleted successfully.')
 
     def dataset_initialize(self, folder: str) -> str:
         """Initializes a folder with a dataset configuration (metadata) file.

--- a/tests/unit/test_dataset_delete.py
+++ b/tests/unit/test_dataset_delete.py
@@ -1,0 +1,64 @@
+# coding=utf-8
+import unittest
+from unittest.mock import MagicMock, patch
+import sys
+from io import StringIO
+
+sys.path.insert(0, "../..")
+
+from kaggle.api.kaggle_api_extended import KaggleApi
+
+
+def _make_api():
+    api = KaggleApi.__new__(KaggleApi)
+    api.already_printed_version_warning = True
+    api.config_values = {"username": "owner"}
+    return api
+
+
+class TestDatasetDelete(unittest.TestCase):
+    """Tests for dataset_delete_cli() and dataset_delete()."""
+
+    def setUp(self):
+        self.api = _make_api()
+
+    @patch("builtins.print")
+    @patch.object(KaggleApi, "confirmation", return_value=False)
+    def test_dataset_delete_cli_cancelled(self, mock_confirmation, mock_print):
+        """When confirmation is cancelled (returns False), print 'Deletion cancelled' and no success message."""
+        self.api.dataset_delete_cli("owner/dataset-slug")
+        
+        # Verify confirmation was called
+        mock_confirmation.assert_called_once_with("delete the dataset: owner/dataset-slug")
+        
+        # Verify that print("Deletion cancelled") was called
+        mock_print.assert_any_call("Deletion cancelled")
+        
+        # Verify that the success message was NOT printed
+        for call_args in mock_print.call_args_list:
+            printed_str = call_args[0][0]
+            if "deleted successfully" in printed_str:
+                self.fail("Success message was printed on cancellation!")
+
+    @patch("builtins.print")
+    @patch.object(KaggleApi, "confirmation", return_value=True)
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_dataset_delete_cli_success(self, mock_build, mock_confirmation, mock_print):
+        """When confirmation is approved (returns True), call backend and print success message."""
+        mock_kaggle = MagicMock()
+        mock_build.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_build.return_value.__exit__ = MagicMock(return_value=False)
+
+        self.api.dataset_delete_cli("owner/dataset-slug")
+
+        mock_confirmation.assert_called_once_with("delete the dataset: owner/dataset-slug")
+        
+        # Verify backend client delete_dataset was called
+        mock_kaggle.datasets.dataset_api_client.delete_dataset.assert_called_once()
+        
+        # Verify success message was printed
+        mock_print.assert_any_call('Dataset "owner/dataset-slug" deleted successfully.')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_dataset_delete.py
+++ b/tests/unit/test_dataset_delete.py
@@ -27,13 +27,13 @@ class TestDatasetDelete(unittest.TestCase):
     def test_dataset_delete_cli_cancelled(self, mock_confirmation, mock_print):
         """When confirmation is cancelled (returns False), print 'Deletion cancelled' and no success message."""
         self.api.dataset_delete_cli("owner/dataset-slug")
-        
+
         # Verify confirmation was called
         mock_confirmation.assert_called_once_with("delete the dataset: owner/dataset-slug")
-        
+
         # Verify that print("Deletion cancelled") was called
         mock_print.assert_any_call("Deletion cancelled")
-        
+
         # Verify that the success message was NOT printed
         for call_args in mock_print.call_args_list:
             printed_str = call_args[0][0]
@@ -52,10 +52,10 @@ class TestDatasetDelete(unittest.TestCase):
         self.api.dataset_delete_cli("owner/dataset-slug")
 
         mock_confirmation.assert_called_once_with("delete the dataset: owner/dataset-slug")
-        
+
         # Verify backend client delete_dataset was called
         mock_kaggle.datasets.dataset_api_client.delete_dataset.assert_called_once()
-        
+
         # Verify success message was printed
         mock_print.assert_any_call('Dataset "owner/dataset-slug" deleted successfully.')
 


### PR DESCRIPTION
## Summary

Fixes a bug in the dataset deletion CLI where a success message was printed even when the user cancelled the deletion confirmation.

## Problem

When running:

```bash
kaggle datasets delete <owner>/<dataset>
```

and responding `no` to the confirmation prompt, the CLI printed:

```text
Deletion cancelled
Dataset "<owner>/<dataset>" deleted successfully.
```

Although the deletion was cancelled, the success message was still displayed, resulting in misleading user feedback.

## Root Cause

`dataset_delete()` returned after printing `Deletion cancelled`, but `dataset_delete_cli()` always printed the success message without checking whether the deletion had actually proceeded.

## Solution

* Updated `dataset_delete()` to return whether the deletion was executed.
* Updated `dataset_delete_cli()` to print the success message only when the deletion completed successfully.

This change only affects the dataset deletion flow and does not modify the deletion logic itself.

## Testing

### Manual

* Created a temporary private dataset.
* Ran `kaggle datasets delete <owner>/<dataset>`.
* Answered `no` at the confirmation prompt.
* Verified that the dataset still existed.
* Confirmed that the success message is no longer printed after cancellation.

### Automated

* Added unit tests covering:

  * cancellation path (success message is not printed)
  * successful deletion path (success message is printed)
* Ran the new dataset deletion tests successfully.
* Ran existing dataset-related unit tests to verify no regressions.

## Before

```text
Are you sure you want to delete the dataset: owner/dataset? [yes/no] no
Deletion cancelled
Dataset "owner/dataset" deleted successfully.
```

## After

```text
Are you sure you want to delete the dataset: owner/dataset? [yes/no] no
Deletion cancelled
```

### Screenshot

A screenshot demonstrating the original incorrect behavior is attached for reference.
