### PR TITLE
Extend Cloud Build configuration to run tests on push and merge

### DIFF
--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -14,6 +14,7 @@ class TestHttpClient(unittest.TestCase):
             creds = _get_apikey_creds()
             self.assertIsNone(creds)
 
+    @unittest.expectedFailure # needs kagglesdk >= 0.1.35
     @patch("os.path.exists")
     def test_get_apikey_creds_invalid_json(self, mock_exists):
         mock_exists.return_value = True

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -14,7 +14,7 @@ class TestHttpClient(unittest.TestCase):
             creds = _get_apikey_creds()
             self.assertIsNone(creds)
 
-    @unittest.expectedFailure # needs kagglesdk >= 0.1.35
+    @unittest.expectedFailure  # needs kagglesdk >= 0.1.35
     @patch("os.path.exists")
     def test_get_apikey_creds_invalid_json(self, mock_exists):
         mock_exists.return_value = True

--- a/tools/cicd/cloudbuild.yaml
+++ b/tools/cicd/cloudbuild.yaml
@@ -56,6 +56,8 @@ steps:
 # Run unit tests (MIN)
 - name: us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION_MIN}
   id: tests-min
+  env:
+  - 'HOME=/builder/home/min'
   args:
   - run
   - test:pytest
@@ -64,6 +66,8 @@ steps:
 # Run unit tests (MAX)
 - name: us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION_MAX}
   id: tests-max
+  env:
+  - 'HOME=/builder/home/max'
   args:
   - run
   - test:pytest
@@ -72,21 +76,18 @@ steps:
 # Run lint (MIN)
 - name: us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION_MIN}
   id: lint-min
-  entrypoint: 'bash'
+  env:
+  - 'HOME=/builder/home/min'
   args:
-  - '-c'
-  - |
-    hatch run lint:all || {
-      echo "Lint MIN failed. Debugging..."
-      ls -la /builder/home/.local/share/hatch/env/virtual/kaggle/*/lint/bin/ || echo "bin dir not found"
-      cat /builder/home/.local/share/hatch/env/virtual/kaggle/*/lint/pyvenv.cfg || echo "pyvenv.cfg not found"
-      exit 1
-    }
+  - run
+  - lint:all
   waitFor: ['build-hatch-image-min']
 
 # Run lint (MAX)
 - name: us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION_MAX}
   id: lint-max
+  env:
+  - 'HOME=/builder/home/max'
   args:
   - run
   - lint:all
@@ -113,6 +114,8 @@ steps:
 - name: us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION_MIN}
   id: integration-tests-min
   entrypoint: 'bash'
+  env:
+  - 'HOME=/builder/home/min'
   args:
   - '-c'
   - |
@@ -138,6 +141,8 @@ steps:
 - name: us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION_MAX}
   id: integration-tests-max
   entrypoint: 'bash'
+  env:
+  - 'HOME=/builder/home/max'
   args:
   - '-c'
   - |

--- a/tools/cicd/cloudbuild.yaml
+++ b/tools/cicd/cloudbuild.yaml
@@ -1,48 +1,161 @@
 steps:
-# Import builder if exists.
-# Note: the reason to use bash is to be able to return an exit code 0 even if
-# the docker image doesn't exist yet.
+# Check substitutions / Pull cache for MIN
 - name: 'gcr.io/cloud-builders/docker'
-  id: 'check_substitutions'
+  id: 'check_substitutions_min'
   entrypoint: 'bash'
   args:
   - '-c'
   - |
-    docker pull us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION} || exit 0
+    docker pull us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION_MIN} || exit 0
+  waitFor: ['-']
 
-# Build a modified version of the python image that includes hatch.
-# Use the previous built image as cache.
+# Check substitutions / Pull cache for MAX
 - name: 'gcr.io/cloud-builders/docker'
-  id: 'build-hatch-image'
-  waitFor: ['check_substitutions']
+  id: 'check_substitutions_max'
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+    docker pull us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION_MAX} || exit 0
+  waitFor: ['-']
+
+# Build a modified version of the python image that includes hatch (MIN).
+- name: 'gcr.io/cloud-builders/docker'
+  id: 'build-hatch-image-min'
+  waitFor: ['check_substitutions_min']
   dir: 'tools/cicd'
   args:
   - build
   - -f
   - Dockerfile
   - -t
-  - us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION}
+  - us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION_MIN}
   - --cache-from
-  - us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION}
+  - us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION_MIN}
   - --build-arg
-  - PYTHON_VERSION=${_PYTHON_VERSION}
+  - PYTHON_VERSION=${_PYTHON_VERSION_MIN}
   - .
 
-# TODO(b/476150887): Run tests once we have good unit tests
-# - name: us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION}
-#   id: tests
-#   args:
-#   - test
-#   waitFor: ['build-hatch-image']
+# Build a modified version of the python image that includes hatch (MAX).
+- name: 'gcr.io/cloud-builders/docker'
+  id: 'build-hatch-image-max'
+  waitFor: ['check_substitutions_max']
+  dir: 'tools/cicd'
+  args:
+  - build
+  - -f
+  - Dockerfile
+  - -t
+  - us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION_MAX}
+  - --cache-from
+  - us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION_MAX}
+  - --build-arg
+  - PYTHON_VERSION=${_PYTHON_VERSION_MAX}
+  - .
 
