### PR TITLE
feat(cli): add competitions pages create command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ keywords = ["Kaggle", "API"]
 requires-python = ">= 3.11"
 dependencies = [
     "bleach",
-    "kagglesdk >= 0.1.30, < 1.0", # sync with kagglehub
+    "kagglesdk >= 0.1.31, < 1.0", # sync with kagglehub
     "python-slugify",
     "requests",
     "python-dateutil",

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -2345,8 +2345,8 @@ class KaggleApi:
 
     def competition_create_page(
         self,
-        competition: str,
-        name: str,
+        competition_name: str,
+        page_name: str,
         content_path: str,
         mime_type: Optional[str] = None,
         post_title: Optional[str] = None,
@@ -2355,13 +2355,13 @@ class KaggleApi:
         """Create a new page on a competition you host.
 
         Args:
-            competition (str): The competition name (slug).
-            name (str): Page name (e.g. "description", "rules", "evaluation").
+            competition_name (str): The competition name (slug).
+            page_name (str): Page name (e.g. "description", "rules", "evaluation").
             content_path (str): Path to a file whose contents become the page body.
             mime_type (Optional[str]): MIME type of the content. Defaults to "text/html"
                 server-side if omitted.
             post_title (Optional[str]): Title shown above the content. Defaults to
-                ``name`` server-side if omitted.
+                ``page_name`` server-side if omitted.
             publish (bool): If True, publish the page immediately (default: staged
                 as unpublished).
 
@@ -2374,7 +2374,7 @@ class KaggleApi:
             content = f.read()
 
         page = ApiCompetitionPage()
-        page.name = name
+        page.name = page_name
         page.content = content
         if mime_type is not None:
             page.mime_type = mime_type
@@ -2384,7 +2384,7 @@ class KaggleApi:
 
         with self.build_kaggle_client() as kaggle:
             request = ApiCreateCompetitionPageRequest()
-            request.competition_name = competition
+            request.competition_name = competition_name
             request.page = page
             return kaggle.competitions.competition_api_client.create_competition_page(request)
 
@@ -2392,7 +2392,7 @@ class KaggleApi:
         self,
         competition=None,
         competition_opt=None,
-        name=None,
+        page_name=None,
         file_path=None,
         mime_type=None,
         post_title=None,
@@ -2400,28 +2400,28 @@ class KaggleApi:
         quiet=False,
     ):
         """CLI wrapper for competition_create_page."""
-        competition = competition or competition_opt
-        if competition is None:
-            competition = self.get_config_value(self.CONFIG_NAME_COMPETITION)
-            if competition is not None and not quiet:
-                print("Using competition: " + competition)
-        if competition is None:
+        competition_name = competition or competition_opt
+        if competition_name is None:
+            competition_name = self.get_config_value(self.CONFIG_NAME_COMPETITION)
+            if competition_name is not None and not quiet:
+                print("Using competition: " + competition_name)
+        if competition_name is None:
             raise ValueError("No competition specified")
-        if not name:
-            raise ValueError("--name is required")
+        if not page_name:
+            raise ValueError("--page-name is required")
         if not file_path:
             raise ValueError("-f/--file is required")
 
         page = self.competition_create_page(
-            competition,
-            name=name,
+            competition_name=competition_name,
+            page_name=page_name,
             content_path=file_path,
             mime_type=mime_type,
             post_title=post_title,
             publish=publish,
         )
         status = "published" if page.is_published else "staged (unpublished)"
-        print(f'Page "{page.name}" created on competition "{competition}" — {status}.')
+        print(f'Page "{page.name}" created on competition "{competition_name}" — {status}.')
 
     def competition_list_topics(self, competition: str, sort_by: Optional[str] = None, page: Optional[int] = None):
         """List discussion topics for a competition.

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -98,6 +98,8 @@ from kagglesdk.competitions.types.competition_api_service import (
     ApiGetEpisodeAgentLogsRequest,
     ApiListCompetitionPagesRequest,
     ApiListCompetitionPagesResponse,
+    ApiCreateCompetitionPageRequest,
+    ApiCompetitionPage,
     ApiListCompetitionTopicsRequest,
     ApiListCompetitionTopicsResponse,
     ApiListTopicMessagesRequest,
@@ -2340,6 +2342,86 @@ class KaggleApi:
             )
         else:
             print("No pages found")
+
+    def competition_create_page(
+        self,
+        competition: str,
+        name: str,
+        content_path: str,
+        mime_type: Optional[str] = None,
+        post_title: Optional[str] = None,
+        publish: bool = False,
+    ) -> ApiCompetitionPage:
+        """Create a new page on a competition you host.
+
+        Args:
+            competition (str): The competition name (slug).
+            name (str): Page name (e.g. "description", "rules", "evaluation").
+            content_path (str): Path to a file whose contents become the page body.
+            mime_type (Optional[str]): MIME type of the content. Defaults to "text/html"
+                server-side if omitted.
+            post_title (Optional[str]): Title shown above the content. Defaults to
+                ``name`` server-side if omitted.
+            publish (bool): If True, publish the page immediately (default: staged
+                as unpublished).
+
+        Returns:
+            ApiCompetitionPage: the created page.
+        """
+        if not os.path.isfile(content_path):
+            raise ValueError("Content file not found: " + content_path)
+        with open(content_path, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        page = ApiCompetitionPage()
+        page.name = name
+        page.content = content
+        if mime_type is not None:
+            page.mime_type = mime_type
+        if post_title is not None:
+            page.post_title = post_title
+        page.is_published = publish
+
+        with self.build_kaggle_client() as kaggle:
+            request = ApiCreateCompetitionPageRequest()
+            request.competition_name = competition
+            request.page = page
+            return kaggle.competitions.competition_api_client.create_competition_page(request)
+
+    def competition_create_page_cli(
+        self,
+        competition=None,
+        competition_opt=None,
+        name=None,
+        file_path=None,
+        mime_type=None,
+        post_title=None,
+        publish=False,
+        quiet=False,
+    ):
+        """CLI wrapper for competition_create_page."""
+        competition = competition or competition_opt
+        if competition is None:
+            competition = self.get_config_value(self.CONFIG_NAME_COMPETITION)
+            if competition is not None and not quiet:
+                print("Using competition: " + competition)
+        if competition is None:
+            raise ValueError("No competition specified")
+        if not name:
+            raise ValueError("--name is required")
+        if not file_path:
+            raise ValueError("-f/--file is required")
+
+        page = self.competition_create_page(
+            competition,
+            name=name,
+            content_path=file_path,
+            mime_type=mime_type,
+            post_title=post_title,
+            publish=publish,
+        )
+        status = "published" if page.is_published else "staged (unpublished)"
+        print(f'Page "{page.name}" created on competition "{competition}" — {status}.')
 
     def competition_list_topics(self, competition: str, sort_by: Optional[str] = None, page: Optional[int] = None):
         """List discussion topics for a competition.

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -380,30 +380,94 @@ def parse_competitions(subparsers) -> None:
     parser_competitions_episode_logs._action_groups.append(parser_competitions_episode_logs_optional)
     parser_competitions_episode_logs.set_defaults(func=api.competition_episode_agent_logs_cli)
 
-    # Competitions list pages
-    parser_competitions_pages = subparsers_competitions.add_parser(
-        "pages", formatter_class=argparse.RawTextHelpFormatter, help=Help.command_competitions_pages
+    # Competitions pages (group: list / create)
+    shared_competition_pages_list = argparse.ArgumentParser(add_help=False)
+    shared_competition_pages_list.add_argument(
+        "competition", nargs="?", default=None, help=Help.param_competition
     )
-    parser_competitions_pages_optional = parser_competitions_pages._action_groups.pop()
-    parser_competitions_pages_optional.add_argument("competition", nargs="?", default=None, help=Help.param_competition)
-    parser_competitions_pages_optional.add_argument(
+    shared_competition_pages_list.add_argument(
         "-c", "--competition", dest="competition_opt", required=False, help=argparse.SUPPRESS
     )
-    _add_output_format_args(parser_competitions_pages_optional)
-    parser_competitions_pages_optional.add_argument(
+    _add_output_format_args(shared_competition_pages_list)
+    shared_competition_pages_list.add_argument(
         "-q", "--quiet", dest="quiet", action="store_true", help=Help.param_quiet
     )
-    parser_competitions_pages_optional.add_argument(
+    shared_competition_pages_list.add_argument(
         "--content", dest="content", action="store_true", help="Show full page content"
     )
-    parser_competitions_pages_optional.add_argument(
+    shared_competition_pages_list.add_argument(
         "--page-name",
         dest="page_name",
         required=False,
         help='Filter to a specific page (e.g. "description", "rules", "evaluation")',
     )
-    parser_competitions_pages._action_groups.append(parser_competitions_pages_optional)
+
+    parser_competitions_pages = subparsers_competitions.add_parser(
+        "pages",
+        formatter_class=argparse.RawTextHelpFormatter,
+        help=Help.command_competitions_pages,
+        parents=[shared_competition_pages_list],
+    )
+    subparsers_competitions_pages = parser_competitions_pages.add_subparsers(title="commands", dest="command")
+    subparsers_competitions_pages.choices = Help.entity_pages_choices
+
+    # Default action when no subcommand is given: list
     parser_competitions_pages.set_defaults(func=api.competition_list_pages_cli)
+
+    # Competitions pages list (explicit)
+    parser_competitions_pages_list = subparsers_competitions_pages.add_parser(
+        "list",
+        formatter_class=argparse.RawTextHelpFormatter,
+        help=Help.command_competitions_pages,
+        parents=[shared_competition_pages_list],
+    )
+    parser_competitions_pages_list.set_defaults(func=api.competition_list_pages_cli)
+
+    # Competitions pages create
+    parser_competitions_pages_create = subparsers_competitions_pages.add_parser(
+        "create",
+        formatter_class=argparse.RawTextHelpFormatter,
+        help=Help.command_competitions_pages_create,
+    )
+    parser_competitions_pages_create_optional = parser_competitions_pages_create._action_groups.pop()
+    parser_competitions_pages_create_optional.add_argument(
+        "competition", nargs="?", default=None, help=Help.param_competition
+    )
+    parser_competitions_pages_create_optional.add_argument(
+        "-c", "--competition", dest="competition_opt", required=False, help=argparse.SUPPRESS
+    )
+    parser_competitions_pages_create_optional.add_argument(
+        "--name",
+        dest="name",
+        required=True,
+        help='Page name (e.g. "description", "rules", "evaluation").',
+    )
+    parser_competitions_pages_create_optional.add_argument(
+        "-f", "--file", dest="file_path", required=True, help="Path to a file containing the page body."
+    )
+    parser_competitions_pages_create_optional.add_argument(
+        "--mime-type",
+        dest="mime_type",
+        required=False,
+        help='MIME type of the content (defaults to "text/html" server-side).',
+    )
+    parser_competitions_pages_create_optional.add_argument(
+        "--post-title",
+        dest="post_title",
+        required=False,
+        help="Title displayed above the page content (defaults to the page name).",
+    )
+    parser_competitions_pages_create_optional.add_argument(
+        "--publish",
+        dest="publish",
+        action="store_true",
+        help="Publish the page immediately (default: staged as unpublished).",
+    )
+    parser_competitions_pages_create_optional.add_argument(
+        "-q", "--quiet", dest="quiet", action="store_true", help=Help.param_quiet
+    )
+    parser_competitions_pages_create._action_groups.append(parser_competitions_pages_create_optional)
+    parser_competitions_pages_create.set_defaults(func=api.competition_create_page_cli)
 
     shared_topics = _get_shared_topics_parser()
     shared_competition_topics = _get_shared_competition_topics_parser()
@@ -1973,6 +2037,7 @@ class Help(object):
     forums_choices = ["list", "topics"]
     forums_topics_choices = ["list", "show"]
     entity_topics_choices = ["list", "show"]
+    entity_pages_choices = ["list", "create"]
     config_choices = ["view", "set", "unset"]
     auth_choices = ["login", "print-access-token", "revoke"]
 
@@ -2045,6 +2110,7 @@ class Help(object):
     command_competitions_episode_replay = "Download the replay for a simulation episode"
     command_competitions_episode_logs = "Download agent logs for a simulation episode"
     command_competitions_pages = "List pages for a competition"
+    command_competitions_pages_create = "Create a new page on a competition you host"
     command_competitions_topics = "List discussion topics for a competition"
     command_competitions_topic_messages = "List messages within a competition discussion topic"
 

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -382,9 +382,7 @@ def parse_competitions(subparsers) -> None:
 
     # Competitions pages (group: list / create)
     shared_competition_pages_list = argparse.ArgumentParser(add_help=False)
-    shared_competition_pages_list.add_argument(
-        "competition", nargs="?", default=None, help=Help.param_competition
-    )
+    shared_competition_pages_list.add_argument("competition", nargs="?", default=None, help=Help.param_competition)
     shared_competition_pages_list.add_argument(
         "-c", "--competition", dest="competition_opt", required=False, help=argparse.SUPPRESS
     )
@@ -437,8 +435,8 @@ def parse_competitions(subparsers) -> None:
         "-c", "--competition", dest="competition_opt", required=False, help=argparse.SUPPRESS
     )
     parser_competitions_pages_create_optional.add_argument(
-        "--name",
-        dest="name",
+        "--page-name",
+        dest="page_name",
         required=True,
         help='Page name (e.g. "description", "rules", "evaluation").',
     )

--- a/tests/test_commands.sh
+++ b/tests/test_commands.sh
@@ -38,6 +38,7 @@ echo "kaggle competitions pages"
 kaggle c pages titanic
 kaggle c pages titanic -v -q
 kaggle c pages titanic --page-name rules --content
+kaggle c pages list titanic --page-name rules
 rm -r titanic.zip tost sample_submission.csv leaders leaderboard.txt
 
 echo "kaggle kernels list"

--- a/tests/unit/test_competition_create_page.py
+++ b/tests/unit/test_competition_create_page.py
@@ -1,0 +1,166 @@
+# coding=utf-8
+import io
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, "../..")
+
+from kaggle.api.kaggle_api_extended import KaggleApi
+
+
+def _mock_created_page(name="rules", is_published=False):
+    page = MagicMock()
+    page.name = name
+    page.is_published = is_published
+    return page
+
+
+class TestCompetitionCreatePage(unittest.TestCase):
+    """Tests for competition_create_page and its CLI wrapper."""
+
+    def setUp(self):
+        self.api = KaggleApi.__new__(KaggleApi)
+        self._tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False, encoding="utf-8")
+        self._tmp.write("# Rules\nYou must follow these rules.\n")
+        self._tmp.close()
+        self.content_path = self._tmp.name
+
+    def tearDown(self):
+        os.unlink(self.content_path)
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_create_page_sends_expected_request(self, mock_client):
+        created = _mock_created_page(name="rules", is_published=True)
+        mock_kaggle = MagicMock()
+        mock_kaggle.competitions.competition_api_client.create_competition_page.return_value = created
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = self.api.competition_create_page(
+            competition_name="my-comp",
+            page_name="rules",
+            content_path=self.content_path,
+            mime_type="text/markdown",
+            post_title="Competition Rules",
+            publish=True,
+        )
+
+        self.assertIs(result, created)
+        call = mock_kaggle.competitions.competition_api_client.create_competition_page.call_args
+        request = call[0][0]
+        self.assertEqual(request.competition_name, "my-comp")
+        self.assertEqual(request.page.name, "rules")
+        self.assertEqual(request.page.content, "# Rules\nYou must follow these rules.\n")
+        self.assertEqual(request.page.mime_type, "text/markdown")
+        self.assertEqual(request.page.post_title, "Competition Rules")
+        self.assertTrue(request.page.is_published)
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_create_page_defaults_unpublished_and_omits_optionals(self, mock_client):
+        mock_kaggle = MagicMock()
+        mock_kaggle.competitions.competition_api_client.create_competition_page.return_value = _mock_created_page(
+            name="description", is_published=False
+        )
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        self.api.competition_create_page(
+            competition_name="my-comp",
+            page_name="description",
+            content_path=self.content_path,
+        )
+
+        request = mock_kaggle.competitions.competition_api_client.create_competition_page.call_args[0][0]
+        self.assertEqual(request.page.name, "description")
+        self.assertFalse(request.page.is_published)
+        # mime_type / post_title left unset so the server applies its defaults.
+        self.assertEqual(request.page.mime_type, "")
+        self.assertEqual(request.page.post_title, "")
+
+    def test_create_page_missing_content_file_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.api.competition_create_page(
+                competition_name="my-comp",
+                page_name="rules",
+                content_path="/tmp/does-not-exist-12345.md",
+            )
+        self.assertIn("Content file not found", str(ctx.exception))
+
+    @patch.object(KaggleApi, "competition_create_page")
+    def test_cli_invokes_api_with_resolved_args(self, mock_create):
+        mock_create.return_value = _mock_created_page(name="rules", is_published=True)
+
+        captured = io.StringIO()
+        sys.stdout = captured
+        try:
+            self.api.competition_create_page_cli(
+                competition="my-comp",
+                page_name="rules",
+                file_path=self.content_path,
+                mime_type="text/markdown",
+                publish=True,
+            )
+        finally:
+            sys.stdout = sys.__stdout__
+
+        mock_create.assert_called_once_with(
+            competition_name="my-comp",
+            page_name="rules",
+            content_path=self.content_path,
+            mime_type="text/markdown",
+            post_title=None,
+            publish=True,
+        )
+        output = captured.getvalue()
+        self.assertIn('Page "rules" created on competition "my-comp"', output)
+        self.assertIn("published", output)
+
+    @patch.object(KaggleApi, "competition_create_page")
+    def test_cli_uses_competition_opt_flag(self, mock_create):
+        mock_create.return_value = _mock_created_page(name="rules", is_published=False)
+
+        captured = io.StringIO()
+        sys.stdout = captured
+        try:
+            self.api.competition_create_page_cli(
+                competition_opt="my-comp",
+                page_name="rules",
+                file_path=self.content_path,
+            )
+        finally:
+            sys.stdout = sys.__stdout__
+
+        self.assertEqual(mock_create.call_args.kwargs["competition_name"], "my-comp")
+        self.assertIn("staged (unpublished)", captured.getvalue())
+
+    def test_cli_missing_competition_raises(self):
+        self.api.config_values = {}
+        with self.assertRaises(ValueError) as ctx:
+            self.api.competition_create_page_cli(
+                page_name="rules",
+                file_path=self.content_path,
+            )
+        self.assertIn("No competition specified", str(ctx.exception))
+
+    def test_cli_missing_page_name_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.api.competition_create_page_cli(
+                competition="my-comp",
+                file_path=self.content_path,
+            )
+        self.assertIn("--page-name is required", str(ctx.exception))
+
+    def test_cli_missing_file_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.api.competition_create_page_cli(
+                competition="my-comp",
+                page_name="rules",
+            )
+        self.assertIn("-f/--file is required", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Wrap kagglesdk 0.1.31's new create_competition_page RPC behind `kaggle competitions pages create <competition> --name <page-name> -f <path> [--mime-type ...] [--post-title ...] [--publish]`.

The existing `kaggle competitions pages` flat list command is preserved by promoting `pages` to a subcommand group that defaults to `list` when no subcommand is given (same pattern as `competitions topics`).

Bumps the kagglesdk floor to 0.1.31 for the new request types.