### PR TITLE
feat(cli): expose userRank in competitions list output

### DIFF
--- a/docs/competitions.md
+++ b/docs/competitions.md
@@ -24,6 +24,13 @@ kaggle competitions list [options]
 *   `-p, --page <PAGE>`: Page number for results (default: 1).
 *   `-s, --search <SEARCH_TERM>`: Search term.
 *   `-v, --csv`: Print results in CSV format.
+*   `--format`: Output format (`csv`, `table`, `json`, or a field projection). See [output_format.md](./output_format.md).
+
+**Output columns:**
+
+`ref`, `deadline`, `category`, `reward`, `teamCount`, `userHasEntered`, `userRank`
+
+`userRank` is your public leaderboard position when you have entered the competition. It is `0` when you have not entered, or when no public rank is available yet.
 
 **Example:**
 
@@ -33,9 +40,15 @@ List featured competitions in the general group, sorted by prize:
 kaggle competitions list --group general --category featured --sort-by prize
 ```
 
+List entered competitions with rank in CSV format:
+
+```bash
+kaggle competitions list --group entered -v
+```
+
 **Purpose:**
 
-This command helps you discover new competitions or find specific ones based on various criteria.
+This command helps you discover new competitions or find specific ones based on various criteria. Use `--group entered` to see your rank across competitions you have joined.
 
 ## `kaggle competitions files`
 

--- a/skills/references/competitions.md
+++ b/skills/references/competitions.md
@@ -56,16 +56,22 @@ kaggle competitions list [options]
 - `--page-token <TOKEN>`: Page token.
 - `-s, --search <TERM>`: Search text.
 - `-v, --csv`: Print CSV instead of table.
+- `--format`: Output format (`csv`, `table`, `json`, or field projection).
+
+**Output columns:** `ref`, `deadline`, `category`, `reward`, `teamCount`, `userHasEntered`, `userRank`
+
+`userRank` is your public leaderboard position when entered. It is `0` when not entered or when no public rank is available yet.
 
 **Examples:**
 
 ```bash
 kaggle competitions list
 kaggle competitions list --category gettingStarted --sort-by latestDeadline
+kaggle competitions list --group entered -v
 kaggle c list -s titanic -v
 ```
 
-**Purpose:** Find competition slugs to use with other commands.
+**Purpose:** Find competition slugs to use with other commands. Use `--group entered` to see your rank across joined competitions.
 
 ## `kaggle competitions files`
 

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -861,7 +861,7 @@ class KaggleApi:
     command_prefixes_allowing_anonymous_access = ("datasets download", "datasets files", "auth login")
 
     # Attributes
-    competition_fields = ["ref", "deadline", "category", "reward", "teamCount", "userHasEntered"]
+    competition_fields = ["ref", "deadline", "category", "reward", "teamCount", "userHasEntered", "userRank"]
     submission_fields = ["ref", "fileName", "date", "description", "status", "publicScore", "privateScore"]
     competition_file_fields = ["name", "totalBytes", "creationDate"]
     competition_file_labels = ["name", "size", "creationDate"]

--- a/tests/unit/test_competitions_list.py
+++ b/tests/unit/test_competitions_list.py
@@ -1,0 +1,95 @@
+# coding=utf-8
+import io
+import sys
+import unittest
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, "../..")
+
+from kagglesdk.competitions.types.competition_api_service import ApiCompetition, ApiListCompetitionsResponse
+
+from kaggle.api.kaggle_api_extended import KaggleApi
+
+
+def _make_api():
+    api = KaggleApi.__new__(KaggleApi)
+    api.already_printed_version_warning = True
+    return api
+
+
+def _make_competition(user_rank=784, user_has_entered=True):
+    competition = ApiCompetition()
+    competition.ref = "https://www.kaggle.com/competitions/example-comp"
+    competition.deadline = datetime(2026, 8, 1, 0, 0, 0)
+    competition.category = "Playground"
+    competition.reward = "Swag"
+    competition.team_count = 1200
+    competition.user_has_entered = user_has_entered
+    competition.user_rank = user_rank
+    return competition
+
+
+class TestCompetitionsList(unittest.TestCase):
+    """Tests for competitions_list_cli userRank output."""
+
+    def setUp(self):
+        self.api = _make_api()
+
+    def test_competition_fields_includes_user_rank(self):
+        self.assertIn("userRank", KaggleApi.competition_fields)
+
+    @patch.object(KaggleApi, "competitions_list")
+    def test_competitions_list_cli_csv_includes_user_rank(self, mock_list):
+        response = ApiListCompetitionsResponse()
+        response.competitions = [_make_competition(user_rank=784)]
+        mock_list.return_value = response
+
+        with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            self.api.competitions_list_cli(group="entered", csv_display=True)
+
+        output = mock_stdout.getvalue()
+        self.assertIn("userRank", output)
+        self.assertIn("784", output)
+
+    @patch.object(KaggleApi, "competitions_list")
+    def test_competitions_list_cli_csv_shows_zero_rank(self, mock_list):
+        response = ApiListCompetitionsResponse()
+        response.competitions = [_make_competition(user_rank=0, user_has_entered=True)]
+        mock_list.return_value = response
+
+        with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            self.api.competitions_list_cli(group="entered", csv_display=True)
+
+        output = mock_stdout.getvalue()
+        self.assertIn("userRank", output)
+        self.assertIn(",0", output.splitlines()[-1])
+
+    @patch.object(KaggleApi, "print_results")
+    @patch.object(KaggleApi, "competitions_list")
+    def test_competitions_list_cli_passes_user_rank_to_print_results(self, mock_list, mock_print_results):
+        response = ApiListCompetitionsResponse()
+        response.competitions = [_make_competition()]
+        mock_list.return_value = response
+
+        self.api.competitions_list_cli(group="entered")
+
+        mock_print_results.assert_called_once()
+        fields = mock_print_results.call_args[0][1]
+        self.assertEqual(fields, KaggleApi.competition_fields)
+        self.assertIn("userRank", fields)
+
+    @patch.object(KaggleApi, "competitions_list")
+    def test_competitions_list_cli_no_results(self, mock_list):
+        response = ApiListCompetitionsResponse()
+        response.competitions = []
+        mock_list.return_value = response
+
+        with patch("builtins.print") as mock_print:
+            self.api.competitions_list_cli(group="entered")
+
+        mock_print.assert_called_once_with("No competitions found")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Expose `userRank` in `kaggle competitions list` output. The `ListCompetitions` API already returns this field on `ApiCompetition`; the CLI was filtering it out in `competition_fields`.

## Problem

Users who want their competition rank have to download the full leaderboard and search locally (see #66). `competitions list` already shows `userHasEntered` but not `userRank`, even when the user has a public leaderboard position.

## Solution

Add `userRank` to `competition_fields` so it appears in table, CSV (`-v`), and `--format` output.

Updated `docs/competitions.md` and `skills/references/competitions.md` with output columns and an `--group entered` example.

## Testing

- [x] `hatch -e test run pytest tests/unit/test_competitions_list.py -v` (5 passed)
- [x] `hatch run lint:all`
- [ ] Maintainer: please run `/gcbrun` when convenient

## Related

Fixes #1090
