### PR TITLE
fix(cli): avoid success message after cancelled model deletion

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -5684,7 +5684,7 @@ class KaggleApi:
         else:
             print("Model creation error: " + result.error)
 
-    def model_delete(self, model: str, no_confirm: bool) -> ApiDeleteModelResponse:
+    def model_delete(self, model: str, no_confirm: bool) -> Optional[ApiDeleteModelResponse]:
         """Deletes a model.
 
         Args:
@@ -5692,14 +5692,14 @@ class KaggleApi:
             no_confirm (bool): If True, skip confirmation (default is False).
 
         Returns:
-            ApiDeleteModelResponse: An ApiDeleteModelResponse object.
+            Optional[ApiDeleteModelResponse]: The delete response, or None if cancelled.
         """
         owner_slug, model_slug = self.split_model_string(model)
 
         if not no_confirm:
             if not self.confirmation(f"delete the model {model}"):
                 print("Deletion cancelled")
-                return ApiDeleteModelResponse()
+                return None
 
         with self.build_kaggle_client() as kaggle:
             request = ApiDeleteModelRequest()
@@ -5716,6 +5716,8 @@ class KaggleApi:
             no_confirm: If True, automatically confirm the deletion.
         """
         result = self.model_delete(model, no_confirm)
+        if result is None:
+            return
 
         if result.error:
             print("Model deletion error: " + result.error)
@@ -6019,7 +6021,7 @@ class KaggleApi:
         else:
             print("Model instance creation error: " + result.error)
 
-    def model_instance_delete(self, model_instance: str, no_confirm: bool = False) -> ApiDeleteModelResponse:
+    def model_instance_delete(self, model_instance: str, no_confirm: bool = False) -> Optional[ApiDeleteModelResponse]:
         """Deletes a model instance.
 
         Args:
@@ -6027,7 +6029,7 @@ class KaggleApi:
             no_confirm (bool): If True, skip confirmation (default is False).
 
         Returns:
-            ApiDeleteModelResponse: An ApiDeleteModelResponse object.
+            Optional[ApiDeleteModelResponse]: The delete response, or None if cancelled.
         """
         if model_instance is None:
             raise ValueError("A model instance must be specified")
@@ -6036,7 +6038,7 @@ class KaggleApi:
         if not no_confirm:
             if not self.confirmation(f"delete the variation {model_instance}"):
                 print("Deletion cancelled")
-                return ApiDeleteModelResponse()
+                return None
 
         with self.build_kaggle_client() as kaggle:
             request = ApiDeleteModelInstanceRequest()
@@ -6056,6 +6058,8 @@ class KaggleApi:
             no_confirm: If True, automatically confirm the deletion.
         """
         result = self.model_instance_delete(model_instance, no_confirm)
+        if result is None:
+            return
 
         if len(result.error) > 0:
             print("Model instance deletion error: " + result.error)
@@ -6517,7 +6521,7 @@ class KaggleApi:
 
     def model_instance_version_delete(
         self, model_instance_version: str, no_confirm: bool = False
-    ) -> ApiDeleteModelResponse:
+    ) -> Optional[ApiDeleteModelResponse]:
         """Deletes a model instance version.
 
         Args:
@@ -6525,7 +6529,7 @@ class KaggleApi:
             no_confirm (bool): If True, skip confirmation (default is False).
 
         Returns:
-            ApiDeleteModelResponse: An ApiDeleteModelResponse object.
+            Optional[ApiDeleteModelResponse]: The delete response, or None if cancelled.
         """
         if model_instance_version is None:
             raise ValueError("A model instance version must be specified")
@@ -6541,7 +6545,7 @@ class KaggleApi:
         if not no_confirm:
             if not self.confirmation(f"delete the version {model_instance_version}"):
                 print("Deletion cancelled")
-                return ApiDeleteModelResponse()
+                return None
 
         request = ApiDeleteModelInstanceVersionRequest()
         request.owner_slug = owner_slug