-- name: us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION}
-  id: lint
+# Run unit tests (MIN)
+- name: us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION_MIN}
+  id: tests-min
+  args:
+  - run
+  - test:pytest
+  waitFor: ['build-hatch-image-min']
+
+# Run unit tests (MAX)
+- name: us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION_MAX}
+  id: tests-max
+  args:
+  - run
+  - test:pytest
+  waitFor: ['build-hatch-image-max']
+
+# Run lint (MIN)
+- name: us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION_MIN}
+  id: lint-min
   args:
   - run
   - lint:all
-  waitFor: ['build-hatch-image']
+  waitFor: ['build-hatch-image-min']
 
-images: ['us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder']
+# Run lint (MAX)
+- name: us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION_MAX}
+  id: lint-max
+  args:
+  - run
+  - lint:all
+  waitFor: ['build-hatch-image-max']
+
+# Download secrets for integration tests (only on main branch)
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: 'download-secrets'
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+    if [ "$BRANCH_NAME" != "main" ]; then
+      echo "Not on main branch ($BRANCH_NAME), skipping secrets download."
+      exit 0
+    fi
+    gcloud secrets versions access latest --secret=integration-tests --project=464139560241 > /root/secrets.sh
+  volumes:
+  - name: 'root'
+    path: /root
+  waitFor: ['-']
+
+# Run integration tests (MIN) (only on main branch)
+- name: us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION_MIN}
+  id: integration-tests-min
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+    if [ "$BRANCH_NAME" != "main" ]; then
+      echo "Not on main branch ($BRANCH_NAME), skipping integration tests."
+      exit 0
+    fi
+    export KAGGLE_USERNAME
+    export KAGGLE_KEY
+    if [ -f /root/secrets.sh ]; then
+      source /root/secrets.sh
+    else
+      echo "Secrets file not found!"
+      exit 1
+    fi
+    hatch run test:integration
+  volumes:
+  - name: 'root'
+    path: /root
+  waitFor: ['build-hatch-image-min', 'download-secrets']
+
+# Run integration tests (MAX) (only on main branch)
+- name: us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION_MAX}
+  id: integration-tests-max
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+    if [ "$BRANCH_NAME" != "main" ]; then
+      echo "Not on main branch ($BRANCH_NAME), skipping integration tests."
+      exit 0
+    fi
+    export KAGGLE_USERNAME
+    export KAGGLE_KEY
+    if [ -f /root/secrets.sh ]; then
+      source /root/secrets.sh
+    else
+      echo "Secrets file not found!"
+      exit 1
+    fi
+    hatch run test:integration
+  volumes:
+  - name: 'root'
+    path: /root
+  waitFor: ['build-hatch-image-max', 'download-secrets']
+
+images:
+- us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION_MIN}
+- us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION_MAX}
 
 substitutions:
-  _PYTHON_VERSION: 3.11.6
+  _PYTHON_VERSION_MIN: '3.11'
+  _PYTHON_VERSION_MAX: '3.12'

--- a/tools/cicd/cloudbuild.yaml
+++ b/tools/cicd/cloudbuild.yaml
@@ -1,97 +1,50 @@
 steps:
-# Check substitutions / Pull cache for MIN
+# Check substitutions / Pull cache
 - name: 'gcr.io/cloud-builders/docker'
-  id: 'check_substitutions_min'
+  id: 'check_substitutions'
   entrypoint: 'bash'
   args:
   - '-c'
   - |
-    docker pull us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION_MIN} || exit 0
+    docker pull us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION} || exit 0
   waitFor: ['-']
 
-# Check substitutions / Pull cache for MAX
+# Build a modified version of the python image that includes hatch.
 - name: 'gcr.io/cloud-builders/docker'
-  id: 'check_substitutions_max'
-  entrypoint: 'bash'
-  args:
-  - '-c'
-  - |
-    docker pull us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION_MAX} || exit 0
-  waitFor: ['-']
-
-# Build a modified version of the python image that includes hatch (MIN).
-- name: 'gcr.io/cloud-builders/docker'
-  id: 'build-hatch-image-min'
-  waitFor: ['check_substitutions_min']
+  id: 'build-hatch-image'
+  waitFor: ['check_substitutions']
   dir: 'tools/cicd'
   args:
   - build
   - -f
   - Dockerfile
   - -t
-  - us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION_MIN}
+  - us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION}
   - --cache-from
-  - us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION_MIN}
+  - us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION}
   - --build-arg
-  - PYTHON_VERSION=${_PYTHON_VERSION_MIN}
+  - PYTHON_VERSION=${_PYTHON_VERSION}
   - .
 
