### PR TITLE
feat(cli): add competitions settings get command

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -101,6 +101,7 @@ from kagglesdk.competitions.types.competition_api_service import (
     ApiCreateCompetitionPageRequest,
     ApiDeleteCompetitionPageRequest,
     ApiUpdateCompetitionPageRequest,
+    ApiGetCompetitionSettingsRequest,
     ApiCreateCompetitionDataRequest,
     ApiCreateCompetitionDataResponse,
     ApiCompetitionDataFile,
@@ -147,6 +148,7 @@ from kagglesdk.competitions.types.competition_enums import (
 )
 
 from kagglesdk.competitions.types.competition import Reward, RewardTypeId
+from kagglesdk.competitions.types.host_service import CompetitionSettings
 
 from kagglesdk.common.types.cropped_image_upload import CroppedImageUpload, CroppedImageRectangle
 
@@ -2630,6 +2632,150 @@ class KaggleApi:
 
         if self.competition_delete_page(competition_name, page_name, no_confirm=no_confirm):
             print(f'Page "{page_name}" deleted from competition "{competition_name}".')
+
+    _COMPETITION_SETTINGS_GROUPS = [
+        (
+            "General",
+            [
+                "title",
+                "brief_description",
+                "competition_name",
+                "host_segment",
+                "organization_id",
+                "rules_required",
+                "publicly_cloneable",
+                "has_scripts",
+            ],
+        ),
+        (
+            "Access & Teams",
+            [
+                "requires_identity_verification",
+                "enable_team_files",
+                "team_file_deadline",
+            ],
+        ),
+        (
+            "Key Dates",
+            [
+                "team_merger_explicit_deadline",
+                "prohibit_new_entrants_explicit_deadline",
+                "kernels_publishing_disabled_deadline",
+                "disable_submissions",
+                "public_leaderboard_disclaimer_message",
+            ],
+        ),
+        (
+            "Submissions & Leaderboard",
+            [
+                "has_leaderboard",
+                "disable_leaderboard_prize_indicator",
+                "withold_final_leaderboard_until_it_has_been_verified",
+                "final_leaderboard_has_been_verified",
+                "final_leaderboard_disclaimer_message",
+            ],
+        ),
+        (
+            "Code Competition",
+            [
+                "only_allow_kernel_submissions",
+                "uses_synchronous_reruns",
+                "max_cpu_runtime_minutes",
+                "max_gpu_runtime_minutes",
+                "rerun_override_kernel_id",
+                "gateway_kernel_id",
+                "rerun_max_stagger_minutes",
+            ],
+        ),
+        (
+            "Hosts",
+            [
+                "directly_responsible_user_id",
+            ],
+        ),
+    ]
+
+    def competition_get_settings(self, competition_name: str) -> CompetitionSettings:
+        """Fetch the unified settings blob for a competition you host.
+
+        Args:
+            competition_name (str): The competition name (slug).
+
+        Returns:
+            CompetitionSettings: the current settings.
+        """
+        with self.build_kaggle_client() as kaggle:
+            request = ApiGetCompetitionSettingsRequest()
+            request.competition_name = competition_name
+            return kaggle.competitions.competition_api_client.get_competition_settings(request)
+
+    def competition_get_settings_cli(
+        self,
+        competition=None,
+        competition_opt=None,
+        json_output=False,
+        quiet=False,
+    ):
+        """CLI wrapper for competition_get_settings."""
+        competition_name = competition or competition_opt
+        if competition_name is None:
+            competition_name = self.get_config_value(self.CONFIG_NAME_COMPETITION)
+            if competition_name is not None and not quiet:
+                print("Using competition: " + competition_name)
+        if competition_name is None:
+            raise ValueError("No competition specified")
+
+        settings = self.competition_get_settings(competition_name)
+        if json_output:
+            self.print_obj(settings)
+        else:
+            self._print_competition_settings(settings)
+
+    def _print_competition_settings(self, settings: CompetitionSettings) -> None:
+        """Print settings grouped by UI section, skipping fields left at their default."""
+        printed_any = False
+        for group_title, field_names in self._COMPETITION_SETTINGS_GROUPS:
+            rows = []
+            for name in field_names:
+                value = getattr(settings, name, None)
+                formatted = self._format_setting_value(value)
+                if formatted is None:
+                    continue
+                rows.append((name, formatted))
+            if not rows:
+                continue
+            if printed_any:
+                print("")
+            printed_any = True
+            print(f"[{group_title}]")
+            for name, formatted in rows:
+                print(f"  {name}: {formatted}")
+        if not printed_any:
+            print("(no settings set)")
+
+    @staticmethod
+    def _format_setting_value(value) -> Optional[str]:
+        """Return a display string for a settings value, or None to skip it."""
+        if value is None:
+            return None
+        if isinstance(value, bool):
+            return "true" if value else None
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            if value == 0:
+                return None
+            return str(value)
+        if isinstance(value, str):
+            if value == "":
+                return None
+            return value
+        if isinstance(value, datetime):
+            return value.isoformat()
+        name = getattr(value, "name", None)
+        if name is not None:
+            if name.endswith("_UNSPECIFIED"):
+                return None
+            return name
+        return str(value)
 
     def competition_data_update(
         self,

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -624,6 +624,41 @@ def parse_competitions(subparsers) -> None:
     parser_competitions_data_update._action_groups.append(parser_competitions_data_update_optional)
     parser_competitions_data_update.set_defaults(func=api.competition_data_update_cli)
 
+    # Competitions settings (group: get)
+    parser_competitions_settings = subparsers_competitions.add_parser(
+        "settings",
+        formatter_class=argparse.RawTextHelpFormatter,
+        help=Help.command_competitions_settings,
+    )
+    subparsers_competitions_settings = parser_competitions_settings.add_subparsers(title="commands", dest="command")
+    subparsers_competitions_settings.required = True
+    subparsers_competitions_settings.choices = Help.entity_settings_choices
+
+    # Competitions settings get
+    parser_competitions_settings_get = subparsers_competitions_settings.add_parser(
+        "get",
+        formatter_class=argparse.RawTextHelpFormatter,
+        help=Help.command_competitions_settings_get,
+    )
+    parser_competitions_settings_get_optional = parser_competitions_settings_get._action_groups.pop()
+    parser_competitions_settings_get_optional.add_argument(
+        "competition", nargs="?", default=None, help=Help.param_competition
+    )
+    parser_competitions_settings_get_optional.add_argument(
+        "-c", "--competition", dest="competition_opt", required=False, help=argparse.SUPPRESS
+    )
+    parser_competitions_settings_get_optional.add_argument(
+        "--json",
+        dest="json_output",
+        action="store_true",
+        help="Emit settings as JSON instead of the grouped text view.",
+    )
+    parser_competitions_settings_get_optional.add_argument(
+        "-q", "--quiet", dest="quiet", action="store_true", help=Help.param_quiet
+    )
+    parser_competitions_settings_get._action_groups.append(parser_competitions_settings_get_optional)
+    parser_competitions_settings_get.set_defaults(func=api.competition_get_settings_cli)
+
     # Competitions launch (publish now, or schedule for a future UTC time)
     parser_competitions_launch = subparsers_competitions.add_parser(
         "launch", formatter_class=argparse.RawTextHelpFormatter, help=Help.command_competitions_launch
@@ -2191,6 +2226,7 @@ class Help(object):
         "logs",
         "pages",
         "data",
+        "settings",
         "launch",
         "init",
         "create",
@@ -2257,6 +2293,7 @@ class Help(object):
     entity_topics_choices = ["list", "show"]
     entity_pages_choices = ["list", "create", "update", "delete"]
     entity_data_choices = ["update"]
+    entity_settings_choices = ["get"]
     config_choices = ["view", "set", "unset"]
     auth_choices = ["login", "print-access-token", "revoke"]
 
@@ -2334,6 +2371,8 @@ class Help(object):
     command_competitions_pages_delete = "Delete a page from a competition you host"
     command_competitions_data = "Manage a competition's data files"
     command_competitions_data_update = "Update (version) the data files for a competition you host"
+    command_competitions_settings = "Manage settings for a competition you host"
+    command_competitions_settings_get = "Show the current settings for a competition you host"
     command_competitions_launch = "Launch a competition you host, optionally at a future UTC time"
     command_competitions_init = "Initialize folder with a competition-metadata.json template"
     command_competitions_create = "Create a new competition from competition-metadata.json"

--- a/tests/unit/test_competition_settings_get.py
+++ b/tests/unit/test_competition_settings_get.py
@@ -1,0 +1,121 @@
+# coding=utf-8
+import io
+import json
+import sys
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, "../..")
+
+from kaggle.api.kaggle_api_extended import KaggleApi
+from kagglesdk.competitions.types.host_service import CompetitionSettings
+
+
+def _make_settings(**overrides) -> CompetitionSettings:
+    settings = CompetitionSettings()
+    for name, value in overrides.items():
+        setattr(settings, name, value)
+    return settings
+
+
+class TestCompetitionGetSettings(unittest.TestCase):
+    """Tests for competition_get_settings and its CLI wrapper."""
+
+    def setUp(self):
+        self.api = KaggleApi.__new__(KaggleApi)
+        self.api.config_values = {}
+
+    def _patch_client(self, mock_client, settings=None):
+        mock_kaggle = MagicMock()
+        mock_kaggle.competitions.competition_api_client.get_competition_settings.return_value = (
+            settings if settings is not None else _make_settings()
+        )
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+        return mock_kaggle
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_get_settings_builds_request_with_competition_name(self, mock_client):
+        mock_kaggle = self._patch_client(mock_client, _make_settings(title="Amazing Comp"))
+
+        result = self.api.competition_get_settings("my-comp")
+
+        request = mock_kaggle.competitions.competition_api_client.get_competition_settings.call_args[0][0]
+        self.assertEqual(request.competition_name, "my-comp")
+        self.assertEqual(result.title, "Amazing Comp")
+
+    @patch.object(KaggleApi, "competition_get_settings")
+    def test_cli_positional_competition(self, mock_get):
+        mock_get.return_value = _make_settings(title="T")
+        with redirect_stdout(io.StringIO()):
+            self.api.competition_get_settings_cli(competition="my-comp")
+        mock_get.assert_called_once_with("my-comp")
+
+    @patch.object(KaggleApi, "competition_get_settings")
+    def test_cli_dash_c_option(self, mock_get):
+        mock_get.return_value = _make_settings()
+        with redirect_stdout(io.StringIO()):
+            self.api.competition_get_settings_cli(competition_opt="my-comp")
+        mock_get.assert_called_once_with("my-comp")
+
+    @patch.object(KaggleApi, "competition_get_settings")
+    def test_cli_falls_back_to_config(self, mock_get):
+        mock_get.return_value = _make_settings()
+        self.api.config_values = {self.api.CONFIG_NAME_COMPETITION: "from-config"}
+        with redirect_stdout(io.StringIO()):
+            self.api.competition_get_settings_cli()
+        mock_get.assert_called_once_with("from-config")
+
+    def test_cli_missing_competition_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.api.competition_get_settings_cli()
+        self.assertIn("No competition specified", str(ctx.exception))
+
+    @patch.object(KaggleApi, "competition_get_settings")
+    def test_cli_json_output_emits_valid_json(self, mock_get):
+        mock_get.return_value = _make_settings(
+            title="Amazing Comp",
+            brief_description="do the thing",
+            rules_required=True,
+        )
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            self.api.competition_get_settings_cli(competition="my-comp", json_output=True)
+        payload = json.loads(buf.getvalue())
+        self.assertEqual(payload["title"], "Amazing Comp")
+        self.assertEqual(payload["briefDescription"], "do the thing")
+        self.assertTrue(payload["rulesRequired"])
+
+    @patch.object(KaggleApi, "competition_get_settings")
+    def test_cli_human_readable_groups_and_skips_defaults(self, mock_get):
+        mock_get.return_value = _make_settings(
+            title="Amazing Comp",
+            rules_required=True,
+            max_gpu_runtime_minutes=240,
+        )
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            self.api.competition_get_settings_cli(competition="my-comp")
+        out = buf.getvalue()
+        self.assertIn("[General]", out)
+        self.assertIn("title: Amazing Comp", out)
+        self.assertIn("rules_required: true", out)
+        self.assertIn("[Code Competition]", out)
+        self.assertIn("max_gpu_runtime_minutes: 240", out)
+        # Defaults (unset strings, false bools, zero ints) should be skipped.
+        self.assertNotIn("brief_description", out)
+        self.assertNotIn("has_scripts", out)
+        self.assertNotIn("[Access & Teams]", out)
+
+    @patch.object(KaggleApi, "competition_get_settings")
+    def test_cli_human_readable_all_defaults_shows_placeholder(self, mock_get):
+        mock_get.return_value = _make_settings()
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            self.api.competition_get_settings_cli(competition="my-comp")
+        self.assertIn("(no settings set)", buf.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds `kaggle competitions settings get [competition]` which fetches the unified CompetitionSettings blob via the existing SDK method. Defaults to a grouped human-readable view (organized by the 6 UI sections in host_service.proto) that hides fields left at their defaults, with `--json` for machine consumption.