### PR TITLE
feat(cli): add competitions launch command

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -100,6 +100,7 @@ from kagglesdk.competitions.types.competition_api_service import (
     ApiListCompetitionPagesResponse,
     ApiCreateCompetitionPageRequest,
     ApiCompetitionPage,
+    ApiLaunchCompetitionRequest,
     ApiListCompetitionTopicsRequest,
     ApiListCompetitionTopicsResponse,
     ApiListTopicMessagesRequest,
@@ -2422,6 +2423,53 @@ class KaggleApi:
         )
         status = "published" if page.is_published else "staged (unpublished)"
         print(f'Page "{page.name}" created on competition "{competition_name}" — {status}.')
+
+    def competition_launch(self, competition_name: str, future_time: Optional[datetime] = None) -> None:
+        """Launch a competition you host, optionally at a future UTC time.
+
+        Args:
+            competition_name (str): The competition name (slug).
+            future_time (Optional[datetime]): If set, schedule launch for this UTC
+                instant. If omitted, launch immediately.
+        """
+        with self.build_kaggle_client() as kaggle:
+            request = ApiLaunchCompetitionRequest()
+            request.competition_name = competition_name
+            if future_time is not None:
+                request.future_time = future_time
+            kaggle.competitions.competition_api_client.launch_competition(request)
+
+    def competition_launch_cli(
+        self,
+        competition=None,
+        competition_opt=None,
+        at=None,
+        quiet=False,
+    ):
+        """CLI wrapper for competition_launch."""
+        competition_name = competition or competition_opt
+        if competition_name is None:
+            competition_name = self.get_config_value(self.CONFIG_NAME_COMPETITION)
+            if competition_name is not None and not quiet:
+                print("Using competition: " + competition_name)
+        if competition_name is None:
+            raise ValueError("No competition specified")
+
+        future_time = None
+        if at:
+            try:
+                parsed = datetime.fromisoformat(at.rstrip("Z"))
+            except ValueError as exc:
+                raise ValueError(f"Invalid --at value '{at}'. Use ISO-8601 UTC (e.g. 2027-01-01T00:00:00Z).") from exc
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            future_time = parsed
+
+        self.competition_launch(competition_name=competition_name, future_time=future_time)
+        if future_time is not None:
+            print(f'Competition "{competition_name}" scheduled to launch at {future_time.isoformat()}.')
+        else:
+            print(f'Competition "{competition_name}" launched.')
 
     def competition_list_topics(self, competition: str, sort_by: Optional[str] = None, page: Optional[int] = None):
         """List discussion topics for a competition.

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -467,6 +467,29 @@ def parse_competitions(subparsers) -> None:
     parser_competitions_pages_create._action_groups.append(parser_competitions_pages_create_optional)
     parser_competitions_pages_create.set_defaults(func=api.competition_create_page_cli)
 
+    # Competitions launch (publish now, or schedule for a future UTC time)
+    parser_competitions_launch = subparsers_competitions.add_parser(
+        "launch", formatter_class=argparse.RawTextHelpFormatter, help=Help.command_competitions_launch
+    )
+    parser_competitions_launch_optional = parser_competitions_launch._action_groups.pop()
+    parser_competitions_launch_optional.add_argument(
+        "competition", nargs="?", default=None, help=Help.param_competition
+    )
+    parser_competitions_launch_optional.add_argument(
+        "-c", "--competition", dest="competition_opt", required=False, help=argparse.SUPPRESS
+    )
+    parser_competitions_launch_optional.add_argument(
+        "--at",
+        dest="at",
+        required=False,
+        help='Schedule launch at this UTC ISO-8601 time (e.g. "2027-01-01T00:00:00Z"). Omit to launch now.',
+    )
+    parser_competitions_launch_optional.add_argument(
+        "-q", "--quiet", dest="quiet", action="store_true", help=Help.param_quiet
+    )
+    parser_competitions_launch._action_groups.append(parser_competitions_launch_optional)
+    parser_competitions_launch.set_defaults(func=api.competition_launch_cli)
+
     shared_topics = _get_shared_topics_parser()
     shared_competition_topics = _get_shared_competition_topics_parser()
 
@@ -1974,6 +1997,7 @@ class Help(object):
         "replay",
         "logs",
         "pages",
+        "launch",
         "topics",
         "topic-messages",
     ]
@@ -2109,6 +2133,7 @@ class Help(object):
     command_competitions_episode_logs = "Download agent logs for a simulation episode"
     command_competitions_pages = "List pages for a competition"
     command_competitions_pages_create = "Create a new page on a competition you host"
+    command_competitions_launch = "Launch a competition you host, optionally at a future UTC time"
     command_competitions_topics = "List discussion topics for a competition"
     command_competitions_topic_messages = "List messages within a competition discussion topic"
 

--- a/tests/unit/test_competition_launch.py
+++ b/tests/unit/test_competition_launch.py
@@ -1,0 +1,100 @@
+# coding=utf-8
+import sys
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, "../..")
+
+from kaggle.api.kaggle_api_extended import KaggleApi
+
+
+class TestCompetitionLaunch(unittest.TestCase):
+    """Tests for competition_launch and its CLI wrapper."""
+
+    def setUp(self):
+        self.api = KaggleApi.__new__(KaggleApi)
+
+    def _patch_client(self, mock_client):
+        mock_kaggle = MagicMock()
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+        return mock_kaggle
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_launch_now_sends_request_without_future_time(self, mock_client):
+        mock_kaggle = self._patch_client(mock_client)
+
+        self.api.competition_launch(competition_name="my-comp")
+
+        call = mock_kaggle.competitions.competition_api_client.launch_competition.call_args
+        request = call[0][0]
+        self.assertEqual(request.competition_name, "my-comp")
+        self.assertIsNone(request.future_time)
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_launch_with_future_time(self, mock_client):
+        mock_kaggle = self._patch_client(mock_client)
+        when = datetime(2027, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+        self.api.competition_launch(competition_name="my-comp", future_time=when)
+
+        request = mock_kaggle.competitions.competition_api_client.launch_competition.call_args[0][0]
+        self.assertEqual(request.competition_name, "my-comp")
+        self.assertEqual(request.future_time, when)
+
+    @patch.object(KaggleApi, "competition_launch")
+    def test_cli_launch_now_passes_no_future_time(self, mock_launch):
+        self.api.competition_launch_cli(competition="my-comp")
+
+        mock_launch.assert_called_once_with(competition_name="my-comp", future_time=None)
+
+    @patch.object(KaggleApi, "competition_launch")
+    def test_cli_parses_zulu_iso_string(self, mock_launch):
+        self.api.competition_launch_cli(competition="my-comp", at="2027-01-01T00:00:00Z")
+
+        kwargs = mock_launch.call_args.kwargs
+        self.assertEqual(kwargs["competition_name"], "my-comp")
+        self.assertEqual(
+            kwargs["future_time"],
+            datetime(2027, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+        )
+
+    @patch.object(KaggleApi, "competition_launch")
+    def test_cli_parses_explicit_offset(self, mock_launch):
+        self.api.competition_launch_cli(competition="my-comp", at="2027-01-01T00:00:00+00:00")
+
+        self.assertEqual(
+            mock_launch.call_args.kwargs["future_time"],
+            datetime(2027, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+        )
+
+    @patch.object(KaggleApi, "competition_launch")
+    def test_cli_naive_string_assumed_utc(self, mock_launch):
+        self.api.competition_launch_cli(competition="my-comp", at="2027-01-01T00:00:00")
+
+        self.assertEqual(
+            mock_launch.call_args.kwargs["future_time"],
+            datetime(2027, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+        )
+
+    def test_cli_bad_at_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.api.competition_launch_cli(competition="my-comp", at="not-a-date")
+        self.assertIn("Invalid --at value", str(ctx.exception))
+
+    def test_cli_missing_competition_raises(self):
+        self.api.config_values = {}
+        with self.assertRaises(ValueError) as ctx:
+            self.api.competition_launch_cli()
+        self.assertIn("No competition specified", str(ctx.exception))
+
+    @patch.object(KaggleApi, "competition_launch")
+    def test_cli_uses_competition_opt_flag(self, mock_launch):
+        self.api.competition_launch_cli(competition_opt="my-comp")
+
+        self.assertEqual(mock_launch.call_args.kwargs["competition_name"], "my-comp")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Wrap kagglesdk 0.1.31's new launch_competition RPC behind `kaggle competitions launch <competition> [--at <ISO-8601 UTC>]`. Without --at the competition is launched immediately; with --at the backend schedules a future-time launch.