### PR TITLE
fix(cli): stop treating subcommand -v as version flag

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -1166,7 +1166,15 @@ class KaggleApi:
         Returns:
             bool: True if valid
         """
-        return api_command.endswith(("-h", "--help", "-v", "--version"))
+        argv = sys.argv[1:]
+        if not argv:
+            return False
+        # Top-level only: kaggle -v, kaggle --version, kaggle -h, kaggle --help
+        if len(argv) == 1 and argv[0] in ("-h", "--help", "-v", "--version"):
+            return True
+        # Subcommand help only. Do not treat trailing -v as version: many commands use
+        # -v as the --csv output-format alias (e.g. kaggle quota -v).
+        return api_command.endswith(("-h", "--help"))
 
     def read_config_environment(self, config_data: Optional[Dict[str, str]] = None) -> Dict[str, str]:
         """Reads config values from environment variables.

--- a/tests/unit/test_help_version_auth.py
+++ b/tests/unit/test_help_version_auth.py
@@ -1,0 +1,42 @@
+# coding=utf-8
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, "../../src")
+
+from kaggle.api.kaggle_api_extended import KaggleApi
+
+
+class TestHelpOrVersionAuth(unittest.TestCase):
+    """Tests for help/version detection used during authenticate()."""
+
+    def setUp(self):
+        self.api = KaggleApi.__new__(KaggleApi)
+
+    def _assert_help_or_version(self, argv, expected):
+        with patch.object(sys, "argv", argv):
+            api_command = " ".join(argv[1:])
+            self.assertEqual(self.api._is_help_or_version_command(api_command), expected)
+
+    def test_top_level_version_and_help(self):
+        self._assert_help_or_version(["kaggle", "-v"], True)
+        self._assert_help_or_version(["kaggle", "--version"], True)
+        self._assert_help_or_version(["kaggle", "-h"], True)
+        self._assert_help_or_version(["kaggle", "--help"], True)
+
+    def test_subcommand_csv_flag_is_not_version(self):
+        self._assert_help_or_version(["kaggle", "quota", "-v"], False)
+        self._assert_help_or_version(["kaggle", "datasets", "list", "-v"], False)
+
+    def test_subcommand_help_still_skips_auth(self):
+        self._assert_help_or_version(["kaggle", "quota", "-h"], True)
+        self._assert_help_or_version(["kaggle", "datasets", "list", "--help"], True)
+
+    def test_quota_csv_flag_does_not_allow_logged_out(self):
+        with patch.object(sys, "argv", ["kaggle", "quota", "-v"]):
+            self.assertFalse(self.api._command_allows_logged_out("quota -v"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fix `_is_help_or_version_command` so subcommand `-v` (the CSV output alias on commands like `quota`) no longer skips authentication. Top-level `kaggle -v` / `kaggle --version` still skip auth as before.

The duration parsing crash from #1064 is handled separately in Kaggle/kaggle-sdk-python#58 (needs kapigen sync and a new kagglesdk release).

## Root cause

`authenticate()` runs before argparse and joins `sys.argv[1:]` into a string. `"quota -v".endswith("-v")` matched the global version check even though `-v` here is the CSV flag, causing unauthenticated API calls and 401s.

## Tests

Added `tests/unit/test_help_version_auth.py` covering top-level version/help, subcommand CSV `-v`, and subcommand help.

## Test plan

- [x] `pytest tests/unit/test_help_version_auth.py`
- [ ] Maintainer: please run `/gcbrun` for Cloud Build (fork PR)

Related to Kaggle/kaggle-cli#1064
