### PR TITLE
test: improve coverage for Datasets API (Phase 1)

### DIFF
--- a/tests/unit/test_dataset_create.py
+++ b/tests/unit/test_dataset_create.py
@@ -216,7 +216,7 @@ class TestDatasetCreate(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             self._write_metadata(tmpdir, metadata)
             open(os.path.join(tmpdir, "file1.csv"), "w").close()
-            
+
             with self.assertRaises(ValueError) as context:
                 self.api.dataset_create_new(tmpdir)
             self.assertIn("path was specified more than once", str(context.exception))
@@ -285,14 +285,14 @@ class TestDatasetCreate(unittest.TestCase):
             request = mock_kaggle.datasets.dataset_api_client.create_dataset_version.call_args[0][0]
             self.assertEqual(request.owner_slug, "testuser")
             self.assertEqual(request.dataset_slug, "test-dataset")
-            
+
             body = request.body
             self.assertEqual(body.version_notes, "version notes here")
             self.assertEqual(body.subtitle, "This is a valid subtitle with enough length")
             self.assertEqual(body.description, "Some description")
             self.assertEqual(body.category_ids, ["key1", "key2"])
             self.assertTrue(body.delete_old_versions)
-            
+
             self.assertEqual(response, mock_response)
 
     @patch.object(KaggleApi, "upload_files")
@@ -317,14 +317,13 @@ class TestDatasetCreate(unittest.TestCase):
             mock_kaggle.datasets.dataset_api_client.create_dataset_version_by_id.assert_called_once()
             request = mock_kaggle.datasets.dataset_api_client.create_dataset_version_by_id.call_args[0][0]
             self.assertEqual(request.id, 12345)
-            
+
             body = request.body
             self.assertEqual(body.version_notes, "version notes here")
             self.assertEqual(body.subtitle, "This is a valid subtitle with enough length")
-            
+
             self.assertEqual(response, mock_response)
 
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/tests/unit/test_dataset_create.py
+++ b/tests/unit/test_dataset_create.py
@@ -32,12 +32,12 @@ class TestDatasetCreate(unittest.TestCase):
         with open(meta_file_path, "w", encoding="utf-8") as f:
             json.dump(metadata, f)
 
-    def test_dataset_create_new_invalid_folder(self):
+    def test_dataset_create_new_invalid_folder_fails(self):
         with self.assertRaises(ValueError) as context:
             self.api.dataset_create_new("/non/existent/folder")
         self.assertIn("Invalid folder", str(context.exception))
 
-    def test_dataset_create_new_default_slug(self):
+    def test_dataset_create_new_default_slug_fails(self):
         metadata = self._get_valid_metadata()
         metadata["id"] = "testuser/INSERT_SLUG_HERE"
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -46,7 +46,7 @@ class TestDatasetCreate(unittest.TestCase):
                 self.api.dataset_create_new(tmpdir)
             self.assertIn("Default slug detected", str(context.exception))
 
-    def test_dataset_create_new_default_title(self):
+    def test_dataset_create_new_default_title_fails(self):
         metadata = self._get_valid_metadata()
         metadata["title"] = "INSERT_TITLE_HERE"
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -55,7 +55,7 @@ class TestDatasetCreate(unittest.TestCase):
                 self.api.dataset_create_new(tmpdir)
             self.assertIn("Default title detected", str(context.exception))
 
-    def test_dataset_create_new_multiple_licenses(self):
+    def test_dataset_create_new_multiple_licenses_fails(self):
         metadata = self._get_valid_metadata()
         metadata["licenses"] = [{"name": "CC0-1.0"}, {"name": "CC-BY-4.0"}]
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -64,7 +64,7 @@ class TestDatasetCreate(unittest.TestCase):
                 self.api.dataset_create_new(tmpdir)
             self.assertIn("Please specify exactly one license", str(context.exception))
 
-    def test_dataset_create_new_no_licenses(self):
+    def test_dataset_create_new_no_licenses_fails(self):
         metadata = self._get_valid_metadata()
         metadata["licenses"] = []
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -73,7 +73,7 @@ class TestDatasetCreate(unittest.TestCase):
                 self.api.dataset_create_new(tmpdir)
             self.assertIn("Please specify exactly one license", str(context.exception))
 
-    def test_dataset_create_new_short_slug(self):
+    def test_dataset_create_new_short_slug_fails(self):
         metadata = self._get_valid_metadata()
         metadata["id"] = "testuser/abc"
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -82,7 +82,7 @@ class TestDatasetCreate(unittest.TestCase):
                 self.api.dataset_create_new(tmpdir)
             self.assertIn("The dataset slug must be between 6 and 50 characters", str(context.exception))
 
-    def test_dataset_create_new_long_slug(self):
+    def test_dataset_create_new_long_slug_fails(self):
         metadata = self._get_valid_metadata()
         metadata["id"] = "testuser/" + ("a" * 51)
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -91,7 +91,7 @@ class TestDatasetCreate(unittest.TestCase):
                 self.api.dataset_create_new(tmpdir)
             self.assertIn("The dataset slug must be between 6 and 50 characters", str(context.exception))
 
-    def test_dataset_create_new_short_title(self):
+    def test_dataset_create_new_short_title_fails(self):
         metadata = self._get_valid_metadata()
         metadata["title"] = "abc"
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -100,7 +100,7 @@ class TestDatasetCreate(unittest.TestCase):
                 self.api.dataset_create_new(tmpdir)
             self.assertIn("The dataset title must be between 6 and 50 characters", str(context.exception))
 
-    def test_dataset_create_new_long_title(self):
+    def test_dataset_create_new_long_title_fails(self):
         metadata = self._get_valid_metadata()
         metadata["title"] = "a" * 51
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -109,7 +109,7 @@ class TestDatasetCreate(unittest.TestCase):
                 self.api.dataset_create_new(tmpdir)
             self.assertIn("The dataset title must be between 6 and 50 characters", str(context.exception))
 
-    def test_dataset_create_new_short_subtitle(self):
+    def test_dataset_create_new_short_subtitle_fails(self):
         metadata = self._get_valid_metadata()
         metadata["subtitle"] = "too short"
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -118,7 +118,7 @@ class TestDatasetCreate(unittest.TestCase):
                 self.api.dataset_create_new(tmpdir)
             self.assertIn("Subtitle length must be between 20 and 80 characters", str(context.exception))
 
-    def test_dataset_create_new_long_subtitle(self):
+    def test_dataset_create_new_long_subtitle_fails(self):
         metadata = self._get_valid_metadata()
         metadata["subtitle"] = "a" * 81
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -128,7 +128,7 @@ class TestDatasetCreate(unittest.TestCase):
             self.assertIn("Subtitle length must be between 20 and 80 characters", str(context.exception))
 
     @patch.object(KaggleApi, "dataset_status")
-    def test_dataset_create_new_duplicate_title(self, mock_status):
+    def test_dataset_create_new_duplicate_title_fails(self, mock_status):
         mock_status.return_value = MagicMock()
         metadata = self._get_valid_metadata()
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -141,7 +141,7 @@ class TestDatasetCreate(unittest.TestCase):
     @patch.object(KaggleApi, "dataset_status")
     @patch.object(KaggleApi, "upload_files")
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_dataset_create_new_success(self, mock_client, mock_upload, mock_status):
+    def test_dataset_create_new_valid_metadata_succeeds(self, mock_client, mock_upload, mock_status):
         mock_status.side_effect = HTTPError()
 
         mock_kaggle = MagicMock()
@@ -177,7 +177,7 @@ class TestDatasetCreate(unittest.TestCase):
     @patch.object(KaggleApi, "dataset_status")
     @patch.object(KaggleApi, "upload_files")
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_dataset_create_new_with_valid_resources(self, mock_client, mock_upload, mock_status):
+    def test_dataset_create_new_with_valid_resources_succeeds(self, mock_client, mock_upload, mock_status):
         mock_status.side_effect = HTTPError()
         mock_kaggle = MagicMock()
         mock_response = MagicMock()
@@ -199,7 +199,7 @@ class TestDatasetCreate(unittest.TestCase):
             self.assertEqual(response, mock_response)
             mock_upload.assert_called_once()
 
-    def test_dataset_create_new_with_missing_resources(self):
+    def test_dataset_create_new_with_missing_resources_fails(self):
         metadata = self._get_valid_metadata()
         metadata["resources"] = [{"path": "file1.csv"}]
 
@@ -209,7 +209,7 @@ class TestDatasetCreate(unittest.TestCase):
                 self.api.dataset_create_new(tmpdir)
             self.assertIn("file1.csv does not exist", str(context.exception))
 
-    def test_dataset_create_new_with_duplicate_resources(self):
+    def test_dataset_create_new_with_duplicate_resources_fails(self):
         metadata = self._get_valid_metadata()
         metadata["resources"] = [{"path": "file1.csv"}, {"path": "file1.csv"}]
 
@@ -221,12 +221,12 @@ class TestDatasetCreate(unittest.TestCase):
                 self.api.dataset_create_new(tmpdir)
             self.assertIn("path was specified more than once", str(context.exception))
 
-    def test_dataset_create_version_invalid_folder(self):
+    def test_dataset_create_version_invalid_folder_fails(self):
         with self.assertRaises(ValueError) as context:
             self.api.dataset_create_version("/non/existent/folder", "notes")
         self.assertIn("Invalid folder", str(context.exception))
 
-    def test_dataset_create_version_missing_id(self):
+    def test_dataset_create_version_missing_id_fails(self):
         metadata = self._get_valid_metadata()
         del metadata["id"]
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -235,7 +235,7 @@ class TestDatasetCreate(unittest.TestCase):
                 self.api.dataset_create_version(tmpdir, "notes")
             self.assertIn("ID or slug must be specified", str(context.exception))
 
-    def test_dataset_create_version_default_slug(self):
+    def test_dataset_create_version_default_slug_fails(self):
         metadata = self._get_valid_metadata()
         metadata["id"] = "testuser/INSERT_SLUG_HERE"
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -244,7 +244,7 @@ class TestDatasetCreate(unittest.TestCase):
                 self.api.dataset_create_version(tmpdir, "notes")
             self.assertIn("Default slug detected", str(context.exception))
 
-    def test_dataset_create_version_invalid_subtitle(self):
+    def test_dataset_create_version_invalid_subtitle_fails(self):
         metadata = self._get_valid_metadata()
         metadata["subtitle"] = "too short"
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -253,7 +253,7 @@ class TestDatasetCreate(unittest.TestCase):
                 self.api.dataset_create_version(tmpdir, "notes")
             self.assertIn("Subtitle length must be between 20 and 80 characters", str(context.exception))
 
-    def test_dataset_create_version_invalid_dataset_slug(self):
+    def test_dataset_create_version_invalid_dataset_slug_fails(self):
         metadata = self._get_valid_metadata()
         metadata["id"] = "invalid_slug_no_slash"
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -264,7 +264,7 @@ class TestDatasetCreate(unittest.TestCase):
 
     @patch.object(KaggleApi, "upload_files")
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_dataset_create_version_success_slug(self, mock_client, mock_upload):
+    def test_dataset_create_version_with_slug_succeeds(self, mock_client, mock_upload):
         mock_kaggle = MagicMock()
         mock_response = MagicMock()
         mock_kaggle.datasets.dataset_api_client.create_dataset_version.return_value = mock_response
@@ -297,7 +297,7 @@ class TestDatasetCreate(unittest.TestCase):
 
     @patch.object(KaggleApi, "upload_files")
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_dataset_create_version_success_id(self, mock_client, mock_upload):
+    def test_dataset_create_version_with_id_succeeds(self, mock_client, mock_upload):
         mock_kaggle = MagicMock()
         mock_response = MagicMock()
         mock_kaggle.datasets.dataset_api_client.create_dataset_version_by_id.return_value = mock_response

--- a/tests/unit/test_dataset_create.py
+++ b/tests/unit/test_dataset_create.py
@@ -1,0 +1,330 @@
+# coding=utf-8
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+import sys
+from requests.exceptions import HTTPError
+
+sys.path.insert(0, "../..")
+
+from kaggle.api.kaggle_api_extended import KaggleApi
+
+
+class TestDatasetCreate(unittest.TestCase):
+    """Tests for dataset_create_new and dataset_create_version."""
+
+    def setUp(self):
+        self.api = KaggleApi.__new__(KaggleApi)
+        self.api.config_values = {"username": "testuser"}
+        self.api.already_printed_version_warning = True
+
+    def _get_valid_metadata(self):
+        return {
+            "id": "testuser/test-dataset",
+            "title": "Test Dataset Title",
+            "licenses": [{"name": "CC0-1.0"}],
+        }
+
+    def _write_metadata(self, folder, metadata):
+        meta_file_path = os.path.join(folder, "dataset-metadata.json")
+        with open(meta_file_path, "w", encoding="utf-8") as f:
+            json.dump(metadata, f)
+
+    def test_dataset_create_new_invalid_folder(self):
+        with self.assertRaises(ValueError) as context:
+            self.api.dataset_create_new("/non/existent/folder")
+        self.assertIn("Invalid folder", str(context.exception))
+
+    def test_dataset_create_new_default_slug(self):
+        metadata = self._get_valid_metadata()
+        metadata["id"] = "testuser/INSERT_SLUG_HERE"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            with self.assertRaises(ValueError) as context:
+                self.api.dataset_create_new(tmpdir)
+            self.assertIn("Default slug detected", str(context.exception))
+
+    def test_dataset_create_new_default_title(self):
+        metadata = self._get_valid_metadata()
+        metadata["title"] = "INSERT_TITLE_HERE"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            with self.assertRaises(ValueError) as context:
+                self.api.dataset_create_new(tmpdir)
+            self.assertIn("Default title detected", str(context.exception))
+
+    def test_dataset_create_new_multiple_licenses(self):
+        metadata = self._get_valid_metadata()
+        metadata["licenses"] = [{"name": "CC0-1.0"}, {"name": "CC-BY-4.0"}]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            with self.assertRaises(ValueError) as context:
+                self.api.dataset_create_new(tmpdir)
+            self.assertIn("Please specify exactly one license", str(context.exception))
+
+    def test_dataset_create_new_no_licenses(self):
+        metadata = self._get_valid_metadata()
+        metadata["licenses"] = []
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            with self.assertRaises(ValueError) as context:
+                self.api.dataset_create_new(tmpdir)
+            self.assertIn("Please specify exactly one license", str(context.exception))
+
+    def test_dataset_create_new_short_slug(self):
+        metadata = self._get_valid_metadata()
+        metadata["id"] = "testuser/abc"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            with self.assertRaises(ValueError) as context:
+                self.api.dataset_create_new(tmpdir)
+            self.assertIn("The dataset slug must be between 6 and 50 characters", str(context.exception))
+
+    def test_dataset_create_new_long_slug(self):
+        metadata = self._get_valid_metadata()
+        metadata["id"] = "testuser/" + ("a" * 51)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            with self.assertRaises(ValueError) as context:
+                self.api.dataset_create_new(tmpdir)
+            self.assertIn("The dataset slug must be between 6 and 50 characters", str(context.exception))
+
+    def test_dataset_create_new_short_title(self):
+        metadata = self._get_valid_metadata()
+        metadata["title"] = "abc"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            with self.assertRaises(ValueError) as context:
+                self.api.dataset_create_new(tmpdir)
+            self.assertIn("The dataset title must be between 6 and 50 characters", str(context.exception))
+
+    def test_dataset_create_new_long_title(self):
+        metadata = self._get_valid_metadata()
+        metadata["title"] = "a" * 51
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            with self.assertRaises(ValueError) as context:
+                self.api.dataset_create_new(tmpdir)
+            self.assertIn("The dataset title must be between 6 and 50 characters", str(context.exception))
+
+    def test_dataset_create_new_short_subtitle(self):
+        metadata = self._get_valid_metadata()
+        metadata["subtitle"] = "too short"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            with self.assertRaises(ValueError) as context:
+                self.api.dataset_create_new(tmpdir)
+            self.assertIn("Subtitle length must be between 20 and 80 characters", str(context.exception))
+
+    def test_dataset_create_new_long_subtitle(self):
+        metadata = self._get_valid_metadata()
+        metadata["subtitle"] = "a" * 81
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            with self.assertRaises(ValueError) as context:
+                self.api.dataset_create_new(tmpdir)
+            self.assertIn("Subtitle length must be between 20 and 80 characters", str(context.exception))
+
+    @patch.object(KaggleApi, "dataset_status")
+    def test_dataset_create_new_duplicate_title(self, mock_status):
+        mock_status.return_value = MagicMock()
+        metadata = self._get_valid_metadata()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            response = self.api.dataset_create_new(tmpdir)
+            self.assertEqual(response.status, "error")
+            self.assertIn("already in use by a dataset", response.error)
+            mock_status.assert_called_once_with("testuser/test-dataset")
+
+    @patch.object(KaggleApi, "dataset_status")
+    @patch.object(KaggleApi, "upload_files")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_dataset_create_new_success(self, mock_client, mock_upload, mock_status):
+        mock_status.side_effect = HTTPError()
+
+        mock_kaggle = MagicMock()
+        mock_response = MagicMock()
+        mock_response.error = ""
+        mock_kaggle.datasets.dataset_api_client.create_dataset.return_value = mock_response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        metadata = self._get_valid_metadata()
+        metadata["subtitle"] = "This is a valid subtitle with enough length"
+        metadata["description"] = "Some description"
+        metadata["keywords"] = ["key1", "key2"]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            response = self.api.dataset_create_new(tmpdir, public=True)
+
+            mock_status.assert_called_once_with("testuser/test-dataset")
+            mock_upload.assert_called_once()
+            mock_kaggle.datasets.dataset_api_client.create_dataset.assert_called_once()
+            request = mock_kaggle.datasets.dataset_api_client.create_dataset.call_args[0][0]
+            self.assertEqual(request.title, "Test Dataset Title")
+            self.assertEqual(request.slug, "test-dataset")
+            self.assertEqual(request.owner_slug, "testuser")
+            self.assertEqual(request.license_name, "CC0-1.0")
+            self.assertEqual(request.subtitle, "This is a valid subtitle with enough length")
+            self.assertEqual(request.description, "Some description")
+            self.assertEqual(request.category_ids, ["key1", "key2"])
+            self.assertFalse(request.is_private)
+            self.assertEqual(response, mock_response)
+
+    @patch.object(KaggleApi, "dataset_status")
+    @patch.object(KaggleApi, "upload_files")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_dataset_create_new_with_valid_resources(self, mock_client, mock_upload, mock_status):
+        mock_status.side_effect = HTTPError()
+        mock_kaggle = MagicMock()
+        mock_response = MagicMock()
+        mock_response.error = ""
+        mock_kaggle.datasets.dataset_api_client.create_dataset.return_value = mock_response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        metadata = self._get_valid_metadata()
+        metadata["resources"] = [{"path": "file1.csv"}, {"path": "file2.csv"}]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            open(os.path.join(tmpdir, "file1.csv"), "w").close()
+            open(os.path.join(tmpdir, "file2.csv"), "w").close()
+
+            response = self.api.dataset_create_new(tmpdir)
+
+            self.assertEqual(response, mock_response)
+            mock_upload.assert_called_once()
+
+    def test_dataset_create_new_with_missing_resources(self):
+        metadata = self._get_valid_metadata()
+        metadata["resources"] = [{"path": "file1.csv"}]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            with self.assertRaises(ValueError) as context:
+                self.api.dataset_create_new(tmpdir)
+            self.assertIn("file1.csv does not exist", str(context.exception))
+
+    def test_dataset_create_new_with_duplicate_resources(self):
+        metadata = self._get_valid_metadata()
+        metadata["resources"] = [{"path": "file1.csv"}, {"path": "file1.csv"}]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            open(os.path.join(tmpdir, "file1.csv"), "w").close()
+            
+            with self.assertRaises(ValueError) as context:
+                self.api.dataset_create_new(tmpdir)
+            self.assertIn("path was specified more than once", str(context.exception))
+
+    def test_dataset_create_version_invalid_folder(self):
+        with self.assertRaises(ValueError) as context:
+            self.api.dataset_create_version("/non/existent/folder", "notes")
+        self.assertIn("Invalid folder", str(context.exception))
+
+    def test_dataset_create_version_missing_id(self):
+        metadata = self._get_valid_metadata()
+        del metadata["id"]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            with self.assertRaises(ValueError) as context:
+                self.api.dataset_create_version(tmpdir, "notes")
+            self.assertIn("ID or slug must be specified", str(context.exception))
+
+    def test_dataset_create_version_default_slug(self):
+        metadata = self._get_valid_metadata()
+        metadata["id"] = "testuser/INSERT_SLUG_HERE"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            with self.assertRaises(ValueError) as context:
+                self.api.dataset_create_version(tmpdir, "notes")
+            self.assertIn("Default slug detected", str(context.exception))
+
+    def test_dataset_create_version_invalid_subtitle(self):
+        metadata = self._get_valid_metadata()
+        metadata["subtitle"] = "too short"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            with self.assertRaises(ValueError) as context:
+                self.api.dataset_create_version(tmpdir, "notes")
+            self.assertIn("Subtitle length must be between 20 and 80 characters", str(context.exception))
+
+    def test_dataset_create_version_invalid_dataset_slug(self):
+        metadata = self._get_valid_metadata()
+        metadata["id"] = "invalid_slug_no_slash"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            with self.assertRaises(ValueError) as context:
+                self.api.dataset_create_version(tmpdir, "notes")
+            self.assertIn("Dataset must be specified in the form", str(context.exception))
+
+    @patch.object(KaggleApi, "upload_files")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_dataset_create_version_success_slug(self, mock_client, mock_upload):
+        mock_kaggle = MagicMock()
+        mock_response = MagicMock()
+        mock_kaggle.datasets.dataset_api_client.create_dataset_version.return_value = mock_response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        metadata = self._get_valid_metadata()
+        metadata["subtitle"] = "This is a valid subtitle with enough length"
+        metadata["description"] = "Some description"
+        metadata["keywords"] = ["key1", "key2"]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            response = self.api.dataset_create_version(tmpdir, "version notes here", delete_old_versions=True)
+
+            mock_upload.assert_called_once()
+            mock_kaggle.datasets.dataset_api_client.create_dataset_version.assert_called_once()
+            request = mock_kaggle.datasets.dataset_api_client.create_dataset_version.call_args[0][0]
+            self.assertEqual(request.owner_slug, "testuser")
+            self.assertEqual(request.dataset_slug, "test-dataset")
+            
+            body = request.body
+            self.assertEqual(body.version_notes, "version notes here")
+            self.assertEqual(body.subtitle, "This is a valid subtitle with enough length")
+            self.assertEqual(body.description, "Some description")
+            self.assertEqual(body.category_ids, ["key1", "key2"])
+            self.assertTrue(body.delete_old_versions)
+            
+            self.assertEqual(response, mock_response)
+
+    @patch.object(KaggleApi, "upload_files")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_dataset_create_version_success_id(self, mock_client, mock_upload):
+        mock_kaggle = MagicMock()
+        mock_response = MagicMock()
+        mock_kaggle.datasets.dataset_api_client.create_dataset_version_by_id.return_value = mock_response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        metadata = {
+            "id_no": "12345",
+            "subtitle": "This is a valid subtitle with enough length",
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            response = self.api.dataset_create_version(tmpdir, "version notes here")
+
+            mock_upload.assert_called_once()
+            mock_kaggle.datasets.dataset_api_client.create_dataset_version_by_id.assert_called_once()
+            request = mock_kaggle.datasets.dataset_api_client.create_dataset_version_by_id.call_args[0][0]
+            self.assertEqual(request.id, 12345)
+            
+            body = request.body
+            self.assertEqual(body.version_notes, "version notes here")
+            self.assertEqual(body.subtitle, "This is a valid subtitle with enough length")
+            
+            self.assertEqual(response, mock_response)
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/unit/test_dataset_download.py
+++ b/tests/unit/test_dataset_download.py
@@ -153,7 +153,9 @@ class TestDatasetDownload(unittest.TestCase):
     @patch.object(KaggleApi, "download_needed", return_value=True)
     @patch.object(KaggleApi, "download_file")
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_dataset_download_file_default_path(self, mock_client, mock_download_file, mock_download_needed, mock_get_default_dir):
+    def test_dataset_download_file_default_path(
+        self, mock_client, mock_download_file, mock_download_needed, mock_get_default_dir
+    ):
         mock_kaggle = MagicMock()
         mock_response = MagicMock()
         mock_response.request.url = "http://example.com/download/testuser/test-dataset/file1.csv?token=123"

--- a/tests/unit/test_dataset_download.py
+++ b/tests/unit/test_dataset_download.py
@@ -21,7 +21,7 @@ class TestDatasetDownload(unittest.TestCase):
     @patch.object(KaggleApi, "download_needed", return_value=False)
     @patch.object(KaggleApi, "download_file")
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_dataset_download_cached_unzip(
+    def test_dataset_download_cached_unzip_succeeds(
         self, mock_client, mock_download_file, mock_download_needed, mock_zipfile, mock_remove, mock_exists
     ):
         """Case 1: When dataset is cached (download_needed is False) and unzip=True,
@@ -58,7 +58,7 @@ class TestDatasetDownload(unittest.TestCase):
     @patch.object(KaggleApi, "download_needed", return_value=True)
     @patch.object(KaggleApi, "download_file")
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_dataset_download_fresh_unzip(
+    def test_dataset_download_fresh_unzip_succeeds(
         self, mock_client, mock_download_file, mock_download_needed, mock_zipfile, mock_remove, mock_exists
     ):
         """Case 2: When dataset is not cached (download_needed is True) and unzip=True,
@@ -92,7 +92,7 @@ class TestDatasetDownload(unittest.TestCase):
     @patch.object(KaggleApi, "download_needed", return_value=True)
     @patch.object(KaggleApi, "download_file")
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_dataset_download_file_success(self, mock_client, mock_download_file, mock_download_needed):
+    def test_dataset_download_file_succeeds(self, mock_client, mock_download_file, mock_download_needed):
         mock_kaggle = MagicMock()
         mock_response = MagicMock()
         mock_response.request.url = "http://example.com/download/testuser/test-dataset/file1.csv?token=123"
@@ -118,7 +118,9 @@ class TestDatasetDownload(unittest.TestCase):
     @patch.object(KaggleApi, "download_needed", return_value=False)
     @patch.object(KaggleApi, "download_file")
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_dataset_download_file_not_needed(self, mock_client, mock_download_file, mock_download_needed):
+    def test_dataset_download_file_not_needed_skips_download(
+        self, mock_client, mock_download_file, mock_download_needed
+    ):
         mock_kaggle = MagicMock()
         mock_response = MagicMock()
         mock_response.request.url = "http://example.com/download/testuser/test-dataset/file1.csv?token=123"
@@ -135,7 +137,7 @@ class TestDatasetDownload(unittest.TestCase):
     @patch.object(KaggleApi, "download_needed", return_value=False)
     @patch.object(KaggleApi, "download_file")
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_dataset_download_file_force(self, mock_client, mock_download_file, mock_download_needed):
+    def test_dataset_download_file_force_downloads(self, mock_client, mock_download_file, mock_download_needed):
         mock_kaggle = MagicMock()
         mock_response = MagicMock()
         mock_response.request.url = "http://example.com/download/testuser/test-dataset/file1.csv?token=123"
@@ -153,7 +155,7 @@ class TestDatasetDownload(unittest.TestCase):
     @patch.object(KaggleApi, "download_needed", return_value=True)
     @patch.object(KaggleApi, "download_file")
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_dataset_download_file_default_path(
+    def test_dataset_download_file_default_path_succeeds(
         self, mock_client, mock_download_file, mock_download_needed, mock_get_default_dir
     ):
         mock_kaggle = MagicMock()
@@ -172,7 +174,9 @@ class TestDatasetDownload(unittest.TestCase):
     @patch.object(KaggleApi, "download_needed", return_value=True)
     @patch.object(KaggleApi, "download_file")
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_dataset_download_file_no_owner(self, mock_client, mock_download_file, mock_download_needed):
+    def test_dataset_download_file_no_owner_defaults_owner_succeeds(
+        self, mock_client, mock_download_file, mock_download_needed
+    ):
         mock_kaggle = MagicMock()
         mock_response = MagicMock()
         mock_response.request.url = "http://example.com/download/testuser/test-dataset/file1.csv?token=123"
@@ -189,7 +193,7 @@ class TestDatasetDownload(unittest.TestCase):
     @patch.object(KaggleApi, "download_needed", return_value=True)
     @patch.object(KaggleApi, "download_file")
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_dataset_download_file_with_version(self, mock_client, mock_download_file, mock_download_needed):
+    def test_dataset_download_file_with_version_succeeds(self, mock_client, mock_download_file, mock_download_needed):
         mock_kaggle = MagicMock()
         mock_response = MagicMock()
         mock_response.request.url = "http://example.com/download/testuser/test-dataset/file1.csv?token=123"

--- a/tests/unit/test_dataset_download.py
+++ b/tests/unit/test_dataset_download.py
@@ -89,6 +89,119 @@ class TestDatasetDownload(unittest.TestCase):
         mock_remove.assert_called_once()
         self.assertEqual(os.path.normpath(mock_remove.call_args[0][0]), expected_outfile)
 
+    @patch.object(KaggleApi, "download_needed", return_value=True)
+    @patch.object(KaggleApi, "download_file")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_dataset_download_file_success(self, mock_client, mock_download_file, mock_download_needed):
+        mock_kaggle = MagicMock()
+        mock_response = MagicMock()
+        mock_response.request.url = "http://example.com/download/testuser/test-dataset/file1.csv?token=123"
+        mock_kaggle.datasets.dataset_api_client.download_dataset.return_value = mock_response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = self.api.dataset_download_file("owner/my-dataset", "file1.csv", path="/tmp/download")
+
+        self.assertTrue(result)
+        mock_kaggle.datasets.dataset_api_client.download_dataset.assert_called_once()
+        request = mock_kaggle.datasets.dataset_api_client.download_dataset.call_args[0][0]
+        self.assertEqual(request.owner_slug, "owner")
+        self.assertEqual(request.dataset_slug, "my-dataset")
+        self.assertEqual(request.file_name, "file1.csv")
+        self.assertEqual(request.dataset_version_number, 0)
+
+        mock_download_needed.assert_called_once()
+        mock_download_file.assert_called_once()
+        expected_outfile = os.path.join("/tmp/download", "file1.csv")
+        self.assertEqual(mock_download_file.call_args[0][1], expected_outfile)
+
+    @patch.object(KaggleApi, "download_needed", return_value=False)
+    @patch.object(KaggleApi, "download_file")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_dataset_download_file_not_needed(self, mock_client, mock_download_file, mock_download_needed):
+        mock_kaggle = MagicMock()
+        mock_response = MagicMock()
+        mock_response.request.url = "http://example.com/download/testuser/test-dataset/file1.csv?token=123"
+        mock_kaggle.datasets.dataset_api_client.download_dataset.return_value = mock_response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = self.api.dataset_download_file("owner/my-dataset", "file1.csv", path="/tmp/download")
+
+        self.assertFalse(result)
+        mock_download_needed.assert_called_once()
+        mock_download_file.assert_not_called()
+
+    @patch.object(KaggleApi, "download_needed", return_value=False)
+    @patch.object(KaggleApi, "download_file")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_dataset_download_file_force(self, mock_client, mock_download_file, mock_download_needed):
+        mock_kaggle = MagicMock()
+        mock_response = MagicMock()
+        mock_response.request.url = "http://example.com/download/testuser/test-dataset/file1.csv?token=123"
+        mock_kaggle.datasets.dataset_api_client.download_dataset.return_value = mock_response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = self.api.dataset_download_file("owner/my-dataset", "file1.csv", path="/tmp/download", force=True)
+
+        self.assertTrue(result)
+        mock_download_needed.assert_not_called()
+        mock_download_file.assert_called_once()
+
+    @patch.object(KaggleApi, "get_default_download_dir", return_value="/tmp/default")
+    @patch.object(KaggleApi, "download_needed", return_value=True)
+    @patch.object(KaggleApi, "download_file")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_dataset_download_file_default_path(self, mock_client, mock_download_file, mock_download_needed, mock_get_default_dir):
+        mock_kaggle = MagicMock()
+        mock_response = MagicMock()
+        mock_response.request.url = "http://example.com/download/testuser/test-dataset/file1.csv?token=123"
+        mock_kaggle.datasets.dataset_api_client.download_dataset.return_value = mock_response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        self.api.dataset_download_file("owner/my-dataset", "file1.csv")
+
+        mock_get_default_dir.assert_called_once_with("datasets", "owner", "my-dataset")
+        expected_outfile = os.path.join("/tmp/default", "file1.csv")
+        self.assertEqual(mock_download_file.call_args[0][1], expected_outfile)
+
+    @patch.object(KaggleApi, "download_needed", return_value=True)
+    @patch.object(KaggleApi, "download_file")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_dataset_download_file_no_owner(self, mock_client, mock_download_file, mock_download_needed):
+        mock_kaggle = MagicMock()
+        mock_response = MagicMock()
+        mock_response.request.url = "http://example.com/download/testuser/test-dataset/file1.csv?token=123"
+        mock_kaggle.datasets.dataset_api_client.download_dataset.return_value = mock_response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        self.api.dataset_download_file("my-dataset", "file1.csv", path="/tmp/download")
+
+        request = mock_kaggle.datasets.dataset_api_client.download_dataset.call_args[0][0]
+        self.assertEqual(request.owner_slug, "testuser")
+        self.assertEqual(request.dataset_slug, "my-dataset")
+
+    @patch.object(KaggleApi, "download_needed", return_value=True)
+    @patch.object(KaggleApi, "download_file")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_dataset_download_file_with_version(self, mock_client, mock_download_file, mock_download_needed):
+        mock_kaggle = MagicMock()
+        mock_response = MagicMock()
+        mock_response.request.url = "http://example.com/download/testuser/test-dataset/file1.csv?token=123"
+        mock_kaggle.datasets.dataset_api_client.download_dataset.return_value = mock_response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        self.api.dataset_download_file("owner/my-dataset/3", "file1.csv", path="/tmp/download")
+
+        request = mock_kaggle.datasets.dataset_api_client.download_dataset.call_args[0][0]
+        self.assertEqual(request.owner_slug, "owner")
+        self.assertEqual(request.dataset_slug, "my-dataset")
+        self.assertEqual(request.dataset_version_number, 3)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_dataset_list.py
+++ b/tests/unit/test_dataset_list.py
@@ -83,7 +83,7 @@ class TestDatasetList(unittest.TestCase):
 
         mock_kaggle.datasets.dataset_api_client.list_datasets.assert_called_once()
         request = mock_kaggle.datasets.dataset_api_client.list_datasets.call_args[0][0]
-        
+
         self.assertEqual(request.group, DatasetSelectionGroup.DATASET_SELECTION_GROUP_PUBLIC)
         self.assertEqual(request.sort_by, DatasetSortBy.DATASET_SORT_BY_HOTTEST)
         self.assertEqual(request.file_type, DatasetFileTypeGroup.DATASET_FILE_TYPE_GROUP_ALL)
@@ -119,7 +119,7 @@ class TestDatasetList(unittest.TestCase):
 
         mock_kaggle.datasets.dataset_api_client.list_datasets.assert_called_once()
         request = mock_kaggle.datasets.dataset_api_client.list_datasets.call_args[0][0]
-        
+
         self.assertEqual(request.group, DatasetSelectionGroup.DATASET_SELECTION_GROUP_PUBLIC)
         self.assertEqual(request.sort_by, DatasetSortBy.DATASET_SORT_BY_VOTES)
         self.assertEqual(request.file_type, DatasetFileTypeGroup.DATASET_FILE_TYPE_GROUP_CSV)

--- a/tests/unit/test_dataset_list.py
+++ b/tests/unit/test_dataset_list.py
@@ -22,37 +22,37 @@ class TestDatasetList(unittest.TestCase):
         self.api = KaggleApi.__new__(KaggleApi)
         self.api.already_printed_version_warning = True
 
-    def test_dataset_list_with_response_invalid_sort_by(self):
+    def test_dataset_list_with_response_invalid_sort_by_fails(self):
         with self.assertRaises(ValueError) as context:
             self.api.dataset_list_with_response(sort_by="invalid")
         self.assertIn("Invalid sort by specified", str(context.exception))
 
-    def test_dataset_list_with_response_deprecated_size(self):
+    def test_dataset_list_with_response_deprecated_size_fails(self):
         with self.assertRaises(ValueError) as context:
             self.api.dataset_list_with_response(size="small")
         self.assertIn("The --size parameter has been deprecated", str(context.exception))
 
-    def test_dataset_list_with_response_invalid_file_type(self):
+    def test_dataset_list_with_response_invalid_file_type_fails(self):
         with self.assertRaises(ValueError) as context:
             self.api.dataset_list_with_response(file_type="invalid")
         self.assertIn("Invalid file type specified", str(context.exception))
 
-    def test_dataset_list_with_response_invalid_license_name(self):
+    def test_dataset_list_with_response_invalid_license_name_fails(self):
         with self.assertRaises(ValueError) as context:
             self.api.dataset_list_with_response(license_name="invalid")
         self.assertIn("Invalid license specified", str(context.exception))
 
-    def test_dataset_list_with_response_invalid_page(self):
+    def test_dataset_list_with_response_invalid_page_fails(self):
         with self.assertRaises(ValueError) as context:
             self.api.dataset_list_with_response(page=-1)
         self.assertIn("Page number must be >= 1", str(context.exception))
 
-    def test_dataset_list_with_response_invalid_size_range(self):
+    def test_dataset_list_with_response_invalid_size_range_fails(self):
         with self.assertRaises(ValueError) as context:
             self.api.dataset_list_with_response(max_size="100", min_size="200")
         self.assertIn("Max Size must be max_size >= min_size", str(context.exception))
 
-    def test_dataset_list_with_response_invalid_max_size(self):
+    def test_dataset_list_with_response_invalid_max_size_fails(self):
         with self.assertRaises(ValueError) as context:
             self.api.dataset_list_with_response(max_size="0")
         self.assertIn("Max Size must be > 0", str(context.exception))
@@ -61,18 +61,18 @@ class TestDatasetList(unittest.TestCase):
             self.api.dataset_list_with_response(max_size="-10")
         self.assertIn("Max Size must be > 0", str(context.exception))
 
-    def test_dataset_list_with_response_invalid_min_size(self):
+    def test_dataset_list_with_response_invalid_min_size_fails(self):
         with self.assertRaises(ValueError) as context:
             self.api.dataset_list_with_response(min_size="-5")
         self.assertIn("Min Size must be >= 0", str(context.exception))
 
-    def test_dataset_list_with_response_mine_and_user_conflict(self):
+    def test_dataset_list_with_response_mine_and_user_conflict_fails(self):
         with self.assertRaises(ValueError) as context:
             self.api.dataset_list_with_response(mine=True, user="someuser")
         self.assertIn("Cannot specify both mine and a user", str(context.exception))
 
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_dataset_list_with_response_success_defaults(self, mock_client):
+    def test_dataset_list_with_response_defaults_succeeds(self, mock_client):
         mock_kaggle = MagicMock()
         mock_response = ApiListDatasetsResponse()
         mock_kaggle.datasets.dataset_api_client.list_datasets.return_value = mock_response
@@ -99,7 +99,7 @@ class TestDatasetList(unittest.TestCase):
         self.assertEqual(response, mock_response)
 
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_dataset_list_with_response_success_custom_filters(self, mock_client):
+    def test_dataset_list_with_response_custom_filters_succeeds(self, mock_client):
         mock_kaggle = MagicMock()
         mock_response = ApiListDatasetsResponse()
         mock_kaggle.datasets.dataset_api_client.list_datasets.return_value = mock_response
@@ -134,7 +134,7 @@ class TestDatasetList(unittest.TestCase):
         self.assertEqual(response, mock_response)
 
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_dataset_list_with_response_success_mine(self, mock_client):
+    def test_dataset_list_with_response_mine_succeeds(self, mock_client):
         mock_kaggle = MagicMock()
         mock_kaggle.datasets.dataset_api_client.list_datasets.return_value = ApiListDatasetsResponse()
         mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
@@ -146,7 +146,7 @@ class TestDatasetList(unittest.TestCase):
         self.assertEqual(request.group, DatasetSelectionGroup.DATASET_SELECTION_GROUP_MY)
 
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_dataset_list_with_response_success_user(self, mock_client):
+    def test_dataset_list_with_response_user_succeeds(self, mock_client):
         mock_kaggle = MagicMock()
         mock_kaggle.datasets.dataset_api_client.list_datasets.return_value = ApiListDatasetsResponse()
         mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
@@ -159,7 +159,7 @@ class TestDatasetList(unittest.TestCase):
         self.assertEqual(request.user, "someuser")
 
     @patch.object(KaggleApi, "dataset_list_with_response")
-    def test_dataset_list_wrapper(self, mock_list_with_response):
+    def test_dataset_list_wrapper_succeeds(self, mock_list_with_response):
         mock_response = MagicMock()
         mock_datasets = [MagicMock(), MagicMock()]
         mock_response.datasets = mock_datasets
@@ -183,13 +183,13 @@ class TestDatasetList(unittest.TestCase):
         self.assertEqual(result, mock_datasets)
 
     @patch.object(KaggleApi, "dataset_list_with_response")
-    def test_dataset_list_wrapper_returns_none(self, mock_list_with_response):
+    def test_dataset_list_wrapper_empty_response_returns_none(self, mock_list_with_response):
         mock_list_with_response.return_value = None
         result = self.api.dataset_list()
         self.assertIsNone(result)
 
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_dataset_list_with_response_success_page_token(self, mock_client):
+    def test_dataset_list_with_response_page_token_succeeds(self, mock_client):
         mock_kaggle = MagicMock()
         mock_kaggle.datasets.dataset_api_client.list_datasets.return_value = ApiListDatasetsResponse()
         mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)

--- a/tests/unit/test_dataset_list.py
+++ b/tests/unit/test_dataset_list.py
@@ -1,0 +1,205 @@
+# coding=utf-8
+import unittest
+from unittest.mock import MagicMock, patch
+import sys
+
+sys.path.insert(0, "../..")
+
+from kaggle.api.kaggle_api_extended import KaggleApi
+from kagglesdk.datasets.types.dataset_enums import (
+    DatasetSelectionGroup,
+    DatasetSortBy,
+    DatasetFileTypeGroup,
+    DatasetLicenseGroup,
+)
+from kagglesdk.datasets.types.dataset_api_service import ApiListDatasetsResponse
+
+
+class TestDatasetList(unittest.TestCase):
+    """Tests for dataset_list and dataset_list_with_response."""
+
+    def setUp(self):
+        self.api = KaggleApi.__new__(KaggleApi)
+        self.api.already_printed_version_warning = True
+
+    def test_dataset_list_with_response_invalid_sort_by(self):
+        with self.assertRaises(ValueError) as context:
+            self.api.dataset_list_with_response(sort_by="invalid")
+        self.assertIn("Invalid sort by specified", str(context.exception))
+
+    def test_dataset_list_with_response_deprecated_size(self):
+        with self.assertRaises(ValueError) as context:
+            self.api.dataset_list_with_response(size="small")
+        self.assertIn("The --size parameter has been deprecated", str(context.exception))
+
+    def test_dataset_list_with_response_invalid_file_type(self):
+        with self.assertRaises(ValueError) as context:
+            self.api.dataset_list_with_response(file_type="invalid")
+        self.assertIn("Invalid file type specified", str(context.exception))
+
+    def test_dataset_list_with_response_invalid_license_name(self):
+        with self.assertRaises(ValueError) as context:
+            self.api.dataset_list_with_response(license_name="invalid")
+        self.assertIn("Invalid license specified", str(context.exception))
+
+    def test_dataset_list_with_response_invalid_page(self):
+        with self.assertRaises(ValueError) as context:
+            self.api.dataset_list_with_response(page=-1)
+        self.assertIn("Page number must be >= 1", str(context.exception))
+
+    def test_dataset_list_with_response_invalid_size_range(self):
+        with self.assertRaises(ValueError) as context:
+            self.api.dataset_list_with_response(max_size="100", min_size="200")
+        self.assertIn("Max Size must be max_size >= min_size", str(context.exception))
+
+    def test_dataset_list_with_response_invalid_max_size(self):
+        with self.assertRaises(ValueError) as context:
+            self.api.dataset_list_with_response(max_size="0")
+        self.assertIn("Max Size must be > 0", str(context.exception))
+
+        with self.assertRaises(ValueError) as context:
+            self.api.dataset_list_with_response(max_size="-10")
+        self.assertIn("Max Size must be > 0", str(context.exception))
+
+    def test_dataset_list_with_response_invalid_min_size(self):
+        with self.assertRaises(ValueError) as context:
+            self.api.dataset_list_with_response(min_size="-5")
+        self.assertIn("Min Size must be >= 0", str(context.exception))
+
+    def test_dataset_list_with_response_mine_and_user_conflict(self):
+        with self.assertRaises(ValueError) as context:
+            self.api.dataset_list_with_response(mine=True, user="someuser")
+        self.assertIn("Cannot specify both mine and a user", str(context.exception))
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_dataset_list_with_response_success_defaults(self, mock_client):
+        mock_kaggle = MagicMock()
+        mock_response = ApiListDatasetsResponse()
+        mock_kaggle.datasets.dataset_api_client.list_datasets.return_value = mock_response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        response = self.api.dataset_list_with_response()
+
+        mock_kaggle.datasets.dataset_api_client.list_datasets.assert_called_once()
+        request = mock_kaggle.datasets.dataset_api_client.list_datasets.call_args[0][0]
+        
+        self.assertEqual(request.group, DatasetSelectionGroup.DATASET_SELECTION_GROUP_PUBLIC)
+        self.assertEqual(request.sort_by, DatasetSortBy.DATASET_SORT_BY_HOTTEST)
+        self.assertEqual(request.file_type, DatasetFileTypeGroup.DATASET_FILE_TYPE_GROUP_ALL)
+        self.assertEqual(request.license, DatasetLicenseGroup.DATASET_LICENSE_GROUP_ALL)
+        self.assertEqual(request.tag_ids, "")
+        self.assertEqual(request.search, "")
+        self.assertEqual(request.user, "")
+        self.assertEqual(request.page, 1)
+        self.assertEqual(request.page_size, 20)
+        # Proto3 defaults to 0 for unset int fields when accessed in Python
+        self.assertEqual(request.max_size, 0)
+        self.assertEqual(request.min_size, 0)
+        self.assertEqual(response, mock_response)
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_dataset_list_with_response_success_custom_filters(self, mock_client):
+        mock_kaggle = MagicMock()
+        mock_response = ApiListDatasetsResponse()
+        mock_kaggle.datasets.dataset_api_client.list_datasets.return_value = mock_response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        response = self.api.dataset_list_with_response(
+            sort_by="votes",
+            file_type="csv",
+            license_name="cc",
+            tag_ids="tag1,tag2",
+            search="my search",
+            page=2,
+            max_size="1000",
+            min_size="10",
+        )
+
+        mock_kaggle.datasets.dataset_api_client.list_datasets.assert_called_once()
+        request = mock_kaggle.datasets.dataset_api_client.list_datasets.call_args[0][0]
+        
+        self.assertEqual(request.group, DatasetSelectionGroup.DATASET_SELECTION_GROUP_PUBLIC)
+        self.assertEqual(request.sort_by, DatasetSortBy.DATASET_SORT_BY_VOTES)
+        self.assertEqual(request.file_type, DatasetFileTypeGroup.DATASET_FILE_TYPE_GROUP_CSV)
+        self.assertEqual(request.license, DatasetLicenseGroup.DATASET_LICENSE_GROUP_CC)
+        self.assertEqual(request.tag_ids, "tag1,tag2")
+        self.assertEqual(request.search, "my search")
+        self.assertEqual(request.user, "")
+        self.assertEqual(request.page, 2)
+        self.assertEqual(request.page_size, 20)
+        self.assertEqual(request.max_size, 1000)
+        self.assertEqual(request.min_size, 10)
+        self.assertEqual(response, mock_response)
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_dataset_list_with_response_success_mine(self, mock_client):
+        mock_kaggle = MagicMock()
+        mock_kaggle.datasets.dataset_api_client.list_datasets.return_value = ApiListDatasetsResponse()
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        self.api.dataset_list_with_response(mine=True)
+
+        request = mock_kaggle.datasets.dataset_api_client.list_datasets.call_args[0][0]
+        self.assertEqual(request.group, DatasetSelectionGroup.DATASET_SELECTION_GROUP_MY)
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_dataset_list_with_response_success_user(self, mock_client):
+        mock_kaggle = MagicMock()
+        mock_kaggle.datasets.dataset_api_client.list_datasets.return_value = ApiListDatasetsResponse()
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        self.api.dataset_list_with_response(user="someuser")
+
+        request = mock_kaggle.datasets.dataset_api_client.list_datasets.call_args[0][0]
+        self.assertEqual(request.group, DatasetSelectionGroup.DATASET_SELECTION_GROUP_USER)
+        self.assertEqual(request.user, "someuser")
+
+    @patch.object(KaggleApi, "dataset_list_with_response")
+    def test_dataset_list_wrapper(self, mock_list_with_response):
+        mock_response = MagicMock()
+        mock_datasets = [MagicMock(), MagicMock()]
+        mock_response.datasets = mock_datasets
+        mock_list_with_response.return_value = mock_response
+
+        result = self.api.dataset_list(sort_by="votes", search="test")
+
+        mock_list_with_response.assert_called_once_with(
+            sort_by="votes",
+            size=None,
+            file_type=None,
+            license_name=None,
+            tag_ids=None,
+            search="test",
+            user=None,
+            mine=False,
+            page=1,
+            max_size=None,
+            min_size=None,
+        )
+        self.assertEqual(result, mock_datasets)
+
+    @patch.object(KaggleApi, "dataset_list_with_response")
+    def test_dataset_list_wrapper_returns_none(self, mock_list_with_response):
+        mock_list_with_response.return_value = None
+        result = self.api.dataset_list()
+        self.assertIsNone(result)
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_dataset_list_with_response_success_page_token(self, mock_client):
+        mock_kaggle = MagicMock()
+        mock_kaggle.datasets.dataset_api_client.list_datasets.return_value = ApiListDatasetsResponse()
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        self.api.dataset_list_with_response(page_token="token123")
+
+        request = mock_kaggle.datasets.dataset_api_client.list_datasets.call_args[0][0]
+        self.assertEqual(request.page_token, "token123")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_dataset_metadata_update.py
+++ b/tests/unit/test_dataset_metadata_update.py
@@ -131,10 +131,7 @@ class TestDatasetMetadataUpdate(unittest.TestCase):
     @patch.object(KaggleApi, "_upload_file")
     @patch.object(KaggleApi, "build_kaggle_client")
     def test_metadata_update_with_image(self, mock_build, mock_upload_file):
-        metadata = {
-            "title": "New Title",
-            "image": "cover.png"
-        }
+        metadata = {"title": "New Title", "image": "cover.png"}
         meta_file = os.path.join(self.temp_dir, "dataset-metadata.json")
         with open(meta_file, "w") as f:
             json.dump(metadata, f)
@@ -170,9 +167,7 @@ class TestDatasetMetadataUpdate(unittest.TestCase):
         self.assertEqual(call_args.settings.image.crop_rectangles[1].title, "thumbnail")
 
     def test_metadata_update_with_image_file_not_found(self):
-        metadata = {
-            "image": "non-existent.png"
-        }
+        metadata = {"image": "non-existent.png"}
         meta_file = os.path.join(self.temp_dir, "dataset-metadata.json")
         with open(meta_file, "w") as f:
             json.dump(metadata, f)
@@ -182,9 +177,7 @@ class TestDatasetMetadataUpdate(unittest.TestCase):
         self.assertIn("Image file was not found", str(context.exception))
 
     def test_metadata_update_with_image_invalid_extension(self):
-        metadata = {
-            "image": "cover.txt"
-        }
+        metadata = {"image": "cover.txt"}
         meta_file = os.path.join(self.temp_dir, "dataset-metadata.json")
         with open(meta_file, "w") as f:
             json.dump(metadata, f)
@@ -199,9 +192,7 @@ class TestDatasetMetadataUpdate(unittest.TestCase):
     @patch.object(KaggleApi, "_upload_file", return_value=None)
     @patch.object(KaggleApi, "build_kaggle_client")
     def test_metadata_update_with_image_upload_failure(self, mock_build, mock_upload_file):
-        metadata = {
-            "image": "cover.png"
-        }
+        metadata = {"image": "cover.png"}
         meta_file = os.path.join(self.temp_dir, "dataset-metadata.json")
         with open(meta_file, "w") as f:
             json.dump(metadata, f)

--- a/tests/unit/test_dataset_metadata_update.py
+++ b/tests/unit/test_dataset_metadata_update.py
@@ -128,6 +128,91 @@ class TestDatasetMetadataUpdate(unittest.TestCase):
         processed = self.api.process_column(col_dict)
         self.assertEqual(processed.description, "desc")
 
+    @patch.object(KaggleApi, "_upload_file")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_metadata_update_with_image(self, mock_build, mock_upload_file):
+        metadata = {
+            "title": "New Title",
+            "image": "cover.png"
+        }
+        meta_file = os.path.join(self.temp_dir, "dataset-metadata.json")
+        with open(meta_file, "w") as f:
+            json.dump(metadata, f)
+
+        image_file = os.path.join(self.temp_dir, "cover.png")
+        open(image_file, "w").close()
+
+        mock_upload_file_result = MagicMock()
+        mock_upload_file_result.token = "image-token-123"
+        mock_upload_file.return_value = mock_upload_file_result
+
+        mock_kaggle = MagicMock()
+        mock_response = MagicMock()
+        mock_response.errors = []
+        mock_kaggle.datasets.dataset_api_client.update_dataset_metadata.return_value = mock_response
+        mock_build.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_build.return_value.__exit__ = MagicMock(return_value=False)
+
+        self.api.dataset_metadata_update("owner/dataset", self.temp_dir)
+
+        mock_upload_file.assert_called_once()
+        self.assertEqual(mock_upload_file.call_args[0][0], "cover.png")
+        self.assertEqual(mock_upload_file.call_args[0][1], image_file)
+
+        mock_kaggle.datasets.dataset_api_client.update_dataset_metadata.assert_called_once()
+        call_args = mock_kaggle.datasets.dataset_api_client.update_dataset_metadata.call_args[0][0]
+        self.assertIsInstance(call_args, ApiUpdateDatasetMetadataRequest)
+        self.assertEqual(call_args.settings.title, "New Title")
+        self.assertIsNotNone(call_args.settings.image)
+        self.assertEqual(call_args.settings.image.token, "image-token-123")
+        self.assertEqual(len(call_args.settings.image.crop_rectangles), 2)
+        self.assertEqual(call_args.settings.image.crop_rectangles[0].title, "cover image")
+        self.assertEqual(call_args.settings.image.crop_rectangles[1].title, "thumbnail")
+
+    def test_metadata_update_with_image_file_not_found(self):
+        metadata = {
+            "image": "non-existent.png"
+        }
+        meta_file = os.path.join(self.temp_dir, "dataset-metadata.json")
+        with open(meta_file, "w") as f:
+            json.dump(metadata, f)
+
+        with self.assertRaises(ValueError) as context:
+            self.api.dataset_metadata_update("owner/dataset", self.temp_dir)
+        self.assertIn("Image file was not found", str(context.exception))
+
+    def test_metadata_update_with_image_invalid_extension(self):
+        metadata = {
+            "image": "cover.txt"
+        }
+        meta_file = os.path.join(self.temp_dir, "dataset-metadata.json")
+        with open(meta_file, "w") as f:
+            json.dump(metadata, f)
+
+        image_file = os.path.join(self.temp_dir, "cover.txt")
+        open(image_file, "w").close()
+
+        with self.assertRaises(ValueError) as context:
+            self.api.dataset_metadata_update("owner/dataset", self.temp_dir)
+        self.assertIn("Image file requires an extension of", str(context.exception))
+
+    @patch.object(KaggleApi, "_upload_file", return_value=None)
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_metadata_update_with_image_upload_failure(self, mock_build, mock_upload_file):
+        metadata = {
+            "image": "cover.png"
+        }
+        meta_file = os.path.join(self.temp_dir, "dataset-metadata.json")
+        with open(meta_file, "w") as f:
+            json.dump(metadata, f)
+
+        image_file = os.path.join(self.temp_dir, "cover.png")
+        open(image_file, "w").close()
+
+        with self.assertRaises(ValueError) as context:
+            self.api.dataset_metadata_update("owner/dataset", self.temp_dir)
+        self.assertIn("Error uploading image file", str(context.exception))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_dataset_metadata_update.py
+++ b/tests/unit/test_dataset_metadata_update.py
@@ -31,7 +31,7 @@ class TestDatasetMetadataUpdate(unittest.TestCase):
         shutil.rmtree(self.temp_dir)
 
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_metadata_update_with_data(self, mock_build):
+    def test_metadata_update_with_data_succeeds(self, mock_build):
         # Prepare metadata file with 'data'
         metadata = {
             "title": "New Title",
@@ -69,7 +69,7 @@ class TestDatasetMetadataUpdate(unittest.TestCase):
         self.assertEqual(call_args.settings.data[0].columns[0].description, "col1 desc")
 
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_metadata_update_with_resources(self, mock_build):
+    def test_metadata_update_with_resources_succeeds(self, mock_build):
         # Prepare metadata file with 'resources'
         metadata = {
             "title": "New Title",
@@ -113,24 +113,24 @@ class TestDatasetMetadataUpdate(unittest.TestCase):
         self.assertEqual(call_args.settings.data[0].columns[1].name, "col2")
         self.assertEqual(call_args.settings.data[0].columns[1].description, "col2 desc")  # title mapped to description
 
-    def test_process_column_description(self):
+    def test_process_column_has_description_uses_description(self):
         col_dict = {"name": "col", "description": "desc", "type": "string"}
         processed = self.api.process_column(col_dict)
         self.assertEqual(processed.description, "desc")
 
-    def test_process_column_title_fallback(self):
+    def test_process_column_has_title_only_falls_back_to_title(self):
         col_dict = {"name": "col", "title": "desc", "type": "string"}
         processed = self.api.process_column(col_dict)
         self.assertEqual(processed.description, "desc")
 
-    def test_process_column_both_prefer_description(self):
+    def test_process_column_has_both_prefers_description(self):
         col_dict = {"name": "col", "description": "desc", "title": "ignored", "type": "string"}
         processed = self.api.process_column(col_dict)
         self.assertEqual(processed.description, "desc")
 
     @patch.object(KaggleApi, "_upload_file")
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_metadata_update_with_image(self, mock_build, mock_upload_file):
+    def test_metadata_update_with_image_succeeds(self, mock_build, mock_upload_file):
         metadata = {"title": "New Title", "image": "cover.png"}
         meta_file = os.path.join(self.temp_dir, "dataset-metadata.json")
         with open(meta_file, "w") as f:
@@ -166,7 +166,7 @@ class TestDatasetMetadataUpdate(unittest.TestCase):
         self.assertEqual(call_args.settings.image.crop_rectangles[0].title, "cover image")
         self.assertEqual(call_args.settings.image.crop_rectangles[1].title, "thumbnail")
 
-    def test_metadata_update_with_image_file_not_found(self):
+    def test_metadata_update_with_image_file_not_found_fails(self):
         metadata = {"image": "non-existent.png"}
         meta_file = os.path.join(self.temp_dir, "dataset-metadata.json")
         with open(meta_file, "w") as f:
@@ -176,7 +176,7 @@ class TestDatasetMetadataUpdate(unittest.TestCase):
             self.api.dataset_metadata_update("owner/dataset", self.temp_dir)
         self.assertIn("Image file was not found", str(context.exception))
 
-    def test_metadata_update_with_image_invalid_extension(self):
+    def test_metadata_update_with_image_invalid_extension_fails(self):
         metadata = {"image": "cover.txt"}
         meta_file = os.path.join(self.temp_dir, "dataset-metadata.json")
         with open(meta_file, "w") as f:
@@ -191,7 +191,7 @@ class TestDatasetMetadataUpdate(unittest.TestCase):
 
     @patch.object(KaggleApi, "_upload_file", return_value=None)
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_metadata_update_with_image_upload_failure(self, mock_build, mock_upload_file):
+    def test_metadata_update_with_image_upload_failure_fails(self, mock_build, mock_upload_file):
         metadata = {"image": "cover.png"}
         meta_file = os.path.join(self.temp_dir, "dataset-metadata.json")
         with open(meta_file, "w") as f:


### PR DESCRIPTION
test: improve coverage for Datasets API (Phase 1)

Added unit tests for:
- dataset_create_new (validation, duplicate checks, success paths)
- dataset_create_version (validation, slug/ID routing, success paths)
- dataset_list_with_response (filters, pagination, validation)
- dataset_download_file (argument parsing, path resolution, force download)
- _upload_dataset_image_file helper (via metadata update tests)

Improves kaggle_api_extended.py coverage by ~5% (+250 lines).

TAG=agy
CONV=c0cb1f34-2aad-4606-a254-bd3618cb845f
