### PR TITLE
Regenerate requirements.lock from recent kagglesdk bump

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -14,8 +14,6 @@ certifi==2026.2.25
     # via requests
 charset-normalizer==3.4.6
     # via requests
-colorama==0.4.6
-    # via tqdm
 fastjsonschema==2.21.2
     # via nbformat
 idna==3.11

--- a/requirements.lock
+++ b/requirements.lock
@@ -14,6 +14,8 @@ certifi==2026.2.25
     # via requests
 charset-normalizer==3.4.6
     # via requests
+colorama==0.4.6
+    # via tqdm
 fastjsonschema==2.21.2
     # via nbformat
 idna==3.11
@@ -26,7 +28,7 @@ jupyter-core==5.9.1
     # via nbformat
 jupytext==1.19.1
     # via kaggle (pyproject.toml)
-kagglesdk==0.1.25
+kagglesdk==0.1.34
     # via kaggle (pyproject.toml)
 markdown-it-py==4.0.0
     # via


### PR DESCRIPTION
### Summary
Regenerates the development `requirements.lock` file to synchronize with the recent `kagglesdk` version bump in `pyproject.toml` (`>= 0.1.34`).

### Why is this needed?
The dependency floor for `kagglesdk` was bumped to `>= 0.1.34` in `pyproject.toml`, but `requirements.lock` still pinned `kagglesdk` to version `0.1.25`. This mismatch caused local developer installs and testing setups using the lockfile to download an outdated version of the SDK, which contains the deserialization bug for whole-second durations (e.g. during `kaggle quota`).

### Changes
- Updated `kagglesdk` from `0.1.25` to `0.1.34` in `requirements.lock`.
- Added `colorama==0.4.6` (introduced as a transitive dependency via `tqdm`).