### PR TITLE
fix(auth): prioritize OAuth credentials over anonymous fallback

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -1063,7 +1063,13 @@ class KaggleApi:
         self.config_values = self.read_config_environment(config_values)
 
     def authenticate(self) -> None:
-        """Authenticate the user with the Kaggle API, using either a legacy API key or a Kaggle OAuth token.
+        """Authenticate the user with the Kaggle API.
+
+        This method attempts to authenticate using one of the following methods in order:
+        1. An active access token
+        2. A legacy API key.
+        3. OAuth credentials
+        4. Anonymous fallback, if allowed by the command.
 
         Returns:
             None:
@@ -1075,31 +1081,36 @@ class KaggleApi:
             return
         if self._authenticate_with_oauth_creds():
             return
+        if self._authenticate_anonymously():
+            return
         print_auth_help()
         exit(1)
 
     def _authenticate_with_legacy_apikey(self) -> bool:
         """Authenticate the user with the Kaggle API using legacy API key.
 
-        This method will generate a configuration, first checking the
-        environment for credential variables, and falling back to looking
-        for the .kaggle/kaggle.json configuration file.
+        This method checks for username and key in the loaded configuration,
+        which are populated from environment variables or the .kaggle/kaggle.json
+        configuration file.
 
         Returns:
-            bool: True if auth succeeded.
+            bool: True if legacy credentials are available.
         """
-        # Ex: 'datasets list', 'competitions files', 'models instances get', etc.
-        api_command = " ".join(sys.argv[1:])
-
         if self.CONFIG_NAME_USER in self.config_values and self.CONFIG_NAME_KEY in self.config_values:
             self.config_values[self.CONFIG_NAME_AUTH_METHOD] = str(AuthMethod.LEGACY_API_KEY)
             self.logger.debug(f"Authenticated with legacy api key in: {self.config}")
             return True
 
-        if self._command_allows_logged_out(api_command):
-            return True
-
         return False
+
+    def _authenticate_anonymously(self) -> bool:
+        """Check if the command can run anonymously.
+
+        Returns:
+            bool: True if anonymous access is allowed.
+        """
+        api_command = " ".join(sys.argv[1:])
+        return self._command_allows_logged_out(api_command)
 
     def _authenticate_with_access_token(self) -> bool:
         access_token, source = get_access_token_from_env()

--- a/tests/unit/test_authenticate.py
+++ b/tests/unit/test_authenticate.py
@@ -70,6 +70,63 @@ class TestAuthenticate(unittest.TestCase):
             if key_env is not None:
                 os.environ["KAGGLE_KEY"] = key_env
 
+    @patch.object(KaggleApi, "_load_config")
+    @patch.object(KaggleApi, "_authenticate_with_access_token")
+    @patch.object(KaggleApi, "_authenticate_with_legacy_apikey")
+    @patch.object(KaggleApi, "_authenticate_with_oauth_creds")
+    @patch.object(KaggleApi, "_authenticate_anonymously")
+    def test_authenticate_call_sequence_and_fallback(
+        self, mock_anon, mock_oauth, mock_legacy, mock_access, mock_load
+    ):
+        api = KaggleApi()
+
+        # Access token succeeds
+        mock_access.return_value = True
+        api.authenticate()
+        mock_load.assert_called_once()
+        mock_access.assert_called_once()
+        mock_legacy.assert_not_called()
+
+        # Legacy key succeeds
+        mock_load.reset_mock()
+        mock_access.reset_mock()
+        mock_access.return_value = False
+        mock_legacy.return_value = True
+        api.authenticate()
+        mock_access.assert_called_once()
+        mock_legacy.assert_called_once()
+        mock_oauth.assert_not_called()
+
+        # OAuth credentials succeeds
+        mock_legacy.reset_mock()
+        mock_legacy.return_value = False
+        mock_oauth.return_value = True
+        api.authenticate()
+        mock_legacy.assert_called_once()
+        mock_oauth.assert_called_once()
+        mock_anon.assert_not_called()
+
+        # Anonymous fallback succeeds
+        mock_oauth.reset_mock()
+        mock_oauth.return_value = False
+        mock_anon.return_value = True
+        api.authenticate()
+        mock_oauth.assert_called_once()
+        mock_anon.assert_called_once()
+
+    def test_authenticate_anonymously_detects_logged_out_commands(self):
+        api = KaggleApi()
+        with patch("sys.argv", ["kaggle", "datasets", "download", "some/dataset"]):
+            self.assertTrue(api._authenticate_anonymously())
+        with patch("sys.argv", ["kaggle", "datasets", "status", "some/dataset"]):
+            self.assertFalse(api._authenticate_anonymously())
+
+    def test_legacy_apikey_does_not_handle_anonymous_fallback(self):
+        api = KaggleApi()
+        api.config_values = {}
+        with patch("sys.argv", ["kaggle", "datasets", "download", "some/dataset"]):
+            self.assertFalse(api._authenticate_with_legacy_apikey())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_authenticate.py
+++ b/tests/unit/test_authenticate.py
@@ -75,9 +75,7 @@ class TestAuthenticate(unittest.TestCase):
     @patch.object(KaggleApi, "_authenticate_with_legacy_apikey")
     @patch.object(KaggleApi, "_authenticate_with_oauth_creds")
     @patch.object(KaggleApi, "_authenticate_anonymously")
-    def test_authenticate_call_sequence_and_fallback(
-        self, mock_anon, mock_oauth, mock_legacy, mock_access, mock_load
-    ):
+    def test_authenticate_call_sequence_and_fallback(self, mock_anon, mock_oauth, mock_legacy, mock_access, mock_load):
         api = KaggleApi()
 
         # Access token succeeds


### PR DESCRIPTION
## Summary

This PR fixes an authentication flow issue where OAuth credentials could be skipped for commands that also support anonymous access.

### Issue

The authentication flow checked for anonymous-compatible commands before attempting OAuth authentication.

As a result, commands such as:

```bash
kaggle datasets download <private-dataset>
```

could run anonymously even when the user was authenticated via `kaggle auth login`. This caused requests for private resources to fail with `403 Forbidden` or `404 Not Found` errors.

### Fix

- Moved the anonymous fallback to the end of the authentication flow.
- Check OAuth credentials before falling back to anonymous access.
- Added unit tests for the authentication flow.

### Behavior

Before

```bash
$ kaggle datasets download <private-dataset>
403 Client Error: Forbidden for url: ...
```

After

```bash
$ kaggle datasets download <private-dataset>

Dataset URL: https://www.kaggle.com/datasets/<owner>/<dataset>
License(s): ...
Downloading <dataset>.zip...
```

### Authentication Order

Before:

1. Access token
2. Legacy API key **or anonymous fallback**
3. OAuth credentials

After:

1. Access token
2. Legacy API key
3. OAuth credentials
4. Anonymous fallback (if supported by the command)