### PR TITLE
fix(tests): support Windows path separators in kernel pull tests

### DIFF
--- a/tests/unit/test_kernels_pull.py
+++ b/tests/unit/test_kernels_pull.py
@@ -36,7 +36,7 @@ class TestKernelsPull(unittest.TestCase):
         mock_client.return_value.__exit__ = MagicMock(return_value=False)
 
         # Call method
-        self.api.kernels_pull("owner/my-slug", path="/tmp/dummy")
+        self.api.kernels_pull("owner/my-slug", path=os.path.join("/tmp", "dummy"))
 
         # Verify request
         call_args = mock_kaggle.kernels.kernels_api_client.get_kernel.call_args
@@ -45,7 +45,7 @@ class TestKernelsPull(unittest.TestCase):
         self.assertEqual(request.kernel_slug, "my-slug")
 
         # Verify file write
-        expected_path = os.path.join("/tmp/dummy", "my-slug.py")
+        expected_path = os.path.join("/tmp", "dummy", "my-slug.py")
         mock_open_file.assert_called_once_with(expected_path, "w", encoding="utf-8")
         mock_open_file().write.assert_called_once_with("print('hello')")
 
@@ -69,7 +69,7 @@ class TestKernelsPull(unittest.TestCase):
         mock_client.return_value.__exit__ = MagicMock(return_value=False)
 
         # Call method with version
-        self.api.kernels_pull("owner/my-slug/3", path="/tmp/dummy")
+        self.api.kernels_pull("owner/my-slug/3", path=os.path.join("/tmp", "dummy"))
 
         # Verify request has version in slug
         call_args = mock_kaggle.kernels.kernels_api_client.get_kernel.call_args
@@ -78,7 +78,7 @@ class TestKernelsPull(unittest.TestCase):
         self.assertEqual(request.kernel_slug, "my-slug/3")
 
         # Verify file write (path should still use clean slug)
-        expected_path = os.path.join("/tmp/dummy", "my-slug.py")
+        expected_path = os.path.join("/tmp", "dummy", "my-slug.py")
         mock_open_file.assert_called_once_with(expected_path, "w", encoding="utf-8")
         mock_open_file().write.assert_called_once_with("print('hello')")
 
@@ -121,7 +121,7 @@ class TestKernelsPull(unittest.TestCase):
         mock_client.return_value.__exit__ = MagicMock(return_value=False)
 
         # Call method with metadata=True
-        self.api.kernels_pull("owner/my-slug/3", path="/tmp/dummy", metadata=True)
+        self.api.kernels_pull("owner/my-slug/3", path=os.path.join("/tmp", "dummy"), metadata=True)
 
         # Verify request has version in slug
         call_args = mock_kaggle.kernels.kernels_api_client.get_kernel.call_args
@@ -134,10 +134,10 @@ class TestKernelsPull(unittest.TestCase):
 
         # We can check the calls
         # First call: script
-        expected_script_path = os.path.join("/tmp/dummy", "my-slug.py")
+        expected_script_path = os.path.join("/tmp", "dummy", "my-slug.py")
         mock_open_file.assert_any_call(expected_script_path, "w", encoding="utf-8")
         # Second call: metadata
-        expected_metadata_path = os.path.join("/tmp/dummy", "kernel-metadata.json")
+        expected_metadata_path = os.path.join("/tmp", "dummy", "kernel-metadata.json")
         mock_open_file.assert_any_call(expected_metadata_path, "w")
 
     @patch("os.path.exists", return_value=True)
@@ -168,10 +168,10 @@ class TestKernelsPull(unittest.TestCase):
 
             mock_open_file.reset_mock()
             # Call method
-            self.api.kernels_pull("owner/my-slug", path="/tmp/dummy")
+            self.api.kernels_pull("owner/my-slug", path=os.path.join("/tmp", "dummy"))
 
             # Verify file write uses script.py
