### PR TITLE
fix(cli): restore fallback for unknown kernel language/type in kernels_pull

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -5454,7 +5454,10 @@ class KaggleApi:
                         extension = ".irnb"
                     elif language == "julia":
                         extension = ".ijlnb"
-                file_name = blob.slug + extension
+                if extension:
+                    file_name = blob.slug + extension
+                else:
+                    file_name = None
 
             if file_name is None:
                 print(

--- a/tests/unit/test_kernels_pull.py
+++ b/tests/unit/test_kernels_pull.py
@@ -136,6 +136,40 @@ class TestKernelsPull(unittest.TestCase):
         # Second call: metadata
         mock_open_file.assert_any_call("/tmp/dummy/kernel-metadata.json", "w")
 
+    @patch("os.path.exists", return_value=True)
+    @patch("os.path.isfile", return_value=False)
+    @patch("builtins.open", new_callable=mock_open)
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_kernels_pull_fallback_scenarios(self, mock_client, mock_open_file, mock_isfile, mock_exists):
+        scenarios = [
+            ("unsupported-lang", "script"),
+            ("", "script"),
+            ("python", ""),
+            ("python", "something-new"),
+        ]
+        for lang, kt in scenarios:
+            # Setup mocks
+            mock_kaggle = MagicMock()
+            mock_response = MagicMock()
+            mock_blob = MagicMock()
+            mock_blob.language = lang
+            mock_blob.kernel_type = kt
+            mock_blob.slug = "my-slug"
+            mock_blob.source = "print('hello')"
+            mock_response.blob = mock_blob
+
+            mock_kaggle.kernels.kernels_api_client.get_kernel.return_value = mock_response
+            mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+            mock_open_file.reset_mock()
+            # Call method
+            self.api.kernels_pull("owner/my-slug", path="/tmp/dummy")
+
+            # Verify file write uses script.py with forward slash separator to match standard formatting
+            mock_open_file.assert_called_once_with("/tmp/dummy/script.py", "w", encoding="utf-8")
+            mock_open_file().write.assert_called_once_with("print('hello')")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

This fixes a bug in `kernels_pull` where the existing fallback for unknown kernel language/type combinations was never reached.

If the language/type doesn't match one of the known extension mappings, `extension` remains `None`. The code then attempts to build the filename using:

```python
file_name = blob.slug + extension
```

which raises a `TypeError` before the fallback logic can execute.

## Fix

Instead of concatenating immediately, the code now checks whether an extension was resolved first. If not, it allows the existing fallback to handle the case and use `script.py`.

This doesn't change the behavior for any of the currently supported language/type mappings.

## Tests

Added regression tests covering:

- unknown language
- empty language
- empty kernel type
- unknown kernel type

Also verified that existing mappings continue to work correctly for supported kernel types.

## Validation

- ✅ `pytest tests/unit`
- ✅ `black --check .`
- ✅ `mypy src/kaggle tests`