@@ -6563,6 +6567,8 @@ class KaggleApi:
             no_confirm: If True, automatically confirm the deletion.
         """
         result = self.model_instance_version_delete(model_instance_version, no_confirm)
+        if result is None:
+            return
 
         if len(result.error) > 0:
             print("Model instance version deletion error: " + result.error)

--- a/tests/unit/test_model_delete.py
+++ b/tests/unit/test_model_delete.py
@@ -1,0 +1,127 @@
+# coding=utf-8
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, "../../src")
+
+from kagglesdk.models.types.model_api_service import ApiDeleteModelResponse
+from kagglesdk.models.types.model_enums import ModelFramework
+
+from kaggle.api.kaggle_api_extended import KaggleApi
+
+
+def _make_api():
+    api = KaggleApi.__new__(KaggleApi)
+    api.already_printed_version_warning = True
+    return api
+
+
+def _assert_no_success_message(mock_print, success_phrase):
+    for call_args in mock_print.call_args_list:
+        printed_str = call_args[0][0]
+        if success_phrase in printed_str:
+            raise AssertionError(f"Success message was printed on cancellation: {printed_str}")
+
+
+class TestModelDeleteCli(unittest.TestCase):
+    """Tests for model delete CLI wrappers when confirmation is cancelled or approved."""
+
+    def setUp(self):
+        self.api = _make_api()
+        self.model = "owner/my-model"
+        self.model_instance = "owner/my-model/pytorch/default"
+        self.model_instance_version = "owner/my-model/pytorch/default/1"
+
+    @patch("builtins.print")
+    @patch.object(KaggleApi, "confirmation", return_value=False)
+    @patch.object(KaggleApi, "split_model_string", return_value=("owner", "my-model"))
+    def test_model_delete_cli_cancelled(self, mock_split, mock_confirmation, mock_print):
+        self.api.model_delete_cli(self.model, False)
+
+        mock_confirmation.assert_called_once_with(f"delete the model {self.model}")
+        mock_print.assert_any_call("Deletion cancelled")
+        _assert_no_success_message(mock_print, "The model was deleted.")
+
+    @patch("builtins.print")
+    @patch.object(KaggleApi, "confirmation", return_value=True)
+    @patch.object(KaggleApi, "split_model_string", return_value=("owner", "my-model"))
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_model_delete_cli_success(self, mock_build, mock_split, mock_confirmation, mock_print):
+        mock_kaggle = MagicMock()
+        mock_kaggle.models.model_api_client.delete_model.return_value = ApiDeleteModelResponse()
+        mock_build.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_build.return_value.__exit__ = MagicMock(return_value=False)
+
+        self.api.model_delete_cli(self.model, False)
+
+        mock_kaggle.models.model_api_client.delete_model.assert_called_once()
+        mock_print.assert_any_call("The model was deleted.")
+
+    @patch("builtins.print")
+    @patch.object(KaggleApi, "confirmation", return_value=False)
+    @patch.object(
+        KaggleApi,
+        "split_model_instance_string",
+        return_value=("owner", "my-model", "pytorch", "default"),
+    )
+    def test_model_instance_delete_cli_cancelled(self, mock_split, mock_confirmation, mock_print):
+        self.api.model_instance_delete_cli(self.model_instance, False)
+
+        mock_confirmation.assert_called_once_with(f"delete the variation {self.model_instance}")
+        mock_print.assert_any_call("Deletion cancelled")
+        _assert_no_success_message(mock_print, "The model instance was deleted.")
+
+    @patch("builtins.print")
+    @patch.object(KaggleApi, "confirmation", return_value=True)
+    @patch.object(
+        KaggleApi,
+        "split_model_instance_string",
+        return_value=("owner", "my-model", "pytorch", "default"),
+    )
+    @patch.object(KaggleApi, "lookup_enum", return_value=ModelFramework.MODEL_FRAMEWORK_PY_TORCH)
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_model_instance_delete_cli_success(
+        self, mock_build, mock_lookup, mock_split, mock_confirmation, mock_print
+    ):
+        mock_kaggle = MagicMock()
+        mock_kaggle.models.model_api_client.delete_model_instance.return_value = ApiDeleteModelResponse()
+        mock_build.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_build.return_value.__exit__ = MagicMock(return_value=False)
+
+        self.api.model_instance_delete_cli(self.model_instance, False)
+
+        mock_kaggle.models.model_api_client.delete_model_instance.assert_called_once()
+        mock_print.assert_any_call("The model instance was deleted.")
+
+    @patch("builtins.print")
+    @patch.object(KaggleApi, "confirmation", return_value=False)
+    @patch.object(KaggleApi, "validate_model_instance_version_string")
+    def test_model_instance_version_delete_cli_cancelled(self, mock_validate, mock_confirmation, mock_print):
+        self.api.model_instance_version_delete_cli(self.model_instance_version, False)
+
+        mock_confirmation.assert_called_once_with(f"delete the version {self.model_instance_version}")
+        mock_print.assert_any_call("Deletion cancelled")
+        _assert_no_success_message(mock_print, "The model instance version was deleted.")
+
+    @patch("builtins.print")
+    @patch.object(KaggleApi, "confirmation", return_value=True)
+    @patch.object(KaggleApi, "validate_model_instance_version_string")
+    @patch.object(KaggleApi, "lookup_enum", return_value=ModelFramework.MODEL_FRAMEWORK_PY_TORCH)
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_model_instance_version_delete_cli_success(
+        self, mock_build, mock_lookup, mock_validate, mock_confirmation, mock_print
+    ):
+        mock_kaggle = MagicMock()
+        mock_kaggle.models.model_api_client.delete_model_instance_version.return_value = ApiDeleteModelResponse()
+        mock_build.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_build.return_value.__exit__ = MagicMock(return_value=False)
+
+        self.api.model_instance_version_delete_cli(self.model_instance_version, False)
+
+        mock_kaggle.models.model_api_client.delete_model_instance_version.assert_called_once()
+        mock_print.assert_any_call("The model instance version was deleted.")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #1076. When a user cancels a model delete confirmation, the CLI no longer prints a success message.

## Problem

These commands printed a success message after the user answered `no` at the confirmation prompt:

- `kaggle models delete`
- `kaggle models instances delete`
- `kaggle models instances versions delete`

## Root cause

On cancellation, the delete methods returned an empty `ApiDeleteModelResponse()` whose `error` field is `''`. The CLI wrappers treated that as a successful delete.

## Solution

Return `None` when the user cancels. Update the `*_cli` wrappers to skip the success message when the result is `None`.

This follows the same approach as PR #1073 for dataset delete.

## Testing

Added `tests/unit/test_model_delete.py` with unit tests for cancelled and successful paths for all three commands.