### PR TITLE
fix(cli): read kernel metadata and source files using UTF-8 in kernels_push

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -5351,7 +5351,7 @@ class KaggleApi:
         if not os.path.isfile(meta_file):
             raise ValueError("Metadata file not found: " + str(meta_file))
 
-        with open(meta_file) as f:
+        with open(meta_file, encoding="utf-8") as f:
             meta_data = json.load(f)
 
         title = self.get_or_default(meta_data, "title", None)
@@ -5421,7 +5421,7 @@ class KaggleApi:
                 "If specified, the docker_image_pinning_type must be " "one of " + str(self.valid_push_pinning_types)
             )
 
-        with open(code_file) as f:
+        with open(code_file, encoding="utf-8") as f:
             script_body = f.read()
 
         if kernel_type == "notebook":

--- a/tests/unit/test_kernels_push.py
+++ b/tests/unit/test_kernels_push.py
@@ -1,0 +1,96 @@
+# coding=utf-8
+import json
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../src")))
+
+from kaggle.api.kaggle_api_extended import KaggleApi
+
+
+class TestKernelsPush(unittest.TestCase):
+
+    def setUp(self):
+        self.api = KaggleApi.__new__(KaggleApi)
+        self.api.config_values = {"username": "testuser"}
+        self.api.valid_push_language_types = ["python", "r", "julia", "rmarkdown"]
+        self.api.valid_push_kernel_types = ["script", "notebook"]
+        self.api.valid_push_pinning_types = ["original", "latest"]
+        self.api.KERNEL_METADATA_FILE = "kernel-metadata.json"
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_kernels_push_utf8_behavior(self, mock_client):
+        # Setup mock client response
+        mock_kaggle = MagicMock()
+        mock_response = MagicMock()
+        mock_response.error = None
+        mock_response.invalidTags = []
+        mock_response.invalidDatasetSources = []
+        mock_response.invalidCompetitionSources = []
+        mock_response.invalidKernelSources = []
+        mock_response.versionNumber = 1
+        mock_response.url = "https://www.kaggle.com/testuser/test-kernel"
+        mock_kaggle.kernels.kernels_api_client.save_kernel.return_value = mock_response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        # Content with non-ASCII characters to trigger UnicodeDecodeError if opened as ANSI
+        unicode_content = (
+            'print("\U0001f44b")\n'
+            'print("R\u00e9sum\u00e9")\n'
+            'print("\u3053\u3093\u306b\u3061\u306f")\n'
+            'print("\u0928\u092e\u0938\u094d\u0924\u0947")\n'
+        )
+
+        metadata_dict = {
+            "id": "testuser/test-kernel",
+            "title": "Test Kernel Title",
+            "code_file": "script.py",
+            "language": "python",
+            "kernel_type": "script",
+            "is_private": True,
+            "enable_gpu": False,
+            "enable_tpu": False,
+            "enable_internet": True,
+            "dataset_sources": [],
+            "competition_sources": [],
+            "kernel_sources": [],
+            "model_sources": [],
+        }
+
+        # Create actual temporary directory and files to test real filesystem behavior
+        with tempfile.TemporaryDirectory() as tmpdir:
+            meta_file_path = os.path.join(tmpdir, "kernel-metadata.json")
+            code_file_path = os.path.join(tmpdir, "script.py")
+
+            # Write UTF-8 metadata (which can also contain unicode characters in title)
+            metadata_dict["title"] = "Test R\u00e9sum\u00e9 Title \U0001f44b"
+            with open(meta_file_path, "w", encoding="utf-8") as f:
+                json.dump(metadata_dict, f)
+
+            # Write UTF-8 script code
+            with open(code_file_path, "w", encoding="utf-8") as f:
+                f.write(unicode_content)
+
+            # Run kernels_push on the temporary directory, forcing preferred encoding to be cp1252
+            # to verify that explicit utf-8 encoding is used regardless of the system locale.
+            try:
+                with patch("locale.getpreferredencoding", return_value="cp1252"):
+                    self.api.kernels_push(tmpdir)
+            except Exception as e:
+                self.fail(f"kernels_push raised an unexpected exception: {e}")
+
+            # Verify that save_kernel was called with the correctly read request body
+            mock_kaggle.kernels.kernels_api_client.save_kernel.assert_called_once()
+            call_args = mock_kaggle.kernels.kernels_api_client.save_kernel.call_args
+            request = call_args[0][0]
+
+            self.assertEqual(request.new_title, "Test R\u00e9sum\u00e9 Title \U0001f44b")
+            self.assertEqual(request.text, unicode_content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR updates `kernels_push()` to explicitly read the kernel metadata and source files using UTF-8 instead of relying on the platform's default encoding.

## Problem

On Windows systems where the default text encoding is not UTF-8, running:

```bash
kaggle kernels push -p .
```

can fail with an error similar to:

```text
'charmap' codec can't decode byte 0x81...
```

This happens because `kernel-metadata.json` and the kernel source file are opened without specifying an encoding. If either file contains Unicode characters (for example emojis, accented characters, or non-English text), reading the file may fail depending on the system's default encoding.

## Solution

This PR adds `encoding="utf-8"` to the two file reads in `kernels_push()`:

- `kernel-metadata.json`
- Kernel source file (`.py`, `.ipynb`, etc.)

This makes file reading consistent across platforms while preserving the existing behavior.

## Tests

Added a regression test that:

- Creates a temporary kernel directory.
- Writes UTF-8 encoded metadata and source files containing Unicode characters.
- Verifies that `kernels_push()` reads them successfully.
- Confirms the test fails with the original implementation and passes with this change.

## Why this change is safe

- JSON metadata files are expected to be UTF-8.
- Python source files and Jupyter notebooks are also expected to use UTF-8.
- The change only affects two `open()` calls inside `kernels_push()`.
- No other commands or file operations are modified.