-            expected_path = os.path.join("/tmp/dummy", "script.py")
+            expected_path = os.path.join("/tmp", "dummy", "script.py")
             mock_open_file.assert_called_once_with(expected_path, "w", encoding="utf-8")
             mock_open_file().write.assert_called_once_with("print('hello')")
 

--- a/tests/unit/test_kernels_pull.py
+++ b/tests/unit/test_kernels_pull.py
@@ -45,7 +45,8 @@ class TestKernelsPull(unittest.TestCase):
         self.assertEqual(request.kernel_slug, "my-slug")
 
         # Verify file write
-        mock_open_file.assert_called_once_with("/tmp/dummy/my-slug.py", "w", encoding="utf-8")
+        expected_path = os.path.join("/tmp/dummy", "my-slug.py")
+        mock_open_file.assert_called_once_with(expected_path, "w", encoding="utf-8")
         mock_open_file().write.assert_called_once_with("print('hello')")
 
     @patch("os.path.exists", return_value=True)
@@ -77,7 +78,8 @@ class TestKernelsPull(unittest.TestCase):
         self.assertEqual(request.kernel_slug, "my-slug/3")
 
         # Verify file write (path should still use clean slug)
-        mock_open_file.assert_called_once_with("/tmp/dummy/my-slug.py", "w", encoding="utf-8")
+        expected_path = os.path.join("/tmp/dummy", "my-slug.py")
+        mock_open_file.assert_called_once_with(expected_path, "w", encoding="utf-8")
         mock_open_file().write.assert_called_once_with("print('hello')")
 
     @patch("os.path.exists", return_value=True)
@@ -132,9 +134,11 @@ class TestKernelsPull(unittest.TestCase):
 
         # We can check the calls
         # First call: script
-        mock_open_file.assert_any_call("/tmp/dummy/my-slug.py", "w", encoding="utf-8")
+        expected_script_path = os.path.join("/tmp/dummy", "my-slug.py")
+        mock_open_file.assert_any_call(expected_script_path, "w", encoding="utf-8")
         # Second call: metadata
-        mock_open_file.assert_any_call("/tmp/dummy/kernel-metadata.json", "w")
+        expected_metadata_path = os.path.join("/tmp/dummy", "kernel-metadata.json")
+        mock_open_file.assert_any_call(expected_metadata_path, "w")
 
     @patch("os.path.exists", return_value=True)
     @patch("os.path.isfile", return_value=False)
@@ -166,8 +170,9 @@ class TestKernelsPull(unittest.TestCase):
             # Call method
             self.api.kernels_pull("owner/my-slug", path="/tmp/dummy")
 
-            # Verify file write uses script.py with forward slash separator to match standard formatting
-            mock_open_file.assert_called_once_with("/tmp/dummy/script.py", "w", encoding="utf-8")
+            # Verify file write uses script.py
+            expected_path = os.path.join("/tmp/dummy", "script.py")
+            mock_open_file.assert_called_once_with(expected_path, "w", encoding="utf-8")
             mock_open_file().write.assert_called_once_with("print('hello')")
 
 


### PR DESCRIPTION
## Summary

This PR fixes platform-dependent assertions in the `kernels_pull` unit tests.

## Problem

The tests in `tests/unit/test_kernels_pull.py` expected hardcoded POSIX-style paths (for example, `/tmp/dummy/my-slug.py`). On Windows, the production code constructs paths using `os.path.join()`, which produces Windows path separators. As a result, the tests failed even though the production code behaved correctly.

## Solution

Updated the test assertions to construct the expected paths using `os.path.join()`, matching the behavior of the production code and making the tests platform-independent.

No production code was changed.

## Testing

Verified on Windows by running:

```bash
python -m pytest tests/unit/test_kernels_pull.py -v
```

All four tests pass after the change.

Also ran:

```bash
python -m pytest tests/unit/ -v
```

All unit tests pass successfully.