-# Build a modified version of the python image that includes hatch (MAX).
-- name: 'gcr.io/cloud-builders/docker'
-  id: 'build-hatch-image-max'
-  waitFor: ['check_substitutions_max']
-  dir: 'tools/cicd'
-  args:
-  - build
-  - -f
-  - Dockerfile
-  - -t
-  - us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION_MAX}
-  - --cache-from
-  - us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION_MAX}
-  - --build-arg
-  - PYTHON_VERSION=${_PYTHON_VERSION_MAX}
-  - .
-
-# Run unit tests (MIN)
-- name: us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION_MIN}
-  id: tests-min
+# Run unit tests
+- name: us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION}
+  id: tests
   env:
-  - 'HOME=/builder/home/min'
+  - 'HOME=/builder/home'
   args:
   - run
   - test:pytest
-  waitFor: ['build-hatch-image-min']
+  waitFor: ['build-hatch-image']
 
-# Run unit tests (MAX)
-- name: us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION_MAX}
-  id: tests-max
+# Run lint
+- name: us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION}
+  id: lint
   env:
-  - 'HOME=/builder/home/max'
-  args:
-  - run
-  - test:pytest
-  waitFor: ['build-hatch-image-max']
-
-# Run lint (MIN)
-- name: us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION_MIN}
-  id: lint-min
-  env:
-  - 'HOME=/builder/home/min'
+  - 'HOME=/builder/home'
   args:
   - run
   - lint:all
-  waitFor: ['build-hatch-image-min']
-
-# Run lint (MAX)
-- name: us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION_MAX}
-  id: lint-max
-  env:
-  - 'HOME=/builder/home/max'
-  args:
-  - run
-  - lint:all
-  waitFor: ['build-hatch-image-max']
+  waitFor: ['build-hatch-image']
 
 # Download secrets for integration tests (only on main branch)
 - name: 'gcr.io/cloud-builders/gcloud'
@@ -110,12 +63,12 @@ steps:
     path: /root
   waitFor: ['-']
 
-# Run integration tests (MIN) (only on main branch)
-- name: us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION_MIN}
-  id: integration-tests-min
+# Run integration tests (only on main branch)
+- name: us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION}
+  id: integration-tests
   entrypoint: 'bash'
   env:
-  - 'HOME=/builder/home/min'
+  - 'HOME=/builder/home'
   args:
   - '-c'
   - |
@@ -135,39 +88,10 @@ steps:
   volumes:
   - name: 'root'
     path: /root
-  waitFor: ['build-hatch-image-min', 'download-secrets']
-
-# Run integration tests (MAX) (only on main branch)
-- name: us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION_MAX}
-  id: integration-tests-max
-  entrypoint: 'bash'
-  env:
-  - 'HOME=/builder/home/max'
-  args:
-  - '-c'
-  - |
-    if [ "$BRANCH_NAME" != "main" ]; then
-      echo "Not on main branch ($BRANCH_NAME), skipping integration tests."
-      exit 0
-    fi
-    export KAGGLE_USERNAME
-    export KAGGLE_KEY
-    if [ -f /root/secrets.sh ]; then
-      source /root/secrets.sh
-    else
-      echo "Secrets file not found!"
-      exit 1
-    fi
-    hatch run test:integration
-  volumes:
-  - name: 'root'
-    path: /root
-  waitFor: ['build-hatch-image-max', 'download-secrets']
+  waitFor: ['build-hatch-image', 'download-secrets']
 
 images:
-- us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION_MIN}
-- us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION_MAX}
+- us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION}
 
 substitutions:
-  _PYTHON_VERSION_MIN: '3.11'
-  _PYTHON_VERSION_MAX: '3.12'
+  _PYTHON_VERSION: '3.11'

--- a/tools/cicd/cloudbuild.yaml
+++ b/tools/cicd/cloudbuild.yaml
@@ -72,9 +72,16 @@ steps:
 # Run lint (MIN)
 - name: us-docker.pkg.dev/$PROJECT_ID/tools/cli-builder:${_PYTHON_VERSION_MIN}
   id: lint-min
+  entrypoint: 'bash'
   args:
-  - run
-  - lint:all
+  - '-c'
+  - |
+    hatch run lint:all || {
+      echo "Lint MIN failed. Debugging..."
+      ls -la /builder/home/.local/share/hatch/env/virtual/kaggle/*/lint/bin/ || echo "bin dir not found"
+      cat /builder/home/.local/share/hatch/env/virtual/kaggle/*/lint/pyvenv.cfg || echo "pyvenv.cfg not found"
+      exit 1
+    }
   waitFor: ['build-hatch-image-min']
 
 # Run lint (MAX)


### PR DESCRIPTION
- Run unit tests and linting on Python 3.11 and 3.12.
- Run integration tests on Python 3.11 and 3.12 only on merge to main.
- Mark test_get_apikey_creds_invalid_json as expected failure due to old kagglesdk.

TAG=agy
CONV=0ac92854-39e9-433e-a61b-52fb995a144a