### PR TITLE
feat(cli): support --page-token and --page-size, preserve --page

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -152,6 +152,7 @@ from kagglesdk.common.types.cropped_image_upload import CroppedImageUpload, Crop
 
 from kagglesdk.datasets.types.dataset_api_service import (
     ApiListDatasetsRequest,
+    ApiListDatasetsResponse,
     ApiListDatasetFilesRequest,
     ApiGetDatasetRequest,
     ApiGetDatasetStatusRequest,
@@ -184,6 +185,7 @@ from kagglesdk.datasets.types.dataset_types import (
 from kagglesdk.kaggle_object import KaggleObject
 from kagglesdk.kernels.types.kernels_api_service import (
     ApiListKernelsRequest,
+    ApiListKernelsResponse,
     ApiListKernelFilesRequest,
     ApiSaveKernelRequest,
     ApiGetKernelRequest,
@@ -1572,7 +1574,7 @@ class KaggleApi:
         group: Optional[str] = None,
         category: Optional[str] = None,
         sort_by: Optional[str] = None,
-        page: Optional[int] = 1,
+        page: Optional[int] = -1,
         search: Optional[str] = None,
         page_size: Optional[int] = 20,
         page_token: Optional[str] = None,
@@ -1623,6 +1625,8 @@ class KaggleApi:
             # -1 is the default in argparse. We don't set it here to indicate we are using new pagination.
             if page != -1:
                 request.page = page
+            elif page_token is None:
+                request.page = 1
             request.category = category_val
             request.search = search or ""
             request.sort_by = sort_by_val
@@ -1635,7 +1639,7 @@ class KaggleApi:
         group: Optional[str] = None,
         category: Optional[str] = None,
         sort_by: Optional[str] = None,
-        page: Optional[int] = 1,
+        page: Optional[int] = -1,
         search: Optional[str] = None,
         csv_display: Optional[bool] = False,
         page_size: Optional[int] = 20,
@@ -1658,6 +1662,9 @@ class KaggleApi:
         Returns:
             None:
         """
+        if page != -1 and page_token is not None:
+            raise ValueError("Cannot specify both page and page_token")
+
         response = self.competitions_list(
             group=group,
             category=category,
@@ -2976,10 +2983,19 @@ class KaggleApi:
         if competition is None:
             raise ValueError("No competition specified")
 
-        if not quiet and (page_size is not None or page_token is not None or search is not None):
-            print(
-                "Warning: --page-size, --page-token, and --search are not supported for competition topics and will be ignored."
-            )
+        if not quiet and (page_size is not None or search is not None):
+            print("Warning: --page-size and --search are not supported for competition topics and will be ignored.")
+
+        if page is not None and page_token is not None:
+            raise ValueError("Cannot specify both page and page_token")
+
+        if page_token:
+            try:
+                page = int(page_token)
+            except ValueError:
+                raise ValueError("Invalid page token. For this command, page token must be a page number.")
+        elif page is None:
+            page = 1
 
         response = self.competition_list_topics(
             competition=competition,
@@ -2994,6 +3010,9 @@ class KaggleApi:
                 csv_display=csv_display,
                 output_format=output_format,
             )
+            page_size_default = 20
+            if response.total_count and page * page_size_default < response.total_count:
+                print("Next Page Token = {}".format(page + 1))
         else:
             print("No topics found")
 
@@ -3805,6 +3824,37 @@ class KaggleApi:
         Returns:
             Union[listApiDataset, None, None]:
         """
+        response = self.dataset_list_with_response(
+            sort_by=sort_by,
+            size=size,
+            file_type=file_type,
+            license_name=license_name,
+            tag_ids=tag_ids,
+            search=search,
+            user=user,
+            mine=mine,
+            page=page,
+            max_size=max_size,
+            min_size=min_size,
+        )
+        return response.datasets if response else None
+
+    def dataset_list_with_response(
+        self,
+        sort_by: Optional[str] = None,
+        size: Optional[str] = None,
+        file_type: Optional[str] = None,
+        license_name: Optional[str] = None,
+        tag_ids: Optional[str] = None,
+        search: Optional[str] = None,
+        user: Optional[str] = None,
+        mine: Optional[bool] = False,
+        page: Optional[int] = None,
+        max_size: Optional[str] = None,
+        min_size: Optional[str] = None,
+        page_size: Optional[int] = 20,
+        page_token: Optional[str] = None,
+    ) -> ApiListDatasetsResponse:
         sort_by_val = DatasetSortBy.DATASET_SORT_BY_HOTTEST
         if sort_by:
             if sort_by not in self.valid_dataset_sort_bys:
@@ -3862,12 +3912,17 @@ class KaggleApi:
             request.tag_ids = tag_ids or ""
             request.search = search or ""
             request.user = user or ""
-            request.page = int(page) if page else None  # type: ignore[assignment] # https://github.com/python/mypy/issues/17043
+            if page is not None:
+                request.page = int(page)
+            elif page_token is None:
+                request.page = 1
+            if page_size is not None:
+                request.page_size = page_size
+            if page_token is not None:
+                request.page_token = page_token
             request.max_size = int(max_size) if max_size else None  # type: ignore[assignment]
             request.min_size = int(min_size) if min_size else None  # type: ignore[assignment]
-            response = kaggle.datasets.dataset_api_client.list_datasets(request)
-            result: list[ApiDataset | None] | None = response.datasets
-            return result
+            return kaggle.datasets.dataset_api_client.list_datasets(request)
 
     def dataset_list_cli(
         self,
@@ -3879,7 +3934,9 @@ class KaggleApi:
         search=None,
         user=None,
         mine=False,
-        page=1,
+        page=None,
+        page_size=20,
+        page_token=None,
         csv_display=False,
         max_size=None,
         min_size=None,
@@ -3896,15 +3953,34 @@ class KaggleApi:
             search: a search term to use (default is empty string)
             user: username to filter the search to
             mine: boolean if True, group is changed to "my" to return personal
-            page: the page to return (default is 1)
+            page_size: the number of items to show on a page
+            page_token: the page token for pagination
             csv_display: if True, print comma separated values instead of table
             max_size: the maximum size of the dataset to return (bytes)
             min_size: the minimum size of the dataset to return (bytes)
             output_format: the output format to use
         """
-        datasets = self.dataset_list(
-            sort_by, size, file_type, license_name, tag_ids, search, user, mine, page, max_size, min_size
+        if page is not None and page_token is not None:
+            raise ValueError("Cannot specify both page and page_token")
+
+        response = self.dataset_list_with_response(
+            sort_by=sort_by,
+            size=size,
+            file_type=file_type,
+            license_name=license_name,
+            tag_ids=tag_ids,
+            search=search,
+            user=user,
+            mine=mine,
+            max_size=max_size,
+            min_size=min_size,
+            page=page,
+            page_size=page_size,
+            page_token=page_token,
         )
+        datasets = response.datasets if response else None
+        if response and response.next_page_token:
+            print("Next Page Token = {}".format(response.next_page_token))
         if datasets:
             self.print_results(
                 datasets,
@@ -5058,7 +5134,39 @@ class KaggleApi:
         Returns:
             Union[List[ApiKernelMetadata, None], None]: A list of ApiKernelMetadata objects.
         """
-        if int(page) <= 0:
+        response = self.kernels_list_with_response(
+            page=page,
+            page_size=page_size,
+            dataset=dataset,
+            competition=competition,
+            parent_kernel=parent_kernel,
+            search=search,
+            mine=mine,
+            user=user,
+            language=language,
+            kernel_type=kernel_type,
+            output_type=output_type,
+            sort_by=sort_by,
+        )
+        return response.kernels if response else None
+
+    def kernels_list_with_response(
+        self,
+        page: Optional[int] = None,
+        page_size: int = 20,
+        dataset: Optional[str] = None,
+        competition: Optional[str] = None,
+        parent_kernel: Optional[str] = None,
+        search: Optional[str] = None,
+        mine: bool = False,
+        user: Optional[str] = None,
+        language: Optional[str] = None,
+        kernel_type: Optional[str] = None,
+        output_type: Optional[str] = None,
+        sort_by: Optional[str] = None,
+        page_token: Optional[str] = None,
+    ) -> ApiListKernelsResponse:
+        if page and int(page) <= 0:
             raise ValueError("Page number must be >= 1")
 
         page_size = int(page_size)
@@ -5095,8 +5203,13 @@ class KaggleApi:
 
         with self.build_kaggle_client() as kaggle:
             request = ApiListKernelsRequest()
-            request.page = page
+            if page is not None:
+                request.page = page
+            elif page_token is None:
+                request.page = 1
             request.page_size = page_size
+            if page_token is not None:
+                request.page_token = page_token
             request.group = group_val
             request.user = user or ""
             request.language = language or "all"
@@ -5107,16 +5220,14 @@ class KaggleApi:
             request.competition = competition or ""
             request.parent_kernel = parent_kernel or ""
             request.search = search or ""
-            result: list[ApiKernelMetadata | None] | None = kaggle.kernels.kernels_api_client.list_kernels(
-                request
-            ).kernels
-            return result
+            return kaggle.kernels.kernels_api_client.list_kernels(request)
 
     def kernels_list_cli(
         self,
         mine=False,
-        page=1,
+        page=None,
         page_size=20,
+        page_token=None,
         search=None,
         csv_display=False,
         parent=None,
@@ -5136,8 +5247,8 @@ class KaggleApi:
 
         Args:
             mine: If True, return personal kernels.
-            page: The page of results to return (default is 1).
             page_size: The number of results per page (default is 20).
+            page_token: The page token for pagination.
             search: A custom search string to pass to the list query.
             csv_display: If True, print comma-separated values instead of a table.
             parent: If defined, filter to those with the specified parent.
@@ -5150,9 +5261,13 @@ class KaggleApi:
             sort_by: How to sort the result, see valid_list_sort_by for options.
             output_format: The output format to use.
         """
-        kernels = self.kernels_list(
+        if page is not None and page_token is not None:
+            raise ValueError("Cannot specify both page and page_token")
+
+        response = self.kernels_list_with_response(
             page=page,
             page_size=page_size,
+            page_token=page_token,
             search=search,
             mine=mine,
             dataset=dataset,
@@ -5164,6 +5279,9 @@ class KaggleApi:
             output_type=output_type,
             sort_by=sort_by,
         )
+        kernels = response.kernels if response else None
+        if response and response.next_page_token:
+            print("Next Page Token = {}".format(response.next_page_token))
         fields = ["ref", "title", "author", "lastRunTime", "totalVotes"]
         if kernels:
             self.print_results(

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -134,7 +134,9 @@ def _get_shared_topics_parser() -> argparse.ArgumentParser:
 
 def _get_shared_competition_topics_parser() -> argparse.ArgumentParser:
     shared = argparse.ArgumentParser(add_help=False)
-    shared.add_argument("-p", "--page", dest="page", type=int, default=1, required=False, help=Help.param_page)
+    shared.add_argument("-p", "--page", dest="page", type=int, default=None, required=False, help=Help.param_page)
+    shared.add_argument("--page-size", dest="page_size", type=int, required=False, help=Help.param_page_size)
+    shared.add_argument("--page-token", dest="page_token", required=False, help=Help.param_page_token)
     _add_output_format_args(shared)
     shared.add_argument("-q", "--quiet", dest="quiet", action="store_true", help=Help.param_quiet)
     return shared
@@ -165,6 +167,7 @@ def parse_competitions(subparsers) -> None:
     parser_competitions_list_optional.add_argument(
         "-p", "--page", dest="page", default=-1, type=int, required=False, help=Help.param_page
     )
+
     parser_competitions_list_optional.add_argument(
         "-s", "--search", dest="search", required=False, help=Help.param_search
     )
@@ -807,7 +810,11 @@ def parse_datasets(subparsers) -> None:
     parser_datasets_list.add_argument("-m", "--mine", dest="mine", action="store_true", help=Help.param_mine)
     parser_datasets_list.add_argument("--user", dest="user", required=False, help=Help.param_dataset_user)
     parser_datasets_list.add_argument(
-        "-p", "--page", dest="page", default=1, type=int, required=False, help=Help.param_page
+        "--page-size", dest="page_size", required=False, type=int, help=Help.param_page_size
+    )
+    parser_datasets_list.add_argument("--page-token", dest="page_token", required=False, help=Help.param_page_token)
+    parser_datasets_list.add_argument(
+        "-p", "--page", dest="page", default=None, type=int, required=False, help=Help.param_page
     )
     _add_output_format_args(parser_datasets_list)
     parser_datasets_list.add_argument(
@@ -1038,10 +1045,13 @@ def parse_kernels(subparsers) -> None:
     )
     parser_kernels_list_optional = parser_kernels_list._action_groups.pop()
     parser_kernels_list_optional.add_argument("-m", "--mine", dest="mine", action="store_true", help=Help.param_mine)
-    parser_kernels_list_optional.add_argument("-p", "--page", dest="page", default=1, type=int, help=Help.param_page)
+    parser_kernels_list_optional.add_argument(
+        "--page-token", dest="page_token", required=False, help=Help.param_page_token
+    )
     parser_kernels_list_optional.add_argument(
         "--page-size", dest="page_size", default=20, type=int, help=Help.param_page_size
     )
+    parser_kernels_list_optional.add_argument("-p", "--page", dest="page", default=None, type=int, help=Help.param_page)
     parser_kernels_list_optional.add_argument("-s", "--search", dest="search", help=Help.param_search)
     _add_output_format_args(parser_kernels_list_optional)
     parser_kernels_list_optional.add_argument("--parent", dest="parent", required=False, help=Help.param_kernel_parent)

--- a/tests/unit/test_cli_pagination.py
+++ b/tests/unit/test_cli_pagination.py
@@ -1,0 +1,116 @@
+# coding=utf-8
+import argparse
+from unittest.mock import MagicMock, patch
+import pytest
+from kaggle.api.kaggle_api_extended import KaggleApi
+
+
+@pytest.fixture
+def api():
+    a = KaggleApi()
+    a.authenticate = MagicMock()
+    # Mock build_kaggle_client to avoid any real client instantiation
+    a.build_kaggle_client = MagicMock()
+    return a
+
+
+@pytest.fixture
+def parser(monkeypatch, api):
+    import kaggle
+
+    monkeypatch.setattr(kaggle, "api", api)
+    from kaggle.cli import (
+        parse_competitions,
+        parse_datasets,
+        parse_kernels,
+        Help,
+    )
+    import kaggle.cli
+
+    monkeypatch.setattr(kaggle.cli, "api", api)
+
+    root = argparse.ArgumentParser()
+    subparsers = root.add_subparsers(title="commands", dest="command")
+    subparsers.required = True
+    subparsers.choices = Help.kaggle_choices
+
+    parse_competitions(subparsers)
+    parse_datasets(subparsers)
+    parse_kernels(subparsers)
+    return root
+
+
+def _dispatch(parser, argv):
+    args = parser.parse_args(argv)
+    command_args = dict(vars(args))
+    del command_args["func"]
+    del command_args["command"]
+    return args.func, command_args
+
+
+def test_competitions_list_pagination(parser):
+    # Should accept --page-token and --page-size
+    func, kwargs = _dispatch(parser, ["competitions", "list", "--page-token", "token123", "--page-size", "50"])
+    assert func.__name__ == "competitions_list_cli"
+    assert kwargs["page_token"] == "token123"
+    assert kwargs["page_size"] == 50
+
+    # Should also accept --page (backward compatibility)
+    func, kwargs = _dispatch(parser, ["competitions", "list", "--page", "5"])
+    assert func.__name__ == "competitions_list_cli"
+    assert kwargs["page"] == 5
+
+
+def test_datasets_list_pagination(parser):
+    # Should accept --page-token and --page-size
+    func, kwargs = _dispatch(parser, ["datasets", "list", "--page-token", "token123", "--page-size", "50"])
+    assert func.__name__ == "dataset_list_cli"
+    assert kwargs["page_token"] == "token123"
+    assert kwargs["page_size"] == 50
+
+    # Should also accept --page (backward compatibility)
+    func, kwargs = _dispatch(parser, ["datasets", "list", "--page", "5"])
+    assert func.__name__ == "dataset_list_cli"
+    assert kwargs["page"] == 5
+
+
+def test_kernels_list_pagination(parser):
+    # Should accept --page-token and --page-size
+    func, kwargs = _dispatch(parser, ["kernels", "list", "--page-token", "token123", "--page-size", "50"])
+    assert func.__name__ == "kernels_list_cli"
+    assert kwargs["page_token"] == "token123"
+    assert kwargs["page_size"] == 50
+
+    # Should also accept --page (backward compatibility)
+    func, kwargs = _dispatch(parser, ["kernels", "list", "--page", "5"])
+    assert func.__name__ == "kernels_list_cli"
+    assert kwargs["page"] == 5
+
+
+# ---- Validation Tests ----
+
+
+@patch.object(KaggleApi, "competitions_list")
+def test_competitions_list_mutual_exclusion(mock_list, api):
+    with pytest.raises(ValueError, match="Cannot specify both page and page_token"):
+        api.competitions_list_cli(page=5, page_token="token")
+
+
+@patch.object(KaggleApi, "dataset_list_with_response")
+def test_datasets_list_mutual_exclusion(mock_list, api):
+    with pytest.raises(ValueError, match="Cannot specify both page and page_token"):
+        api.dataset_list_cli(page=5, page_token="token")
+
+
+@patch.object(KaggleApi, "kernels_list_with_response")
+def test_kernels_list_mutual_exclusion(mock_list, api):
+    with pytest.raises(ValueError, match="Cannot specify both page and page_token"):
+        api.kernels_list_cli(page=5, page_token="token")
+
+
+@patch.object(KaggleApi, "competition_list_topics")
+def test_competition_topics_mutual_exclusion(mock_list, api):
+    # Mock get_config_value to avoid config lookup issues
+    api.get_config_value = MagicMock(return_value="some-competition")
+    with pytest.raises(ValueError, match="Cannot specify both page and page_token"):
+        api.competition_list_topics_cli(page=5, page_token="token")

--- a/tests/unit/test_discussions_cli.py
+++ b/tests/unit/test_discussions_cli.py
@@ -132,7 +132,7 @@ class TestTopicsListParsing:
             ("kernels", ["list", "--sort-by", "hot", "-s", "keyword"]),
             ("models", ["--page-size", "50"]),
             ("benchmarks", ["--page-token", "abc"]),
-            ("competitions", ["list", "--page", "5", "--sort-by", "recent"]),
+            ("competitions", ["list", "--page-token", "5", "--sort-by", "recent"]),
         ],
         ids=[
             "datasets_sort_search",


### PR DESCRIPTION
- Add --page-token and --page-size to datasets and kernels list commands.
- Add --page-token to competitions topics commands (emulated).
- Restore --page and -p options to competitions list, datasets list, kernels list, and competitions topics to preserve backward compatibility.
- Raise ValueError if both page and page_token are specified.
- Add unit tests to verify pagination arguments and mutual exclusion.

BUG=516818438
TAG=agy
CONV=37f1c9b9-ac6f-4e29-874d-c083460c7db1
