### PR TITLE
feat(cli): add competitions pages delete command

### DIFF
--- a/docs/competition_creation.md
+++ b/docs/competition_creation.md
@@ -204,10 +204,50 @@ kaggle competitions pages create my-comp --name rules -f ./rules-final.md --publ
 ```
 
 **Note:** `pages create` does not update an existing page in place — it creates
-a new page. Update / delete endpoints are not yet exposed in the public API.
+a new page. Use [`kaggle competitions pages delete`](#kaggle-competitions-pages-delete)
+to remove a page.
 
 You can list and inspect existing pages with `kaggle competitions pages`
 (or the explicit `kaggle competitions pages list`).
+
+---
+
+## `kaggle competitions pages delete`
+
+Deletes a page from a competition you host. Prompts for confirmation unless
+`-y/--yes` is passed (matches the existing `kaggle datasets delete` /
+`kaggle kernels delete` patterns).
+
+**Usage:**
+
+```bash
+kaggle competitions pages delete <competition> --page-name <name> [-y]
+```
+
+**Arguments:**
+
+- `<competition>`: The competition slug.
+
+**Options:**
+
+- `--page-name <name>` (required): Name of the page to delete.
+- `-y, --yes` (optional): Skip the confirmation prompt — useful for scripts.
+
+**Examples:**
+
+```bash
+# Interactive: prompts "Are you sure you want to delete the page 'faq' ...?"
+kaggle competitions pages delete my-comp --page-name faq
+
+# Scripted: skip the prompt.
+kaggle competitions pages delete my-comp --page-name faq -y
+```
+
+**Note:** a small set of pages is protected by the backend and cannot be
+deleted; attempting to delete one returns an error from the server.
+
+Deletion is not recoverable — there is no "undelete". List pages first with
+`kaggle competitions pages list <competition>` if you're unsure of the name.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ keywords = ["Kaggle", "API"]
 requires-python = ">= 3.11"
 dependencies = [
     "bleach",
-    "kagglesdk >= 0.1.31, < 1.0", # sync with kagglehub
+    "kagglesdk >= 0.1.32, < 1.0", # sync with kagglehub
     "python-slugify",
     "requests",
     "python-dateutil",

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -99,6 +99,7 @@ from kagglesdk.competitions.types.competition_api_service import (
     ApiListCompetitionPagesRequest,
     ApiListCompetitionPagesResponse,
     ApiCreateCompetitionPageRequest,
+    ApiDeleteCompetitionPageRequest,
     ApiCompetitionPage,
     ApiCreateCompetitionRequest,
     ApiCreateCompetitionResponse,
@@ -2429,6 +2430,56 @@ class KaggleApi:
         )
         status = "published" if page.is_published else "staged (unpublished)"
         print(f'Page "{page.name}" created on competition "{competition_name}" — {status}.')
+
+    def competition_delete_page(
+        self,
+        competition_name: str,
+        page_name: str,
+        no_confirm: bool = False,
+    ) -> bool:
+        """Delete a page from a competition you host.
+
+        Args:
+            competition_name (str): The competition name (slug).
+            page_name (str): Name of the page to delete.
+            no_confirm (bool): If True, skip the confirmation prompt.
+
+        Returns:
+            bool: True if deleted, False if cancelled.
+        """
+        if not no_confirm:
+            if not self.confirmation(f"delete the page '{page_name}' from competition '{competition_name}'"):
+                print("Deletion cancelled")
+                return False
+
+        with self.build_kaggle_client() as kaggle:
+            request = ApiDeleteCompetitionPageRequest()
+            request.competition_name = competition_name
+            request.page_name = page_name
+            kaggle.competitions.competition_api_client.delete_competition_page(request)
+        return True
+
+    def competition_delete_page_cli(
+        self,
+        competition=None,
+        competition_opt=None,
+        page_name=None,
+        no_confirm=False,
+        quiet=False,
+    ):
+        """CLI wrapper for competition_delete_page."""
+        competition_name = competition or competition_opt
+        if competition_name is None:
+            competition_name = self.get_config_value(self.CONFIG_NAME_COMPETITION)
+            if competition_name is not None and not quiet:
+                print("Using competition: " + competition_name)
+        if competition_name is None:
+            raise ValueError("No competition specified")
+        if not page_name:
+            raise ValueError("--page-name is required")
+
+        if self.competition_delete_page(competition_name, page_name, no_confirm=no_confirm):
+            print(f'Page "{page_name}" deleted from competition "{competition_name}".')
 
     def competition_launch(self, competition_name: str, future_time: Optional[datetime] = None) -> None:
         """Launch a competition you host, optionally at a future UTC time.

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -467,6 +467,38 @@ def parse_competitions(subparsers) -> None:
     parser_competitions_pages_create._action_groups.append(parser_competitions_pages_create_optional)
     parser_competitions_pages_create.set_defaults(func=api.competition_create_page_cli)
 
+    # Competitions pages delete
+    parser_competitions_pages_delete = subparsers_competitions_pages.add_parser(
+        "delete",
+        formatter_class=argparse.RawTextHelpFormatter,
+        help=Help.command_competitions_pages_delete,
+    )
+    parser_competitions_pages_delete_optional = parser_competitions_pages_delete._action_groups.pop()
+    parser_competitions_pages_delete_optional.add_argument(
+        "competition", nargs="?", default=None, help=Help.param_competition
+    )
+    parser_competitions_pages_delete_optional.add_argument(
+        "-c", "--competition", dest="competition_opt", required=False, help=argparse.SUPPRESS
+    )
+    parser_competitions_pages_delete_optional.add_argument(
+        "--page-name",
+        dest="page_name",
+        required=True,
+        help="Name of the page to delete.",
+    )
+    parser_competitions_pages_delete_optional.add_argument(
+        "-y",
+        "--yes",
+        dest="no_confirm",
+        action="store_true",
+        help="Skip the confirmation prompt.",
+    )
+    parser_competitions_pages_delete_optional.add_argument(
+        "-q", "--quiet", dest="quiet", action="store_true", help=Help.param_quiet
+    )
+    parser_competitions_pages_delete._action_groups.append(parser_competitions_pages_delete_optional)
+    parser_competitions_pages_delete.set_defaults(func=api.competition_delete_page_cli)
+
     # Competitions launch (publish now, or schedule for a future UTC time)
     parser_competitions_launch = subparsers_competitions.add_parser(
         "launch", formatter_class=argparse.RawTextHelpFormatter, help=Help.command_competitions_launch
@@ -2090,7 +2122,7 @@ class Help(object):
     forums_choices = ["list", "topics"]
     forums_topics_choices = ["list", "show"]
     entity_topics_choices = ["list", "show"]
-    entity_pages_choices = ["list", "create"]
+    entity_pages_choices = ["list", "create", "delete"]
     config_choices = ["view", "set", "unset"]
     auth_choices = ["login", "print-access-token", "revoke"]
 
@@ -2164,6 +2196,7 @@ class Help(object):
     command_competitions_episode_logs = "Download agent logs for a simulation episode"
     command_competitions_pages = "List pages for a competition"
     command_competitions_pages_create = "Create a new page on a competition you host"
+    command_competitions_pages_delete = "Delete a page from a competition you host"
     command_competitions_launch = "Launch a competition you host, optionally at a future UTC time"
     command_competitions_init = "Initialize folder with a competition-metadata.json template"
     command_competitions_create = "Create a new competition from competition-metadata.json"

--- a/tests/unit/test_competition_delete_page.py
+++ b/tests/unit/test_competition_delete_page.py
@@ -1,0 +1,117 @@
+# coding=utf-8
+import io
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, "../..")
+
+from kaggle.api.kaggle_api_extended import KaggleApi
+
+
+class TestCompetitionDeletePage(unittest.TestCase):
+    """Tests for competition_delete_page and its CLI wrapper."""
+
+    def setUp(self):
+        self.api = KaggleApi.__new__(KaggleApi)
+
+    def _patch_client(self, mock_client):
+        mock_kaggle = MagicMock()
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+        return mock_kaggle
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_delete_no_confirm_sends_request(self, mock_client):
+        mock_kaggle = self._patch_client(mock_client)
+
+        result = self.api.competition_delete_page(
+            competition_name="my-comp",
+            page_name="rules",
+            no_confirm=True,
+        )
+
+        self.assertTrue(result)
+        request = mock_kaggle.competitions.competition_api_client.delete_competition_page.call_args[0][0]
+        self.assertEqual(request.competition_name, "my-comp")
+        self.assertEqual(request.page_name, "rules")
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    @patch.object(KaggleApi, "confirmation", return_value=True)
+    def test_delete_with_confirmation_yes_sends_request(self, mock_confirm, mock_client):
+        mock_kaggle = self._patch_client(mock_client)
+
+        result = self.api.competition_delete_page(competition_name="my-comp", page_name="rules")
+
+        self.assertTrue(result)
+        mock_confirm.assert_called_once()
+        self.assertIn("rules", mock_confirm.call_args[0][0])
+        self.assertIn("my-comp", mock_confirm.call_args[0][0])
+        mock_kaggle.competitions.competition_api_client.delete_competition_page.assert_called_once()
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    @patch.object(KaggleApi, "confirmation", return_value=False)
+    def test_delete_cancelled_skips_request(self, mock_confirm, mock_client):
+        mock_kaggle = self._patch_client(mock_client)
+
+        captured = io.StringIO()
+        sys.stdout = captured
+        try:
+            result = self.api.competition_delete_page(competition_name="my-comp", page_name="rules")
+        finally:
+            sys.stdout = sys.__stdout__
+
+        self.assertFalse(result)
+        self.assertIn("Deletion cancelled", captured.getvalue())
+        mock_kaggle.competitions.competition_api_client.delete_competition_page.assert_not_called()
+
+    @patch.object(KaggleApi, "competition_delete_page", return_value=True)
+    def test_cli_forwards_yes_flag(self, mock_delete):
+        captured = io.StringIO()
+        sys.stdout = captured
+        try:
+            self.api.competition_delete_page_cli(
+                competition="my-comp",
+                page_name="rules",
+                no_confirm=True,
+            )
+        finally:
+            sys.stdout = sys.__stdout__
+
+        mock_delete.assert_called_once_with("my-comp", "rules", no_confirm=True)
+        self.assertIn('Page "rules" deleted', captured.getvalue())
+
+    @patch.object(KaggleApi, "competition_delete_page", return_value=False)
+    def test_cli_cancelled_prints_no_success(self, mock_delete):
+        captured = io.StringIO()
+        sys.stdout = captured
+        try:
+            self.api.competition_delete_page_cli(competition="my-comp", page_name="rules")
+        finally:
+            sys.stdout = sys.__stdout__
+
+        self.assertNotIn("deleted", captured.getvalue())
+
+    @patch.object(KaggleApi, "competition_delete_page", return_value=True)
+    def test_cli_uses_competition_opt_flag(self, mock_delete):
+        self.api.competition_delete_page_cli(
+            competition_opt="my-comp",
+            page_name="rules",
+            no_confirm=True,
+        )
+        self.assertEqual(mock_delete.call_args[0][0], "my-comp")
+
+    def test_cli_missing_competition_raises(self):
+        self.api.config_values = {}
+        with self.assertRaises(ValueError) as ctx:
+            self.api.competition_delete_page_cli(page_name="rules")
+        self.assertIn("No competition specified", str(ctx.exception))
+
+    def test_cli_missing_page_name_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.api.competition_delete_page_cli(competition="my-comp")
+        self.assertIn("--page-name is required", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Wrap kagglesdk 0.1.32's new delete_competition_page RPC behind `kaggle competitions pages delete <competition> --page-name <name> [-y/--yes]`. Confirms before deleting (matches the existing `kaggle datasets delete` / `kaggle kernels delete` patterns); -y skips the prompt.

Bumps the kagglesdk floor to 0.1.32.