### PR TITLE
chore(deps): bump kagglesdk to >= 0.1.33

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ keywords = ["Kaggle", "API"]
 requires-python = ">= 3.11"
 dependencies = [
     "bleach",
-    "kagglesdk >= 0.1.32, < 1.0", # sync with kagglehub
+    "kagglesdk >= 0.1.33, < 1.0", # sync with kagglehub
     "python-slugify",
     "requests",
     "python-dateutil",

--- a/tests/unit/test_competition_create.py
+++ b/tests/unit/test_competition_create.py
@@ -12,7 +12,6 @@ from kaggle.api.kaggle_api_extended import KaggleApi
 from kagglesdk.competitions.types.competition_enums import CompetitionPrivacy
 from kagglesdk.competitions.types.competition import RewardTypeId
 
-
 _MINIMAL_META = {
     "title": "My Awesome Comp",
     "slug": "my-awesome-comp",


### PR DESCRIPTION
0.1.32 shipped with a broken import chain — `kagglesdk.competitions.types.host_service` references a `kagglesdk.competitions.legacy` module that isn't included in the wheel, so `import kagglesdk` fails at load time. 0.1.33 restores the missing modules. Bumping the floor prevents anyone installing kaggle-cli against the broken release.

Resolves #1087 