### PR TITLE
feat(cli): add competitions settings update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,11 @@ See the [User documentation](docs/README.md) for more examples & tutorials.
 
 ## Hosting a competition
 
-End-to-end host commands — scaffold a new competition, author its pages, and
-launch it — are documented in
+End-to-end host commands — scaffold a new competition, author its pages,
+tune its settings, and launch it — are documented in
 [docs/competition_creation.md](docs/competition_creation.md). Covers
-`kaggle competitions init`, `create`, `pages create`, and `launch`.
+`kaggle competitions init`, `create`, `pages create`, `settings get`,
+`settings update`, and `launch`.
 
 ## Development
 

--- a/docs/competition_creation.md
+++ b/docs/competition_creation.md
@@ -6,6 +6,8 @@ public competition-creation API endpoints (kagglesdk 0.1.31+):
 - [`kaggle competitions init`](#kaggle-competitions-init)
 - [`kaggle competitions create`](#kaggle-competitions-create)
 - [`kaggle competitions pages create`](#kaggle-competitions-pages-create)
+- [`kaggle competitions settings get`](#kaggle-competitions-settings-get)
+- [`kaggle competitions settings update`](#kaggle-competitions-settings-update)
 - [`kaggle competitions launch`](#kaggle-competitions-launch)
 - [`kaggle competitions data update`](#kaggle-competitions-data-update)
 
@@ -31,7 +33,12 @@ kaggle competitions pages create my-comp-slug --name rules -f ./rules.md --publi
 # 5. Update the competition data (train.csv, test.csv, sample_submission.csv, ...).
 kaggle competitions data update my-comp-slug -p ./data -m "Initial release"
 
-# 6. Launch the competition (now, or schedule a future UTC time).
+# 6. Optionally tune host-only settings not covered by competition-metadata.json
+#    (deadlines, runtime caps, leaderboard behavior, etc.).
+kaggle competitions settings get my-comp-slug
+kaggle competitions settings update my-comp-slug -f ./settings.json
+
+# 7. Launch the competition (now, or schedule a future UTC time).
 kaggle competitions launch my-comp-slug --at 2027-01-01T00:00:00Z
 ```
 
@@ -307,6 +314,124 @@ deleted; attempting to delete one returns an error from the server.
 
 Deletion is not recoverable — there is no "undelete". List pages first with
 `kaggle competitions pages list <competition>` if you're unsure of the name.
+
+---
+
+## `kaggle competitions settings get`
+
+Shows the unified settings blob for a competition you host — the same set of
+fields the "Settings" tab exposes in the web UI, covering general info,
+access & teams, key dates, submissions & leaderboard behavior, code
+competition parameters, and host attribution.
+
+By default the output is grouped by UI section and hides fields left at their
+type default (unset strings, `false` booleans, zero ints). Pass `--json` for
+the raw blob (camelCase keys, matching the update payload format).
+
+**Usage:**
+
+```bash
+kaggle competitions settings get <competition> [--json]
+```
+
+**Arguments:**
+
+- `<competition>`: The competition slug.
+
+**Examples:**
+
+```bash
+# Grouped, human-readable summary.
+kaggle competitions settings get my-comp
+
+# Machine-readable dump — pipe into jq, or save + edit + feed back to update.
+kaggle competitions settings get my-comp --json > settings.json
+```
+
+---
+
+## `kaggle competitions settings update`
+
+Applies a partial update to a competition's settings. You author a JSON or
+YAML file containing only the fields you want to change; the CLI builds the
+server-side FieldMask from the keys present in the file, so unspecified
+fields are left alone.
+
+The typical loop is:
+
+1. `kaggle competitions settings get my-comp --json > settings.json` — pull
+   the current values.
+2. Edit the file down to just the fields you want to change (delete the rest).
+3. `kaggle competitions settings update my-comp -f ./settings.json`.
+
+**Usage:**
+
+```bash
+kaggle competitions settings update <competition> -f <path> [--json]
+```
+
+**Arguments:**
+
+- `<competition>`: The competition slug.
+
+**Options:**
+
+- `-f, --from-file <path>` (required): JSON or YAML file with the fields to
+  update. Extension picks the parser (`.yaml`/`.yml` → YAML, anything else →
+  JSON). Keys may be `snake_case` (matches the SDK) or `camelCase` (matches
+  the `--json` output of `settings get`).
+- `--json` (optional): After the update, print the returned settings as JSON
+  instead of the grouped text view.
+
+**Examples:**
+
+Toggle a single boolean:
+
+```json
+// disable-leaderboard.json
+{ "has_leaderboard": false }
+```
+
+```bash
+kaggle competitions settings update my-comp -f ./disable-leaderboard.json
+```
+
+Bump the code-competition runtime caps and set the team-merger deadline
+(YAML, mixing types):
+
+```yaml
+# tune.yaml
+max_cpu_runtime_minutes: 540
+max_gpu_runtime_minutes: 720
+team_merger_explicit_deadline: 2027-01-15T00:00:00Z
+rules_required: true
+```
+
+```bash
+kaggle competitions settings update my-comp -f ./tune.yaml
+```
+
+**Type notes:**
+
+- Booleans → JSON `true`/`false` (or YAML equivalents).
+- Numeric fields → plain numbers (`240`, `1.5`).
+- Datetime fields → ISO-8601 strings (`"2027-01-01T00:00:00Z"` or with an
+  explicit offset).
+- Enum fields (`host_segment`, `publicly_cloneable`) → the enum member name
+  as a string; either the full name (`"HOST_SEGMENT_FEATURED"`) or the short
+  suffix (`"FEATURED"`) works.
+
+**Common errors:**
+
+- `Unknown competition setting: '<name>'` — the field name isn't in
+  `CompetitionSettings`. Check `settings get --json` for the exact keys.
+- `Field '<name>' expects a bool, got str` — the file has a string where a
+  boolean is required (e.g. `"true"` instead of `true`).
+- `not a valid HostSegment. Allowed: ...` — the enum value you passed isn't
+  a member; the error lists the accepted names.
+- Some settings are gated to Kaggle admins (marked "ADMIN ONLY" in the
+  proto — e.g. `host_segment`, `directly_responsible_user_id`) and the server
+  will reject writes to them for non-admin hosts.
 
 ---
 

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -2868,17 +2868,10 @@ class KaggleApi:
             raise ValueError(f"Settings file {file_path} must contain a mapping at the top level.")
         return data
 
-    @classmethod
-    def _competition_settings_field_map(cls) -> Dict[str, Any]:
+    @staticmethod
+    def _competition_settings_field_map() -> Dict[str, Any]:
         """Return {snake_case_name: (json_name, python_type)} for CompetitionSettings."""
-        cached = getattr(cls, "_settings_field_map_cache", None)
-        if cached is not None:
-            return cached
-        result: Dict[str, Any] = {}
-        for meta in CompetitionSettings._fields:
-            result[meta.field_name] = (meta.json_name, meta.field_type)
-        cls._settings_field_map_cache = result
-        return result
+        return {meta.field_name: (meta.json_name, meta.field_type) for meta in CompetitionSettings._fields}
 
     @staticmethod
     def _normalize_setting_key(key: str, field_map: Dict[str, Any]) -> Optional[str]:

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -102,6 +102,7 @@ from kagglesdk.competitions.types.competition_api_service import (
     ApiDeleteCompetitionPageRequest,
     ApiUpdateCompetitionPageRequest,
     ApiGetCompetitionSettingsRequest,
+    ApiUpdateCompetitionSettingsRequest,
     ApiCreateCompetitionDataRequest,
     ApiCreateCompetitionDataResponse,
     ApiCompetitionDataFile,
@@ -147,7 +148,7 @@ from kagglesdk.competitions.types.competition_enums import (
     SubmissionSortBy,
 )
 
-from kagglesdk.competitions.types.competition import Reward, RewardTypeId
+from kagglesdk.competitions.types.competition import PubliclyCloneable, Reward, RewardTypeId
 from kagglesdk.competitions.types.host_service import CompetitionSettings
 
 from kagglesdk.common.types.cropped_image_upload import CroppedImageUpload, CroppedImageRectangle
@@ -234,7 +235,7 @@ import kagglesdk.kaggle_client
 from enum import EnumMeta
 from requests.exceptions import HTTPError
 from requests.models import Response
-from typing import Callable, cast, Dict, Iterator, List, Mapping, Optional, Tuple, Union, TypeVar, Iterable
+from typing import Any, Callable, cast, Dict, Iterator, List, Mapping, Optional, Tuple, Union, TypeVar, Iterable
 
 T = TypeVar("T")
 
@@ -2776,6 +2777,179 @@ class KaggleApi:
                 return None
             return name
         return str(value)
+
+    def competition_update_settings(
+        self,
+        competition_name: str,
+        updates: Dict[str, Any],
+    ) -> CompetitionSettings:
+        """Update selected fields on a competition's unified settings.
+
+        Args:
+            competition_name (str): The competition name (slug).
+            updates (Dict[str, Any]): Field name → new value. Keys may be
+                snake_case (matches SDK) or camelCase (matches JSON). Only
+                the fields present here are sent; the server's FieldMask is
+                derived from the keys.
+
+        Returns:
+            CompetitionSettings: the settings blob returned by the server.
+        """
+        if not updates:
+            raise ValueError("No settings to update — the input file has no fields.")
+
+        field_map = self._competition_settings_field_map()
+        settings = CompetitionSettings()
+        paths: List[str] = []
+        for raw_key, raw_value in updates.items():
+            key = self._normalize_setting_key(raw_key, field_map)
+            if key is None:
+                raise ValueError(f"Unknown competition setting: {raw_key!r}")
+            _, field_type = field_map[key]
+            coerced = self._coerce_setting_value(key, field_type, raw_value)
+            setattr(settings, key, coerced)
+            paths.append(key)
+
+        with self.build_kaggle_client() as kaggle:
+            request = ApiUpdateCompetitionSettingsRequest()
+            request.competition_name = competition_name
+            request.settings = settings
+            request.update_mask = field_mask_pb2.FieldMask(paths=paths)
+            return kaggle.competitions.competition_api_client.update_competition_settings(request)
+
+    def competition_update_settings_cli(
+        self,
+        competition=None,
+        competition_opt=None,
+        file_path=None,
+        json_output=False,
+        quiet=False,
+    ):
+        """CLI wrapper for competition_update_settings."""
+        competition_name = competition or competition_opt
+        if competition_name is None:
+            competition_name = self.get_config_value(self.CONFIG_NAME_COMPETITION)
+            if competition_name is not None and not quiet:
+                print("Using competition: " + competition_name)
+        if competition_name is None:
+            raise ValueError("No competition specified")
+        if not file_path:
+            raise ValueError("--from-file is required")
+
+        updates = self._load_settings_file(file_path)
+        settings = self.competition_update_settings(competition_name, updates)
+        if not quiet:
+            print(f'Settings updated on competition "{competition_name}" ({len(updates)} field(s)).')
+        if json_output:
+            self.print_obj(settings)
+        else:
+            self._print_competition_settings(settings)
+
+    @staticmethod
+    def _load_settings_file(file_path: str) -> Dict[str, Any]:
+        """Load a settings update payload from a JSON or YAML file."""
+        if not os.path.isfile(file_path):
+            raise ValueError(f"Settings file not found: {file_path}")
+        with open(file_path, "r", encoding="utf-8") as f:
+            raw = f.read()
+        lower = file_path.lower()
+        try:
+            if lower.endswith((".yaml", ".yml")):
+                import yaml  # transitive via jupytext
+
+                data = yaml.safe_load(raw)
+            else:
+                data = json.loads(raw)
+        except Exception as e:
+            raise ValueError(f"Failed to parse settings file {file_path}: {e}") from e
+        if data is None:
+            raise ValueError(f"Settings file {file_path} is empty.")
+        if not isinstance(data, dict):
+            raise ValueError(f"Settings file {file_path} must contain a mapping at the top level.")
+        return data
+
+    @classmethod
+    def _competition_settings_field_map(cls) -> Dict[str, Any]:
+        """Return {snake_case_name: (json_name, python_type)} for CompetitionSettings."""
+        cached = getattr(cls, "_settings_field_map_cache", None)
+        if cached is not None:
+            return cached
+        result: Dict[str, Any] = {}
+        for meta in CompetitionSettings._fields:
+            result[meta.field_name] = (meta.json_name, meta.field_type)
+        cls._settings_field_map_cache = result
+        return result
+
+    @staticmethod
+    def _normalize_setting_key(key: str, field_map: Dict[str, Any]) -> Optional[str]:
+        """Resolve a user-supplied key (snake or camel) to the snake_case field name."""
+        if not isinstance(key, str):
+            return None
+        if key in field_map:
+            return key
+        for snake, (json_name, _) in field_map.items():
+            if key == json_name:
+                return snake
+        return None
+
+    @staticmethod
+    def _coerce_setting_value(field_name: str, field_type: type, value: Any) -> Any:
+        """Convert a raw JSON/YAML value into the type CompetitionSettings expects."""
+        if value is None:
+            return None
+        if field_type is bool:
+            if isinstance(value, bool):
+                return value
+            raise ValueError(f"Field {field_name!r} expects a bool, got {type(value).__name__}")
+        if field_type is int:
+            if isinstance(value, bool):
+                raise ValueError(f"Field {field_name!r} expects an int, got bool")
+            if isinstance(value, int):
+                return value
+            raise ValueError(f"Field {field_name!r} expects an int, got {type(value).__name__}")
+        if field_type is float:
+            if isinstance(value, bool):
+                raise ValueError(f"Field {field_name!r} expects a float, got bool")
+            if isinstance(value, (int, float)):
+                return float(value)
+            raise ValueError(f"Field {field_name!r} expects a number, got {type(value).__name__}")
+        if field_type is str:
+            if isinstance(value, str):
+                return value
+            raise ValueError(f"Field {field_name!r} expects a string, got {type(value).__name__}")
+        if field_type is datetime:
+            if isinstance(value, datetime):
+                return value
+            if isinstance(value, str):
+                iso = value.replace("Z", "+00:00")
+                try:
+                    return datetime.fromisoformat(iso)
+                except ValueError as e:
+                    raise ValueError(f"Field {field_name!r} expects an ISO-8601 datetime, got {value!r}") from e
+            raise ValueError(f"Field {field_name!r} expects a datetime string, got {type(value).__name__}")
+        # Enum types (HostSegment, PubliclyCloneable, etc.)
+        if isinstance(field_type, EnumMeta):
+            if isinstance(value, field_type):
+                return value
+            if not isinstance(value, str):
+                raise ValueError(
+                    f"Field {field_name!r} expects a {field_type.__name__} name, got {type(value).__name__}"
+                )
+            try:
+                return field_type[value]
+            except KeyError:
+                pass
+            snake = re.sub(r"(?<!^)(?=[A-Z])", "_", field_type.__name__).upper()
+            candidate = f"{snake}_{value.upper()}"
+            try:
+                return field_type[candidate]
+            except KeyError as e:
+                allowed = [n for n in field_type.__members__ if not n.endswith("_UNSPECIFIED")]
+                raise ValueError(
+                    f"Field {field_name!r} value {value!r} is not a valid {field_type.__name__}. "
+                    f"Allowed: {', '.join(allowed)}"
+                ) from e
+        raise ValueError(f"Field {field_name!r} has unsupported type {field_type!r}")
 
     def competition_data_update(
         self,

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -659,6 +659,42 @@ def parse_competitions(subparsers) -> None:
     parser_competitions_settings_get._action_groups.append(parser_competitions_settings_get_optional)
     parser_competitions_settings_get.set_defaults(func=api.competition_get_settings_cli)
 
+    # Competitions settings update
+    parser_competitions_settings_update = subparsers_competitions_settings.add_parser(
+        "update",
+        formatter_class=argparse.RawTextHelpFormatter,
+        help=Help.command_competitions_settings_update,
+    )
+    parser_competitions_settings_update_optional = parser_competitions_settings_update._action_groups.pop()
+    parser_competitions_settings_update_optional.add_argument(
+        "competition", nargs="?", default=None, help=Help.param_competition
+    )
+    parser_competitions_settings_update_optional.add_argument(
+        "-c", "--competition", dest="competition_opt", required=False, help=argparse.SUPPRESS
+    )
+    parser_competitions_settings_update_optional.add_argument(
+        "-f",
+        "--from-file",
+        dest="file_path",
+        required=True,
+        help=(
+            "Path to a JSON or YAML file with the fields to update (extension "
+            "picks the parser: .yaml/.yml → YAML, anything else → JSON). "
+            "Only fields present in the file are sent."
+        ),
+    )
+    parser_competitions_settings_update_optional.add_argument(
+        "--json",
+        dest="json_output",
+        action="store_true",
+        help="After updating, print the returned settings as JSON instead of the grouped text view.",
+    )
+    parser_competitions_settings_update_optional.add_argument(
+        "-q", "--quiet", dest="quiet", action="store_true", help=Help.param_quiet
+    )
+    parser_competitions_settings_update._action_groups.append(parser_competitions_settings_update_optional)
+    parser_competitions_settings_update.set_defaults(func=api.competition_update_settings_cli)
+
     # Competitions launch (publish now, or schedule for a future UTC time)
     parser_competitions_launch = subparsers_competitions.add_parser(
         "launch", formatter_class=argparse.RawTextHelpFormatter, help=Help.command_competitions_launch
@@ -2293,7 +2329,7 @@ class Help(object):
     entity_topics_choices = ["list", "show"]
     entity_pages_choices = ["list", "create", "update", "delete"]
     entity_data_choices = ["update"]
-    entity_settings_choices = ["get"]
+    entity_settings_choices = ["get", "update"]
     config_choices = ["view", "set", "unset"]
     auth_choices = ["login", "print-access-token", "revoke"]
 
@@ -2373,6 +2409,7 @@ class Help(object):
     command_competitions_data_update = "Update (version) the data files for a competition you host"
     command_competitions_settings = "Manage settings for a competition you host"
     command_competitions_settings_get = "Show the current settings for a competition you host"
+    command_competitions_settings_update = "Update settings for a competition you host from a JSON or YAML file"
     command_competitions_launch = "Launch a competition you host, optionally at a future UTC time"
     command_competitions_init = "Initialize folder with a competition-metadata.json template"
     command_competitions_create = "Create a new competition from competition-metadata.json"

--- a/tests/unit/test_competition_settings_update.py
+++ b/tests/unit/test_competition_settings_update.py
@@ -1,0 +1,212 @@
+# coding=utf-8
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, "../..")
+
+from kaggle.api.kaggle_api_extended import KaggleApi
+from kagglesdk.competitions.types.host_service import CompetitionSettings
+
+
+class TestCompetitionUpdateSettings(unittest.TestCase):
+    """Tests for competition_update_settings and its CLI wrapper."""
+
+    def setUp(self):
+        self.api = KaggleApi.__new__(KaggleApi)
+        self.api.config_values = {}
+        self._tmp_files = []
+
+    def tearDown(self):
+        for path in self._tmp_files:
+            try:
+                os.unlink(path)
+            except FileNotFoundError:
+                pass
+
+    def _write_tmp(self, suffix: str, contents: str) -> str:
+        f = tempfile.NamedTemporaryFile(mode="w", suffix=suffix, delete=False, encoding="utf-8")
+        f.write(contents)
+        f.close()
+        self._tmp_files.append(f.name)
+        return f.name
+
+    def _patch_client(self, mock_client, returned=None):
+        mock_kaggle = MagicMock()
+        mock_kaggle.competitions.competition_api_client.update_competition_settings.return_value = (
+            returned if returned is not None else CompetitionSettings()
+        )
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+        return mock_kaggle
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_update_builds_field_mask_from_supplied_keys_only(self, mock_client):
+        mock_kaggle = self._patch_client(mock_client)
+
+        self.api.competition_update_settings(
+            "my-comp",
+            {"title": "New Title", "rules_required": True},
+        )
+
+        request = mock_kaggle.competitions.competition_api_client.update_competition_settings.call_args[0][0]
+        self.assertEqual(request.competition_name, "my-comp")
+        self.assertEqual(sorted(request.update_mask.paths), ["rules_required", "title"])
+        self.assertEqual(request.settings.title, "New Title")
+        self.assertTrue(request.settings.rules_required)
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_update_accepts_camel_case_keys(self, mock_client):
+        mock_kaggle = self._patch_client(mock_client)
+
+        self.api.competition_update_settings(
+            "my-comp",
+            {"briefDescription": "sub", "maxGpuRuntimeMinutes": 240},
+        )
+
+        request = mock_kaggle.competitions.competition_api_client.update_competition_settings.call_args[0][0]
+        # FieldMask paths always use snake_case (SDK canonical form).
+        self.assertEqual(sorted(request.update_mask.paths), ["brief_description", "max_gpu_runtime_minutes"])
+        self.assertEqual(request.settings.brief_description, "sub")
+        self.assertEqual(request.settings.max_gpu_runtime_minutes, 240)
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_update_coerces_iso_datetime_string(self, mock_client):
+        mock_kaggle = self._patch_client(mock_client)
+
+        self.api.competition_update_settings(
+            "my-comp",
+            {"team_file_deadline": "2026-08-01T10:30:00Z"},
+        )
+
+        request = mock_kaggle.competitions.competition_api_client.update_competition_settings.call_args[0][0]
+        self.assertEqual(
+            request.settings.team_file_deadline,
+            datetime(2026, 8, 1, 10, 30, 0, tzinfo=timezone.utc),
+        )
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_update_coerces_enum_from_full_name(self, mock_client):
+        mock_kaggle = self._patch_client(mock_client)
+
+        self.api.competition_update_settings(
+            "my-comp",
+            {"host_segment": "HOST_SEGMENT_FEATURED"},
+        )
+
+        request = mock_kaggle.competitions.competition_api_client.update_competition_settings.call_args[0][0]
+        self.assertEqual(request.settings.host_segment.name, "HOST_SEGMENT_FEATURED")
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_update_coerces_enum_from_short_name(self, mock_client):
+        mock_kaggle = self._patch_client(mock_client)
+
+        self.api.competition_update_settings(
+            "my-comp",
+            {"publicly_cloneable": "WITH_PRIVATE_SOLUTION_FILE"},
+        )
+
+        request = mock_kaggle.competitions.competition_api_client.update_competition_settings.call_args[0][0]
+        self.assertEqual(request.settings.publicly_cloneable.name, "PUBLICLY_CLONEABLE_WITH_PRIVATE_SOLUTION_FILE")
+
+    def test_update_empty_updates_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.api.competition_update_settings("my-comp", {})
+        self.assertIn("No settings to update", str(ctx.exception))
+
+    def test_update_unknown_field_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.api.competition_update_settings("my-comp", {"bogus_field": 1})
+        self.assertIn("Unknown competition setting", str(ctx.exception))
+
+    def test_update_wrong_type_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.api.competition_update_settings("my-comp", {"title": 42})
+        self.assertIn("expects a string", str(ctx.exception))
+
+    def test_update_bad_enum_lists_allowed(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.api.competition_update_settings("my-comp", {"host_segment": "NOPE"})
+        message = str(ctx.exception)
+        self.assertIn("not a valid HostSegment", message)
+        self.assertIn("HOST_SEGMENT_FEATURED", message)
+
+    def test_update_bad_datetime_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.api.competition_update_settings("my-comp", {"team_file_deadline": "yesterday"})
+        self.assertIn("ISO-8601 datetime", str(ctx.exception))
+
+    # --- CLI wrapper --------------------------------------------------------
+
+    @patch.object(KaggleApi, "competition_update_settings")
+    def test_cli_loads_json_file(self, mock_update):
+        mock_update.return_value = CompetitionSettings()
+        path = self._write_tmp(".json", json.dumps({"title": "X", "rules_required": True}))
+
+        with redirect_stdout(io.StringIO()):
+            self.api.competition_update_settings_cli(
+                competition="my-comp",
+                file_path=path,
+                quiet=True,
+            )
+
+        mock_update.assert_called_once()
+        called_updates = mock_update.call_args[0][1]
+        self.assertEqual(called_updates, {"title": "X", "rules_required": True})
+
+    @patch.object(KaggleApi, "competition_update_settings")
+    def test_cli_loads_yaml_file(self, mock_update):
+        mock_update.return_value = CompetitionSettings()
+        path = self._write_tmp(".yaml", "title: X\nrules_required: true\n")
+
+        with redirect_stdout(io.StringIO()):
+            self.api.competition_update_settings_cli(
+                competition="my-comp",
+                file_path=path,
+                quiet=True,
+            )
+
+        called_updates = mock_update.call_args[0][1]
+        self.assertEqual(called_updates, {"title": "X", "rules_required": True})
+
+    def test_cli_missing_file_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.api.competition_update_settings_cli(
+                competition="my-comp",
+                file_path="/tmp/does-not-exist-9999.json",
+            )
+        self.assertIn("Settings file not found", str(ctx.exception))
+
+    def test_cli_empty_file_raises(self):
+        path = self._write_tmp(".json", "")
+        with self.assertRaises(ValueError) as ctx:
+            self.api.competition_update_settings_cli(competition="my-comp", file_path=path)
+        # An empty .json file → JSON parse error surfaces via "Failed to parse".
+        self.assertIn("Failed to parse", str(ctx.exception))
+
+    def test_cli_top_level_not_mapping_raises(self):
+        path = self._write_tmp(".json", "[1, 2, 3]")
+        with self.assertRaises(ValueError) as ctx:
+            self.api.competition_update_settings_cli(competition="my-comp", file_path=path)
+        self.assertIn("mapping at the top level", str(ctx.exception))
+
+    def test_cli_missing_competition_raises(self):
+        path = self._write_tmp(".json", "{}")
+        with self.assertRaises(ValueError) as ctx:
+            self.api.competition_update_settings_cli(file_path=path)
+        self.assertIn("No competition specified", str(ctx.exception))
+
+    def test_cli_missing_file_arg_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.api.competition_update_settings_cli(competition="my-comp")
+        self.assertIn("--from-file is required", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds `kaggle competitions settings update <competition> -f <path>` which sends a partial CompetitionSettings update via the existing SDK method. The FieldMask is derived from the keys present in the user-supplied JSON or YAML file (extension picks the parser). Keys may be snake_case or camelCase; values are coerced to the SDK's declared field type (bool, int, float, str, ISO-8601 datetime, or enum member — enum names accept either the full name or the short suffix).

Also documents the new `settings get` / `settings update` pair in docs/competition_creation.md and extends the README pointer.