### PR TITLE
Fix crash when running kaggle command with invalid credentials

### DIFF
--- a/src/kaggle/__init__.py
+++ b/src/kaggle/__init__.py
@@ -5,4 +5,7 @@ from kaggle.api.kaggle_api_extended import KaggleApi
 __version__ = "2.2.3"
 
 api = KaggleApi()
-api.authenticate()
+try:
+    api.authenticate()
+except (Exception, SystemExit):
+    pass

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -797,6 +797,7 @@ class KaggleApi:
     config = os.path.join(config_dir, config_file)
     config_values: Dict[str, str] = {}
     already_printed_version_warning = False
+    _authenticated = False
 
     args: List[str] = []
     if os.environ.get("KAGGLE_API_ENVIRONMENT") == "LOCALHOST":
@@ -1081,12 +1082,16 @@ class KaggleApi:
         """
         self._load_config()
         if self._authenticate_with_access_token():
+            self._authenticated = True
             return
         if self._authenticate_with_legacy_apikey():
+            self._authenticated = True
             return
         if self._authenticate_with_oauth_creds():
+            self._authenticated = True
             return
         if self._authenticate_anonymously():
+            self._authenticated = True
             return
         print_auth_help()
         exit(1)
@@ -1134,24 +1139,30 @@ class KaggleApi:
         return True
 
     def _authenticate_with_oauth_creds(self) -> bool:
-        with self.build_kaggle_client() as kaggle:
-            creds = KaggleCredentials.load(client=kaggle)
-            if not creds:
-                return False
-            try:
-                access_token = creds.get_access_token()
-            except HTTPError as e:
-                if e.response.status_code == 401:
-                    print("Invalid credentials!")
-                    creds.delete()
+        try:
+            with self.build_kaggle_client() as kaggle:
+                creds = KaggleCredentials.load(client=kaggle)
+                if not creds:
                     return False
-                raise
-            self.config_values[self.CONFIG_NAME_TOKEN] = access_token
-            self.config_values[self.CONFIG_NAME_USER] = creds.get_username()
-            self.config_values[self.CONFIG_NAME_AUTH_METHOD] = str(AuthMethod.OAUTH)
-            creds_path = os.path.expanduser(KaggleCredentials.DEFAULT_CREDENTIALS_FILE)
-            self.logger.debug(f"Authenticated with OAuth credentials in: {creds_path}")
-            return True
+                try:
+                    access_token = creds.get_access_token()
+                except HTTPError as e:
+                    if e.response.status_code == 401:
+                        print("Invalid credentials!")
+                        creds.delete()
+                        return False
+                    raise
+                self.config_values[self.CONFIG_NAME_TOKEN] = access_token
+                self.config_values[self.CONFIG_NAME_USER] = creds.get_username()
+                self.config_values[self.CONFIG_NAME_AUTH_METHOD] = str(AuthMethod.OAUTH)
+                creds_path = os.path.expanduser(KaggleCredentials.DEFAULT_CREDENTIALS_FILE)
+                self.logger.debug(f"Authenticated with OAuth credentials in: {creds_path}")
+                return True
+        except KeyError as e:
+            if e.args[0] == "username":
+                self.logger.debug("Failed to authenticate with OAuth due to missing username in API key config.")
+                return False
+            raise
 
     def _introspect_token(self, access_token: str) -> Optional[str]:
         with self.build_kaggle_client() as kaggle:

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -71,6 +71,9 @@ def main() -> None:
     if command_args["disable_version_warning"]:
         KaggleApi.already_printed_version_warning = True
     del command_args["disable_version_warning"]
+    if not api._authenticated:
+        api.authenticate()
+
     error = False
     try:
         out = args.func(**command_args)


### PR DESCRIPTION
Prevent process exit/crash on import by wrapping api.authenticate() in try-except in __init__.py.
Add _authenticated flag to KaggleApi to track if authentication has succeeded.
Add lazy authentication in cli.py main() before executing commands if not already authenticated.
Handle KeyError in _authenticate_with_oauth_creds in kaggle_api_extended.py to prevent traceback when kaggle.json is invalid.

TAG=agy
CONV=71ce0bd3-ce00-40b5-9529-86de0c1d0618
