### PR TITLE
test: improve coverage for Models API (Phase 2)

### DIFF
--- a/tests/unit/test_model_create.py
+++ b/tests/unit/test_model_create.py
@@ -142,7 +142,7 @@ class TestModelCreate(unittest.TestCase):
             request = mock_kaggle.models.model_api_client.create_model_instance.call_args[0][0]
             self.assertEqual(request.owner_slug, "testuser")
             self.assertEqual(request.model_slug, "test-model")
-            
+
             body = request.body
             self.assertEqual(body.framework, ModelFramework.MODEL_FRAMEWORK_KERAS)
             self.assertEqual(body.instance_slug, "test-instance")
@@ -240,7 +240,7 @@ class TestModelCreate(unittest.TestCase):
             self.assertEqual(response, mock_response)
             mock_kaggle.models.model_api_client.update_model_instance.assert_called_once()
             request = mock_kaggle.models.model_api_client.update_model_instance.call_args[0][0]
-            
+
             self.assertEqual(request.owner_slug, "testuser")
             self.assertEqual(request.model_slug, "test-model")
             self.assertEqual(request.framework, ModelFramework.MODEL_FRAMEWORK_KERAS)
@@ -253,7 +253,7 @@ class TestModelCreate(unittest.TestCase):
             self.assertEqual(request.model_instance_type, ModelInstanceType.MODEL_INSTANCE_TYPE_KAGGLE_VARIANT)
             self.assertEqual(request.base_model_instance, "new-base")
             self.assertEqual(request.external_base_model_url, "http://new-example.com")
-            
+
             # Verify update_mask (expected to be None due to bug, see Task 5.2)
             self.assertIsNone(request.update_mask)
 
@@ -274,12 +274,12 @@ class TestModelCreate(unittest.TestCase):
             self.api.model_instance_update(tmpdir)
 
             request = mock_kaggle.models.model_api_client.update_model_instance.call_args[0][0]
-            
+
             self.assertEqual(request.overview, "Updated overview")
             self.assertEqual(request.usage, "Updated usage")
             self.assertFalse(request.fine_tunable)
-            self.assertEqual(request.license_name, "Apache 2.0") 
-            
+            self.assertEqual(request.license_name, "Apache 2.0")
+
             # Verify update_mask (expected to be None due to bug, see Task 5.2)
             self.assertIsNone(request.update_mask)
 
@@ -434,7 +434,7 @@ class TestModelCreate(unittest.TestCase):
             self.assertEqual(response, mock_response)
             mock_kaggle.models.model_api_client.update_model.assert_called_once()
             request = mock_kaggle.models.model_api_client.update_model.call_args[0][0]
-            
+
             self.assertEqual(request.owner_slug, "testuser")
             self.assertEqual(request.model_slug, "test-model")
             self.assertEqual(request.title, "Updated Model Title")
@@ -442,8 +442,8 @@ class TestModelCreate(unittest.TestCase):
             self.assertFalse(request.is_private)
             self.assertEqual(request.description, "Updated description")
             self.assertIsNone(request.publish_time)
-            self.assertEqual(request.provenance_sources, '')
-            
+            self.assertEqual(request.provenance_sources, "")
+
             # Verify update_mask (expected to be None due to bug, see Task 5.2)
             self.assertIsNone(request.update_mask)
 
@@ -465,12 +465,12 @@ class TestModelCreate(unittest.TestCase):
             self.api.model_update(tmpdir)
 
             request = mock_kaggle.models.model_api_client.update_model.call_args[0][0]
-            
+
             self.assertEqual(request.title, "Updated Title")
-            self.assertEqual(request.subtitle, '')
+            self.assertEqual(request.subtitle, "")
             self.assertTrue(request.is_private)
-            self.assertEqual(request.description, '')
-            
+            self.assertEqual(request.description, "")
+
             self.assertIsNone(request.update_mask)
 
 

--- a/tests/unit/test_model_create.py
+++ b/tests/unit/test_model_create.py
@@ -1,0 +1,478 @@
+# coding=utf-8
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+import sys
+
+sys.path.insert(0, "../..")
+
+from kaggle.api.kaggle_api_extended import KaggleApi
+from kagglesdk.models.types.model_enums import ModelFramework, ModelInstanceType
+from kagglesdk.models.types.model_api_service import (
+    ApiCreateModelResponse,
+    ApiCreateModelRequest,
+    ApiUpdateModelRequest,
+)
+from kagglesdk.blobs.types.blob_api_service import ApiBlobType
+
+
+class TestModelCreate(unittest.TestCase):
+    """Tests for model_instance_create and model_instance_update."""
+
+    def setUp(self):
+        self.api = KaggleApi.__new__(KaggleApi)
+        self.api.config_values = {"username": "testuser"}
+        self.api.already_printed_version_warning = True
+
+    def _get_valid_instance_metadata(self):
+        return {
+            "ownerSlug": "testuser",
+            "modelSlug": "test-model",
+            "instanceSlug": "test-instance",
+            "framework": "keras",
+            "licenseName": "Apache 2.0",
+        }
+
+    def _write_metadata(self, folder, metadata, filename="model-instance-metadata.json"):
+        meta_file_path = os.path.join(folder, filename)
+        with open(meta_file_path, "w", encoding="utf-8") as f:
+            json.dump(metadata, f)
+
+    def test_model_instance_create_invalid_folder(self):
+        with self.assertRaises(ValueError) as context:
+            self.api.model_instance_create("/non/existent/folder")
+        self.assertIn("Invalid folder", str(context.exception))
+
+    def test_model_instance_create_default_owner(self):
+        metadata = self._get_valid_instance_metadata()
+        metadata["ownerSlug"] = "INSERT_OWNER_SLUG_HERE"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            with self.assertRaises(ValueError) as context:
+                self.api.model_instance_create(tmpdir)
+            self.assertIn("Default ownerSlug detected", str(context.exception))
+
+    def test_model_instance_create_default_model_slug(self):
+        metadata = self._get_valid_instance_metadata()
+        metadata["modelSlug"] = "INSERT_EXISTING_MODEL_SLUG_HERE"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            with self.assertRaises(ValueError) as context:
+                self.api.model_instance_create(tmpdir)
+            self.assertIn("Default modelSlug detected", str(context.exception))
+
+    def test_model_instance_create_default_instance_slug(self):
+        metadata = self._get_valid_instance_metadata()
+        metadata["instanceSlug"] = "INSERT_INSTANCE_SLUG_HERE"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            with self.assertRaises(ValueError) as context:
+                self.api.model_instance_create(tmpdir)
+            self.assertIn("Default instanceSlug detected", str(context.exception))
+
+    def test_model_instance_create_default_framework(self):
+        metadata = self._get_valid_instance_metadata()
+        metadata["framework"] = "INSERT_FRAMEWORK_HERE"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            with self.assertRaises(ValueError) as context:
+                self.api.model_instance_create(tmpdir)
+            self.assertIn("Default framework detected", str(context.exception))
+
+    def test_model_instance_create_missing_license(self):
+        metadata = self._get_valid_instance_metadata()
+        metadata["licenseName"] = ""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            with self.assertRaises(ValueError) as context:
+                self.api.model_instance_create(tmpdir)
+            self.assertIn("Please specify a license", str(context.exception))
+
+    def test_model_instance_create_invalid_fine_tunable(self):
+        metadata = self._get_valid_instance_metadata()
+        metadata["fineTunable"] = "not-a-bool"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            with self.assertRaises(ValueError) as context:
+                self.api.model_instance_create(tmpdir)
+            self.assertIn("modelInstance.fineTunable must be a boolean", str(context.exception))
+
+    def test_model_instance_create_invalid_training_data(self):
+        metadata = self._get_valid_instance_metadata()
+        metadata["trainingData"] = "not-a-list"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            with self.assertRaises(ValueError) as context:
+                self.api.model_instance_create(tmpdir)
+            self.assertIn("modelInstance.trainingData must be a list", str(context.exception))
+
+    @patch.object(KaggleApi, "upload_files")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_model_instance_create_success(self, mock_client, mock_upload):
+        mock_kaggle = MagicMock()
+        mock_response = ApiCreateModelResponse()
+        mock_kaggle.models.model_api_client.create_model_instance.return_value = mock_response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        metadata = self._get_valid_instance_metadata()
+        metadata["overview"] = "My model overview"
+        metadata["usage"] = "My model usage"
+        metadata["fineTunable"] = True
+        metadata["trainingData"] = ["dataset1", "dataset2"]
+        metadata["modelInstanceType"] = "kaggleVariant"
+        metadata["baseModelInstance"] = "base-instance"
+        metadata["externalBaseModelUrl"] = "http://example.com"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            response = self.api.model_instance_create(tmpdir, quiet=True, dir_mode="zip")
+
+            self.assertEqual(response, mock_response)
+            mock_upload.assert_called_once()
+            call_args = mock_upload.call_args[0]
+            self.assertEqual(call_args[2], tmpdir)
+            self.assertEqual(call_args[3], ApiBlobType.MODEL)
+            self.assertTrue(call_args[5])
+            self.assertEqual(call_args[6], "zip")
+
+            mock_kaggle.models.model_api_client.create_model_instance.assert_called_once()
+            request = mock_kaggle.models.model_api_client.create_model_instance.call_args[0][0]
+            self.assertEqual(request.owner_slug, "testuser")
+            self.assertEqual(request.model_slug, "test-model")
+            
+            body = request.body
+            self.assertEqual(body.framework, ModelFramework.MODEL_FRAMEWORK_KERAS)
+            self.assertEqual(body.instance_slug, "test-instance")
+            self.assertEqual(body.overview, "My model overview")
+            self.assertEqual(body.usage, "My model usage")
+            self.assertEqual(body.license_name, "Apache 2.0")
+            self.assertTrue(body.fine_tunable)
+            self.assertEqual(body.fine_tunable, True)
+            self.assertEqual(body.training_data, ["dataset1", "dataset2"])
+            self.assertEqual(body.model_instance_type, ModelInstanceType.MODEL_INSTANCE_TYPE_KAGGLE_VARIANT)
+            self.assertEqual(body.base_model_instance, "base-instance")
+            self.assertEqual(body.external_base_model_url, "http://example.com")
+
+    def test_model_instance_update_invalid_folder(self):
+        with self.assertRaises(ValueError) as context:
+            self.api.model_instance_update("/non/existent/folder")
+        self.assertIn("Invalid folder", str(context.exception))
+
+    def test_model_instance_update_default_owner(self):
+        metadata = self._get_valid_instance_metadata()
+        metadata["ownerSlug"] = "INSERT_OWNER_SLUG_HERE"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            with self.assertRaises(ValueError) as context:
+                self.api.model_instance_update(tmpdir)
+            self.assertIn("Default ownerSlug detected", str(context.exception))
+
+    def test_model_instance_update_default_model_slug(self):
+        metadata = self._get_valid_instance_metadata()
+        metadata["modelSlug"] = "INSERT_SLUG_HERE"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            with self.assertRaises(ValueError) as context:
+                self.api.model_instance_update(tmpdir)
+            self.assertIn("Default model slug detected", str(context.exception))
+
+    def test_model_instance_update_default_instance_slug(self):
+        metadata = self._get_valid_instance_metadata()
+        metadata["instanceSlug"] = "INSERT_INSTANCE_SLUG_HERE"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            with self.assertRaises(ValueError) as context:
+                self.api.model_instance_update(tmpdir)
+            self.assertIn("Default instance slug detected", str(context.exception))
+
+    def test_model_instance_update_default_framework(self):
+        metadata = self._get_valid_instance_metadata()
+        metadata["framework"] = "INSERT_FRAMEWORK_HERE"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            with self.assertRaises(ValueError) as context:
+                self.api.model_instance_update(tmpdir)
+            self.assertIn("Default framework detected", str(context.exception))
+
+    def test_model_instance_update_invalid_fine_tunable(self):
+        metadata = self._get_valid_instance_metadata()
+        metadata["fineTunable"] = "not-a-bool"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            with self.assertRaises(ValueError) as context:
+                self.api.model_instance_update(tmpdir)
+            self.assertIn("modelInstance.fineTunable must be a boolean", str(context.exception))
+
+    def test_model_instance_update_invalid_training_data(self):
+        metadata = self._get_valid_instance_metadata()
+        metadata["trainingData"] = "not-a-list"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            with self.assertRaises(ValueError) as context:
+                self.api.model_instance_update(tmpdir)
+            self.assertIn("modelInstance.trainingData must be a list", str(context.exception))
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_model_instance_update_success_all_fields(self, mock_client):
+        mock_kaggle = MagicMock()
+        mock_response = MagicMock()
+        mock_kaggle.models.model_api_client.update_model_instance.return_value = mock_response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        metadata = self._get_valid_instance_metadata()
+        metadata["overview"] = "Updated overview"
+        metadata["usage"] = "Updated usage"
+        metadata["licenseName"] = "MIT"
+        metadata["fineTunable"] = True
+        metadata["trainingData"] = ["dataset3"]
+        metadata["modelInstanceType"] = "kaggleVariant"
+        metadata["baseModelInstance"] = "new-base"
+        metadata["externalBaseModelUrl"] = "http://new-example.com"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            response = self.api.model_instance_update(tmpdir)
+
+            self.assertEqual(response, mock_response)
+            mock_kaggle.models.model_api_client.update_model_instance.assert_called_once()
+            request = mock_kaggle.models.model_api_client.update_model_instance.call_args[0][0]
+            
+            self.assertEqual(request.owner_slug, "testuser")
+            self.assertEqual(request.model_slug, "test-model")
+            self.assertEqual(request.framework, ModelFramework.MODEL_FRAMEWORK_KERAS)
+            self.assertEqual(request.instance_slug, "test-instance")
+            self.assertEqual(request.overview, "Updated overview")
+            self.assertEqual(request.usage, "Updated usage")
+            self.assertEqual(request.license_name, "MIT")
+            self.assertEqual(request.fine_tunable, True)
+            self.assertEqual(request.training_data, ["dataset3"])
+            self.assertEqual(request.model_instance_type, ModelInstanceType.MODEL_INSTANCE_TYPE_KAGGLE_VARIANT)
+            self.assertEqual(request.base_model_instance, "new-base")
+            self.assertEqual(request.external_base_model_url, "http://new-example.com")
+            
+            # Verify update_mask (expected to be None due to bug, see Task 5.2)
+            self.assertIsNone(request.update_mask)
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_model_instance_update_success_partial(self, mock_client):
+        mock_kaggle = MagicMock()
+        mock_kaggle.models.model_api_client.update_model_instance.return_value = MagicMock()
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        metadata = self._get_valid_instance_metadata()
+        del metadata["licenseName"]
+        metadata["overview"] = "Updated overview"
+        metadata["usage"] = "Updated usage"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            self.api.model_instance_update(tmpdir)
+
+            request = mock_kaggle.models.model_api_client.update_model_instance.call_args[0][0]
+            
+            self.assertEqual(request.overview, "Updated overview")
+            self.assertEqual(request.usage, "Updated usage")
+            self.assertFalse(request.fine_tunable)
+            self.assertEqual(request.license_name, "Apache 2.0") 
+            
+            # Verify update_mask (expected to be None due to bug, see Task 5.2)
+            self.assertIsNone(request.update_mask)
+
+    def _get_valid_model_metadata(self):
+        return {
+            "ownerSlug": "testuser",
+            "slug": "test-model",
+            "title": "Test Model Title",
+            "isPrivate": True,
+            "description": "Test model description",
+        }
+
+    def test_model_create_new_invalid_folder(self):
+        with self.assertRaises(ValueError) as context:
+            self.api.model_create_new("/non/existent/folder")
+        self.assertIn("Invalid folder", str(context.exception))
+
+    def test_model_create_new_default_owner(self):
+        metadata = self._get_valid_model_metadata()
+        metadata["ownerSlug"] = "INSERT_OWNER_SLUG_HERE"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata, "model-metadata.json")
+            with self.assertRaises(ValueError) as context:
+                self.api.model_create_new(tmpdir)
+            self.assertIn("Default ownerSlug detected", str(context.exception))
+
+    def test_model_create_new_default_title(self):
+        metadata = self._get_valid_model_metadata()
+        metadata["title"] = "INSERT_TITLE_HERE"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata, "model-metadata.json")
+            with self.assertRaises(ValueError) as context:
+                self.api.model_create_new(tmpdir)
+            self.assertIn("Default title detected", str(context.exception))
+
+    def test_model_create_new_default_slug(self):
+        metadata = self._get_valid_model_metadata()
+        metadata["slug"] = "INSERT_SLUG_HERE"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata, "model-metadata.json")
+            with self.assertRaises(ValueError) as context:
+                self.api.model_create_new(tmpdir)
+            self.assertIn("Default slug detected", str(context.exception))
+
+    def test_model_create_new_invalid_is_private(self):
+        metadata = self._get_valid_model_metadata()
+        metadata["isPrivate"] = "not-a-bool"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata, "model-metadata.json")
+            with self.assertRaises(ValueError) as context:
+                self.api.model_create_new(tmpdir)
+            self.assertIn("model.isPrivate must be a boolean", str(context.exception))
+
+    def test_model_create_new_invalid_publish_time(self):
+        metadata = self._get_valid_model_metadata()
+        metadata["publishTime"] = "invalid-date"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata, "model-metadata.json")
+            with self.assertRaises(ValueError) as context:
+                self.api.model_create_new(tmpdir)
+            self.assertIn("does not match format", str(context.exception))
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_model_create_new_success(self, mock_client):
+        mock_kaggle = MagicMock()
+        mock_response = ApiCreateModelResponse()
+        mock_kaggle.models.model_api_client.create_model.return_value = mock_response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        metadata = self._get_valid_model_metadata()
+        metadata["subtitle"] = "Valid subtitle"
+        metadata["provenanceSources"] = "source1"
+        # publishTime is omitted due to Bug, see Task 5.3
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata, "model-metadata.json")
+            response = self.api.model_create_new(tmpdir)
+
+            self.assertEqual(response, mock_response)
+            mock_kaggle.models.model_api_client.create_model.assert_called_once()
+            request = mock_kaggle.models.model_api_client.create_model.call_args[0][0]
+            self.assertEqual(request.owner_slug, "testuser")
+            self.assertEqual(request.slug, "test-model")
+            self.assertEqual(request.title, "Test Model Title")
+            self.assertEqual(request.subtitle, "Valid subtitle")
+            self.assertTrue(request.is_private)
+            self.assertEqual(request.description, "Test model description")
+            self.assertIsNone(request.publish_time)
+            self.assertEqual(request.provenance_sources, "source1")
+
+    def test_model_update_invalid_folder(self):
+        with self.assertRaises(ValueError) as context:
+            self.api.model_update("/non/existent/folder")
+        self.assertIn("Invalid folder", str(context.exception))
+
+    def test_model_update_default_owner(self):
+        metadata = self._get_valid_model_metadata()
+        metadata["ownerSlug"] = "INSERT_OWNER_SLUG_HERE"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata, "model-metadata.json")
+            with self.assertRaises(ValueError) as context:
+                self.api.model_update(tmpdir)
+            self.assertIn("Default ownerSlug detected", str(context.exception))
+
+    def test_model_update_default_slug(self):
+        metadata = self._get_valid_model_metadata()
+        metadata["slug"] = "INSERT_SLUG_HERE"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata, "model-metadata.json")
+            with self.assertRaises(ValueError) as context:
+                self.api.model_update(tmpdir)
+            self.assertIn("Default slug detected", str(context.exception))
+
+    def test_model_update_invalid_is_private(self):
+        metadata = self._get_valid_model_metadata()
+        metadata["isPrivate"] = "not-a-bool"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata, "model-metadata.json")
+            with self.assertRaises(ValueError) as context:
+                self.api.model_update(tmpdir)
+            self.assertIn("model.isPrivate must be a boolean", str(context.exception))
+
+    def test_model_update_invalid_publish_time(self):
+        metadata = self._get_valid_model_metadata()
+        metadata["publishTime"] = "invalid-date"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata, "model-metadata.json")
+            with self.assertRaises(ValueError) as context:
+                self.api.model_update(tmpdir)
+            self.assertIn("does not match format", str(context.exception))
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_model_update_success_all_fields(self, mock_client):
+        mock_kaggle = MagicMock()
+        mock_response = MagicMock()
+        mock_kaggle.models.model_api_client.update_model.return_value = mock_response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        metadata = self._get_valid_model_metadata()
+        metadata["title"] = "Updated Model Title"
+        metadata["subtitle"] = "Updated subtitle"
+        metadata["isPrivate"] = False
+        metadata["description"] = "Updated description"
+        # publishTime and provenanceSources are omitted to avoid bugs, see Tasks 5.3, 5.4
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata, "model-metadata.json")
+            response = self.api.model_update(tmpdir)
+
+            self.assertEqual(response, mock_response)
+            mock_kaggle.models.model_api_client.update_model.assert_called_once()
+            request = mock_kaggle.models.model_api_client.update_model.call_args[0][0]
+            
+            self.assertEqual(request.owner_slug, "testuser")
+            self.assertEqual(request.model_slug, "test-model")
+            self.assertEqual(request.title, "Updated Model Title")
+            self.assertEqual(request.subtitle, "Updated subtitle")
+            self.assertFalse(request.is_private)
+            self.assertEqual(request.description, "Updated description")
+            self.assertIsNone(request.publish_time)
+            self.assertEqual(request.provenance_sources, '')
+            
+            # Verify update_mask (expected to be None due to bug, see Task 5.2)
+            self.assertIsNone(request.update_mask)
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_model_update_success_partial(self, mock_client):
+        mock_kaggle = MagicMock()
+        mock_kaggle.models.model_api_client.update_model.return_value = MagicMock()
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        metadata = {
+            "ownerSlug": "testuser",
+            "slug": "test-model",
+            "title": "Updated Title",
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata, "model-metadata.json")
+            self.api.model_update(tmpdir)
+
+            request = mock_kaggle.models.model_api_client.update_model.call_args[0][0]
+            
+            self.assertEqual(request.title, "Updated Title")
+            self.assertEqual(request.subtitle, '')
+            self.assertTrue(request.is_private)
+            self.assertEqual(request.description, '')
+            
+            self.assertIsNone(request.update_mask)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_model_create.py
+++ b/tests/unit/test_model_create.py
@@ -40,12 +40,12 @@ class TestModelCreate(unittest.TestCase):
         with open(meta_file_path, "w", encoding="utf-8") as f:
             json.dump(metadata, f)
 
-    def test_model_instance_create_invalid_folder(self):
+    def test_model_instance_create_invalid_folder_fails(self):
         with self.assertRaises(ValueError) as context:
             self.api.model_instance_create("/non/existent/folder")
         self.assertIn("Invalid folder", str(context.exception))
 
-    def test_model_instance_create_default_owner(self):
+    def test_model_instance_create_default_owner_fails(self):
         metadata = self._get_valid_instance_metadata()
         metadata["ownerSlug"] = "INSERT_OWNER_SLUG_HERE"
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -54,7 +54,7 @@ class TestModelCreate(unittest.TestCase):
                 self.api.model_instance_create(tmpdir)
             self.assertIn("Default ownerSlug detected", str(context.exception))
 
-    def test_model_instance_create_default_model_slug(self):
+    def test_model_instance_create_default_model_slug_fails(self):
         metadata = self._get_valid_instance_metadata()
         metadata["modelSlug"] = "INSERT_EXISTING_MODEL_SLUG_HERE"
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -63,7 +63,7 @@ class TestModelCreate(unittest.TestCase):
                 self.api.model_instance_create(tmpdir)
             self.assertIn("Default modelSlug detected", str(context.exception))
 
-    def test_model_instance_create_default_instance_slug(self):
+    def test_model_instance_create_default_instance_slug_fails(self):
         metadata = self._get_valid_instance_metadata()
         metadata["instanceSlug"] = "INSERT_INSTANCE_SLUG_HERE"
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -72,7 +72,7 @@ class TestModelCreate(unittest.TestCase):
                 self.api.model_instance_create(tmpdir)
             self.assertIn("Default instanceSlug detected", str(context.exception))
 
-    def test_model_instance_create_default_framework(self):
+    def test_model_instance_create_default_framework_fails(self):
         metadata = self._get_valid_instance_metadata()
         metadata["framework"] = "INSERT_FRAMEWORK_HERE"
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -81,7 +81,7 @@ class TestModelCreate(unittest.TestCase):
                 self.api.model_instance_create(tmpdir)
             self.assertIn("Default framework detected", str(context.exception))
 
-    def test_model_instance_create_missing_license(self):
+    def test_model_instance_create_missing_license_fails(self):
         metadata = self._get_valid_instance_metadata()
         metadata["licenseName"] = ""
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -90,7 +90,7 @@ class TestModelCreate(unittest.TestCase):
                 self.api.model_instance_create(tmpdir)
             self.assertIn("Please specify a license", str(context.exception))
 
-    def test_model_instance_create_invalid_fine_tunable(self):
+    def test_model_instance_create_invalid_fine_tunable_fails(self):
         metadata = self._get_valid_instance_metadata()
         metadata["fineTunable"] = "not-a-bool"
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -99,7 +99,7 @@ class TestModelCreate(unittest.TestCase):
                 self.api.model_instance_create(tmpdir)
             self.assertIn("modelInstance.fineTunable must be a boolean", str(context.exception))
 
-    def test_model_instance_create_invalid_training_data(self):
+    def test_model_instance_create_invalid_training_data_fails(self):
         metadata = self._get_valid_instance_metadata()
         metadata["trainingData"] = "not-a-list"
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -110,7 +110,7 @@ class TestModelCreate(unittest.TestCase):
 
     @patch.object(KaggleApi, "upload_files")
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_model_instance_create_success(self, mock_client, mock_upload):
+    def test_model_instance_create_valid_metadata_succeeds(self, mock_client, mock_upload):
         mock_kaggle = MagicMock()
         mock_response = ApiCreateModelResponse()
         mock_kaggle.models.model_api_client.create_model_instance.return_value = mock_response
@@ -156,12 +156,12 @@ class TestModelCreate(unittest.TestCase):
             self.assertEqual(body.base_model_instance, "base-instance")
             self.assertEqual(body.external_base_model_url, "http://example.com")
 
-    def test_model_instance_update_invalid_folder(self):
+    def test_model_instance_update_invalid_folder_fails(self):
         with self.assertRaises(ValueError) as context:
             self.api.model_instance_update("/non/existent/folder")
         self.assertIn("Invalid folder", str(context.exception))
 
-    def test_model_instance_update_default_owner(self):
+    def test_model_instance_update_default_owner_fails(self):
         metadata = self._get_valid_instance_metadata()
         metadata["ownerSlug"] = "INSERT_OWNER_SLUG_HERE"
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -170,7 +170,7 @@ class TestModelCreate(unittest.TestCase):
                 self.api.model_instance_update(tmpdir)
             self.assertIn("Default ownerSlug detected", str(context.exception))
 
-    def test_model_instance_update_default_model_slug(self):
+    def test_model_instance_update_default_model_slug_fails(self):
         metadata = self._get_valid_instance_metadata()
         metadata["modelSlug"] = "INSERT_SLUG_HERE"
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -179,7 +179,7 @@ class TestModelCreate(unittest.TestCase):
                 self.api.model_instance_update(tmpdir)
             self.assertIn("Default model slug detected", str(context.exception))
 
-    def test_model_instance_update_default_instance_slug(self):
+    def test_model_instance_update_default_instance_slug_fails(self):
         metadata = self._get_valid_instance_metadata()
         metadata["instanceSlug"] = "INSERT_INSTANCE_SLUG_HERE"
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -188,7 +188,7 @@ class TestModelCreate(unittest.TestCase):
                 self.api.model_instance_update(tmpdir)
             self.assertIn("Default instance slug detected", str(context.exception))
 
-    def test_model_instance_update_default_framework(self):
+    def test_model_instance_update_default_framework_fails(self):
         metadata = self._get_valid_instance_metadata()
         metadata["framework"] = "INSERT_FRAMEWORK_HERE"
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -197,7 +197,7 @@ class TestModelCreate(unittest.TestCase):
                 self.api.model_instance_update(tmpdir)
             self.assertIn("Default framework detected", str(context.exception))
 
-    def test_model_instance_update_invalid_fine_tunable(self):
+    def test_model_instance_update_invalid_fine_tunable_fails(self):
         metadata = self._get_valid_instance_metadata()
         metadata["fineTunable"] = "not-a-bool"
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -206,7 +206,7 @@ class TestModelCreate(unittest.TestCase):
                 self.api.model_instance_update(tmpdir)
             self.assertIn("modelInstance.fineTunable must be a boolean", str(context.exception))
 
-    def test_model_instance_update_invalid_training_data(self):
+    def test_model_instance_update_invalid_training_data_fails(self):
         metadata = self._get_valid_instance_metadata()
         metadata["trainingData"] = "not-a-list"
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -216,7 +216,7 @@ class TestModelCreate(unittest.TestCase):
             self.assertIn("modelInstance.trainingData must be a list", str(context.exception))
 
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_model_instance_update_success_all_fields(self, mock_client):
+    def test_model_instance_update_all_fields_succeeds(self, mock_client):
         mock_kaggle = MagicMock()
         mock_response = MagicMock()
         mock_kaggle.models.model_api_client.update_model_instance.return_value = mock_response
@@ -258,7 +258,7 @@ class TestModelCreate(unittest.TestCase):
             self.assertIsNone(request.update_mask)
 
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_model_instance_update_success_partial(self, mock_client):
+    def test_model_instance_update_partial_fields_succeeds(self, mock_client):
         mock_kaggle = MagicMock()
         mock_kaggle.models.model_api_client.update_model_instance.return_value = MagicMock()
         mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
@@ -292,12 +292,12 @@ class TestModelCreate(unittest.TestCase):
             "description": "Test model description",
         }
 
-    def test_model_create_new_invalid_folder(self):
+    def test_model_create_new_invalid_folder_fails(self):
         with self.assertRaises(ValueError) as context:
             self.api.model_create_new("/non/existent/folder")
         self.assertIn("Invalid folder", str(context.exception))
 
-    def test_model_create_new_default_owner(self):
+    def test_model_create_new_default_owner_fails(self):
         metadata = self._get_valid_model_metadata()
         metadata["ownerSlug"] = "INSERT_OWNER_SLUG_HERE"
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -306,7 +306,7 @@ class TestModelCreate(unittest.TestCase):
                 self.api.model_create_new(tmpdir)
             self.assertIn("Default ownerSlug detected", str(context.exception))
 
-    def test_model_create_new_default_title(self):
+    def test_model_create_new_default_title_fails(self):
         metadata = self._get_valid_model_metadata()
         metadata["title"] = "INSERT_TITLE_HERE"
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -315,7 +315,7 @@ class TestModelCreate(unittest.TestCase):
                 self.api.model_create_new(tmpdir)
             self.assertIn("Default title detected", str(context.exception))
 
-    def test_model_create_new_default_slug(self):
+    def test_model_create_new_default_slug_fails(self):
         metadata = self._get_valid_model_metadata()
         metadata["slug"] = "INSERT_SLUG_HERE"
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -324,7 +324,7 @@ class TestModelCreate(unittest.TestCase):
                 self.api.model_create_new(tmpdir)
             self.assertIn("Default slug detected", str(context.exception))
 
-    def test_model_create_new_invalid_is_private(self):
+    def test_model_create_new_invalid_is_private_fails(self):
         metadata = self._get_valid_model_metadata()
         metadata["isPrivate"] = "not-a-bool"
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -333,7 +333,7 @@ class TestModelCreate(unittest.TestCase):
                 self.api.model_create_new(tmpdir)
             self.assertIn("model.isPrivate must be a boolean", str(context.exception))
 
-    def test_model_create_new_invalid_publish_time(self):
+    def test_model_create_new_invalid_publish_time_fails(self):
         metadata = self._get_valid_model_metadata()
         metadata["publishTime"] = "invalid-date"
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -343,7 +343,7 @@ class TestModelCreate(unittest.TestCase):
             self.assertIn("does not match format", str(context.exception))
 
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_model_create_new_success(self, mock_client):
+    def test_model_create_new_valid_metadata_succeeds(self, mock_client):
         mock_kaggle = MagicMock()
         mock_response = ApiCreateModelResponse()
         mock_kaggle.models.model_api_client.create_model.return_value = mock_response
@@ -371,12 +371,12 @@ class TestModelCreate(unittest.TestCase):
             self.assertIsNone(request.publish_time)
             self.assertEqual(request.provenance_sources, "source1")
 
-    def test_model_update_invalid_folder(self):
+    def test_model_update_invalid_folder_fails(self):
         with self.assertRaises(ValueError) as context:
             self.api.model_update("/non/existent/folder")
         self.assertIn("Invalid folder", str(context.exception))
 
-    def test_model_update_default_owner(self):
+    def test_model_update_default_owner_fails(self):
         metadata = self._get_valid_model_metadata()
         metadata["ownerSlug"] = "INSERT_OWNER_SLUG_HERE"
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -385,7 +385,7 @@ class TestModelCreate(unittest.TestCase):
                 self.api.model_update(tmpdir)
             self.assertIn("Default ownerSlug detected", str(context.exception))
 
-    def test_model_update_default_slug(self):
+    def test_model_update_default_slug_fails(self):
         metadata = self._get_valid_model_metadata()
         metadata["slug"] = "INSERT_SLUG_HERE"
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -394,7 +394,7 @@ class TestModelCreate(unittest.TestCase):
                 self.api.model_update(tmpdir)
             self.assertIn("Default slug detected", str(context.exception))
 
-    def test_model_update_invalid_is_private(self):
+    def test_model_update_invalid_is_private_fails(self):
         metadata = self._get_valid_model_metadata()
         metadata["isPrivate"] = "not-a-bool"
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -403,7 +403,7 @@ class TestModelCreate(unittest.TestCase):
                 self.api.model_update(tmpdir)
             self.assertIn("model.isPrivate must be a boolean", str(context.exception))
 
-    def test_model_update_invalid_publish_time(self):
+    def test_model_update_invalid_publish_time_fails(self):
         metadata = self._get_valid_model_metadata()
         metadata["publishTime"] = "invalid-date"
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -413,7 +413,7 @@ class TestModelCreate(unittest.TestCase):
             self.assertIn("does not match format", str(context.exception))
 
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_model_update_success_all_fields(self, mock_client):
+    def test_model_update_all_fields_succeeds(self, mock_client):
         mock_kaggle = MagicMock()
         mock_response = MagicMock()
         mock_kaggle.models.model_api_client.update_model.return_value = mock_response
@@ -448,7 +448,7 @@ class TestModelCreate(unittest.TestCase):
             self.assertIsNone(request.update_mask)
 
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_model_update_success_partial(self, mock_client):
+    def test_model_update_partial_fields_succeeds(self, mock_client):
         mock_kaggle = MagicMock()
         mock_kaggle.models.model_api_client.update_model.return_value = MagicMock()
         mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)

--- a/tests/unit/test_model_download.py
+++ b/tests/unit/test_model_download.py
@@ -27,30 +27,30 @@ class TestModelDownload(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.temp_dir)
 
-    def test_download_missing_version(self):
+    def test_download_missing_version_fails(self):
         with self.assertRaises(ValueError) as context:
             self.api.model_instance_version_download(None)
         self.assertIn("A model_instance_version must be specified", str(context.exception))
 
-    def test_download_invalid_format(self):
+    def test_download_invalid_format_fails(self):
         # Too few slashes
         with self.assertRaises(ValueError) as context:
             self.api.model_instance_version_download("owner/model/keras/instance")
         self.assertIn("Model instance version must be specified in the form", str(context.exception))
 
-    def test_download_empty_parts(self):
+    def test_download_empty_parts_fails(self):
         with self.assertRaises(ValueError) as context:
             self.api.model_instance_version_download("owner/model/keras//1")
         self.assertIn("Invalid model instance version specification", str(context.exception))
 
-    def test_download_non_int_version(self):
+    def test_download_non_int_version_fails(self):
         with self.assertRaises(ValueError) as context:
             self.api.model_instance_version_download("owner/model/keras/instance/abc")
         self.assertIn("version-number must be an integer", str(context.exception))
 
     @patch.object(KaggleApi, "download_needed", return_value=False)
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_download_cached(self, mock_client, mock_download_needed):
+    def test_download_cached_skips_download(self, mock_client, mock_download_needed):
         mock_kaggle = MagicMock()
         mock_response = MagicMock()
         mock_kaggle.models.model_api_client.download_model_instance_version.return_value = mock_response
@@ -76,7 +76,7 @@ class TestModelDownload(unittest.TestCase):
     @patch.object(KaggleApi, "download_file")
     @patch.object(KaggleApi, "download_needed", return_value=True)
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_download_needed(self, mock_client, mock_download_needed, mock_download_file):
+    def test_download_needed_downloads(self, mock_client, mock_download_needed, mock_download_file):
         mock_kaggle = MagicMock()
         mock_response = MagicMock()
         mock_kaggle.models.model_api_client.download_model_instance_version.return_value = mock_response
@@ -96,7 +96,7 @@ class TestModelDownload(unittest.TestCase):
     @patch.object(KaggleApi, "download_file")
     @patch.object(KaggleApi, "download_needed")
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_download_force(self, mock_client, mock_download_needed, mock_download_file):
+    def test_download_force_downloads(self, mock_client, mock_download_needed, mock_download_file):
         mock_kaggle = MagicMock()
         mock_response = MagicMock()
         mock_kaggle.models.model_api_client.download_model_instance_version.return_value = mock_response
@@ -115,7 +115,7 @@ class TestModelDownload(unittest.TestCase):
 
     @patch.object(KaggleApi, "download_needed", return_value=True)
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_download_untar_success(self, mock_client, mock_download_needed):
+    def test_download_untar_succeeds(self, mock_client, mock_download_needed):
         tar_buffer = io.BytesIO()
         with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
             file_data = b"dummy content"
@@ -147,7 +147,7 @@ class TestModelDownload(unittest.TestCase):
     @patch.object(KaggleApi, "download_file")
     @patch.object(KaggleApi, "download_needed", return_value=True)
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_download_untar_failure(self, mock_client, mock_download_needed, mock_download_file):
+    def test_download_untar_failure_fails(self, mock_client, mock_download_needed, mock_download_file):
         def side_effect_download(response, outfile, http_client, quiet, show_progress):
             open(outfile, "w").close()
 
@@ -170,7 +170,7 @@ class TestModelDownload(unittest.TestCase):
     @patch.object(KaggleApi, "get_default_download_dir")
     @patch.object(KaggleApi, "download_needed", return_value=False)
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_download_default_path(self, mock_client, mock_download_needed, mock_get_dir):
+    def test_download_default_path_succeeds(self, mock_client, mock_download_needed, mock_get_dir):
         mock_get_dir.return_value = self.temp_dir
         mock_kaggle = MagicMock()
         mock_kaggle.models.model_api_client.download_model_instance_version.return_value = MagicMock()

--- a/tests/unit/test_model_download.py
+++ b/tests/unit/test_model_download.py
@@ -1,0 +1,189 @@
+# coding=utf-8
+import os
+import shutil
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+import tarfile
+import io
+import sys
+
+sys.path.insert(0, "../..")
+
+from kaggle.api.kaggle_api_extended import KaggleApi
+from kagglesdk.models.types.model_enums import ModelFramework
+from kagglesdk.models.types.model_api_service import ApiDownloadModelInstanceVersionRequest
+
+
+class TestModelDownload(unittest.TestCase):
+    """Tests for model_instance_version_download."""
+
+    def setUp(self):
+        self.api = KaggleApi.__new__(KaggleApi)
+        self.api.config_values = {"username": "testuser"}
+        self.api.already_printed_version_warning = True
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def test_download_missing_version(self):
+        with self.assertRaises(ValueError) as context:
+            self.api.model_instance_version_download(None)
+        self.assertIn("A model_instance_version must be specified", str(context.exception))
+
+    def test_download_invalid_format(self):
+        # Too few slashes
+        with self.assertRaises(ValueError) as context:
+            self.api.model_instance_version_download("owner/model/keras/instance")
+        self.assertIn("Model instance version must be specified in the form", str(context.exception))
+
+    def test_download_empty_parts(self):
+        with self.assertRaises(ValueError) as context:
+            self.api.model_instance_version_download("owner/model/keras//1")
+        self.assertIn("Invalid model instance version specification", str(context.exception))
+
+    def test_download_non_int_version(self):
+        with self.assertRaises(ValueError) as context:
+            self.api.model_instance_version_download("owner/model/keras/instance/abc")
+        self.assertIn("version-number must be an integer", str(context.exception))
+
+    @patch.object(KaggleApi, "download_needed", return_value=False)
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_download_cached(self, mock_client, mock_download_needed):
+        mock_kaggle = MagicMock()
+        mock_response = MagicMock()
+        mock_kaggle.models.model_api_client.download_model_instance_version.return_value = mock_response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        version_str = "owner/model/keras/instance/2"
+        outfile = self.api.model_instance_version_download(version_str, path=self.temp_dir)
+
+        expected_outfile = os.path.join(self.temp_dir, "model.tar.gz")
+        self.assertEqual(outfile, expected_outfile)
+        
+        mock_kaggle.models.model_api_client.download_model_instance_version.assert_called_once()
+        request = mock_kaggle.models.model_api_client.download_model_instance_version.call_args[0][0]
+        self.assertEqual(request.owner_slug, "owner")
+        self.assertEqual(request.model_slug, "model")
+        self.assertEqual(request.framework, ModelFramework.MODEL_FRAMEWORK_KERAS)
+        self.assertEqual(request.instance_slug, "instance")
+        self.assertEqual(request.version_number, 2)
+
+        mock_download_needed.assert_called_once_with(mock_response, expected_outfile, True)
+
+    @patch.object(KaggleApi, "download_file")
+    @patch.object(KaggleApi, "download_needed", return_value=True)
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_download_needed(self, mock_client, mock_download_needed, mock_download_file):
+        mock_kaggle = MagicMock()
+        mock_response = MagicMock()
+        mock_kaggle.models.model_api_client.download_model_instance_version.return_value = mock_response
+        mock_kaggle.http_client.return_value = "mock-http-client"
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        version_str = "owner/model/keras/instance/2"
+        outfile = self.api.model_instance_version_download(version_str, path=self.temp_dir, quiet=False)
+
+        expected_outfile = os.path.join(self.temp_dir, "model.tar.gz")
+        self.assertEqual(outfile, expected_outfile)
+
+        mock_download_needed.assert_called_once_with(mock_response, expected_outfile, False)
+        mock_download_file.assert_called_once_with(mock_response, expected_outfile, "mock-http-client", False, True)
+
+    @patch.object(KaggleApi, "download_file")
+    @patch.object(KaggleApi, "download_needed")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_download_force(self, mock_client, mock_download_needed, mock_download_file):
+        mock_kaggle = MagicMock()
+        mock_response = MagicMock()
+        mock_kaggle.models.model_api_client.download_model_instance_version.return_value = mock_response
+        mock_kaggle.http_client.return_value = "mock-http-client"
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        version_str = "owner/model/keras/instance/2"
+        outfile = self.api.model_instance_version_download(version_str, path=self.temp_dir, force=True)
+
+        expected_outfile = os.path.join(self.temp_dir, "model.tar.gz")
+        self.assertEqual(outfile, expected_outfile)
+
+        mock_download_needed.assert_not_called()
+        mock_download_file.assert_called_once_with(mock_response, expected_outfile, "mock-http-client", True, False)
+
+    @patch.object(KaggleApi, "download_needed", return_value=True)
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_download_untar_success(self, mock_client, mock_download_needed):
+        tar_buffer = io.BytesIO()
+        with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
+            file_data = b"dummy content"
+            tarinfo = tarfile.TarInfo(name="dummy.txt")
+            tarinfo.size = len(file_data)
+            tar.addfile(tarinfo, io.BytesIO(file_data))
+        tar_bytes = tar_buffer.getvalue()
+
+        def side_effect_download(response, outfile, http_client, quiet, show_progress):
+            with open(outfile, "wb") as f:
+                f.write(tar_bytes)
+
+        mock_kaggle = MagicMock()
+        mock_kaggle.models.model_api_client.download_model_instance_version.return_value = MagicMock()
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        version_str = "owner/model/keras/instance/2"
+        
+        with patch.object(KaggleApi, "download_file", side_effect=side_effect_download):
+            outfile = self.api.model_instance_version_download(version_str, path=self.temp_dir, untar=True)
+
+        self.assertFalse(os.path.exists(outfile))
+        extracted_file = os.path.join(self.temp_dir, "dummy.txt")
+        self.assertTrue(os.path.exists(extracted_file))
+        with open(extracted_file, "rb") as f:
+            self.assertEqual(f.read(), b"dummy content")
+
+    @patch.object(KaggleApi, "download_file")
+    @patch.object(KaggleApi, "download_needed", return_value=True)
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_download_untar_failure(self, mock_client, mock_download_needed, mock_download_file):
+        def side_effect_download(response, outfile, http_client, quiet, show_progress):
+            open(outfile, "w").close()
+
+        mock_download_file.side_effect = side_effect_download
+
+        mock_kaggle = MagicMock()
+        mock_kaggle.models.model_api_client.download_model_instance_version.return_value = MagicMock()
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        version_str = "owner/model/keras/instance/2"
+        
+        with self.assertRaises(ValueError) as context:
+            self.api.model_instance_version_download(version_str, path=self.temp_dir, untar=True)
+        self.assertIn("Error extracting the tar.gz file", str(context.exception))
+        
+        expected_outfile = os.path.join(self.temp_dir, "model.tar.gz")
+        self.assertTrue(os.path.exists(expected_outfile))
+
+    @patch.object(KaggleApi, "get_default_download_dir")
+    @patch.object(KaggleApi, "download_needed", return_value=False)
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_download_default_path(self, mock_client, mock_download_needed, mock_get_dir):
+        mock_get_dir.return_value = self.temp_dir
+        mock_kaggle = MagicMock()
+        mock_kaggle.models.model_api_client.download_model_instance_version.return_value = MagicMock()
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        version_str = "owner/model/keras/instance/2"
+        outfile = self.api.model_instance_version_download(version_str, path=None)
+
+        expected_outfile = os.path.join(self.temp_dir, "model.tar.gz")
+        self.assertEqual(outfile, expected_outfile)
+        mock_get_dir.assert_called_once_with("models", "owner", "model", "keras", "instance", "2")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_model_download.py
+++ b/tests/unit/test_model_download.py
@@ -62,7 +62,7 @@ class TestModelDownload(unittest.TestCase):
 
         expected_outfile = os.path.join(self.temp_dir, "model.tar.gz")
         self.assertEqual(outfile, expected_outfile)
-        
+
         mock_kaggle.models.model_api_client.download_model_instance_version.assert_called_once()
         request = mock_kaggle.models.model_api_client.download_model_instance_version.call_args[0][0]
         self.assertEqual(request.owner_slug, "owner")
@@ -134,7 +134,7 @@ class TestModelDownload(unittest.TestCase):
         mock_client.return_value.__exit__ = MagicMock(return_value=False)
 
         version_str = "owner/model/keras/instance/2"
-        
+
         with patch.object(KaggleApi, "download_file", side_effect=side_effect_download):
             outfile = self.api.model_instance_version_download(version_str, path=self.temp_dir, untar=True)
 
@@ -159,11 +159,11 @@ class TestModelDownload(unittest.TestCase):
         mock_client.return_value.__exit__ = MagicMock(return_value=False)
 
         version_str = "owner/model/keras/instance/2"
-        
+
         with self.assertRaises(ValueError) as context:
             self.api.model_instance_version_download(version_str, path=self.temp_dir, untar=True)
         self.assertIn("Error extracting the tar.gz file", str(context.exception))
-        
+
         expected_outfile = os.path.join(self.temp_dir, "model.tar.gz")
         self.assertTrue(os.path.exists(expected_outfile))
 

--- a/tests/unit/test_model_list.py
+++ b/tests/unit/test_model_list.py
@@ -1,0 +1,195 @@
+# coding=utf-8
+import unittest
+from unittest.mock import MagicMock, patch
+import sys
+
+sys.path.insert(0, "../..")
+
+from kaggle.api.kaggle_api_extended import KaggleApi, FileList
+from kagglesdk.models.types.model_enums import ModelFramework, ListModelsOrderBy
+from kagglesdk.models.types.model_api_service import (
+    ApiListModelsRequest,
+    ApiListModelInstanceVersionFilesRequest,
+    ApiListModelInstanceVersionFilesResponse,
+)
+
+
+class TestModelList(unittest.TestCase):
+    """Tests for model_list, model_instance_files, and model_instance_version_files."""
+
+    def setUp(self):
+        self.api = KaggleApi.__new__(KaggleApi)
+        self.api.config_values = {"username": "testuser"}
+        self.api.already_printed_version_warning = True
+
+    # model_list tests
+    def test_model_list_invalid_sort(self):
+        with self.assertRaises(ValueError) as context:
+            self.api.model_list(sort_by="invalid-sort")
+        self.assertIn("Invalid sort by specified", str(context.exception))
+
+    def test_model_list_invalid_page_size(self):
+        with self.assertRaises(ValueError) as context:
+            self.api.model_list(page_size=0)
+        self.assertIn("Page size must be >= 1", str(context.exception))
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_model_list_success(self, mock_client):
+        mock_kaggle = MagicMock()
+        mock_response = MagicMock()
+        mock_model = MagicMock()
+        mock_response.models = [mock_model]
+        mock_response.next_page_token = "next-token-123"
+        mock_kaggle.models.model_api_client.list_models.return_value = mock_response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        import io
+        from contextlib import redirect_stdout
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = self.api.model_list(
+                sort_by="voteCount",
+                search="query",
+                owner="owner",
+                page_size=10,
+                page_token="token-123"
+            )
+
+        self.assertEqual(result, [mock_model])
+        self.assertIn("Next Page Token = next-token-123", f.getvalue())
+
+        mock_kaggle.models.model_api_client.list_models.assert_called_once()
+        request = mock_kaggle.models.model_api_client.list_models.call_args[0][0]
+        self.assertEqual(request.sort_by, ListModelsOrderBy.LIST_MODELS_ORDER_BY_VOTE_COUNT)
+        self.assertEqual(request.search, "query")
+        self.assertEqual(request.owner, "owner")
+        self.assertEqual(request.page_size, 10)
+        self.assertEqual(request.page_token, "token-123")
+
+    # model_instance_files tests
+    def test_model_instance_files_missing_instance(self):
+        with self.assertRaises(ValueError) as context:
+            self.api.model_instance_files(None)
+        self.assertIn("A model_instance must be specified", str(context.exception))
+
+    def test_model_instance_files_invalid_format(self):
+        with self.assertRaises(ValueError) as context:
+            self.api.model_instance_files("owner/model/keras")
+        self.assertIn("Model instance must be specified in the form of", str(context.exception))
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_model_instance_files_success(self, mock_client):
+        mock_kaggle = MagicMock()
+        mock_response = MagicMock(spec=ApiListModelInstanceVersionFilesResponse)
+        mock_response.next_page_token = "next-file-token"
+        
+        mock_file = MagicMock()
+        mock_file.name = "model.h5"
+        mock_file.size = 1024
+        mock_response.files = [mock_file]
+        
+        mock_kaggle.models.model_api_client.list_model_instance_version_files.return_value = mock_response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        import io
+        from contextlib import redirect_stdout
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = self.api.model_instance_files(
+                "owner/model/keras/instance",
+                page_token="token-456",
+                page_size=50
+            )
+
+        self.assertIsInstance(result, FileList)
+        self.assertIn("Next Page Token = next-file-token", f.getvalue())
+
+        mock_kaggle.models.model_api_client.list_model_instance_version_files.assert_called_once()
+        request = mock_kaggle.models.model_api_client.list_model_instance_version_files.call_args[0][0]
+        self.assertEqual(request.owner_slug, "owner")
+        self.assertEqual(request.model_slug, "model")
+        self.assertEqual(request.framework, ModelFramework.MODEL_FRAMEWORK_KERAS)
+        self.assertEqual(request.instance_slug, "instance")
+        self.assertEqual(request.page_size, 50)
+        self.assertEqual(request.page_token, "token-456")
+
+    # model_instance_version_files tests
+    def test_model_instance_version_files_missing_version(self):
+        with self.assertRaises(ValueError) as context:
+            self.api.model_instance_version_files(None)
+        self.assertIn("A model_instance_version must be specified", str(context.exception))
+
+    def test_model_instance_version_files_invalid_format(self):
+        with self.assertRaises(ValueError) as context:
+            self.api.model_instance_version_files("owner/model/keras/instance")
+        self.assertIn("Model instance version must be specified in the form of", str(context.exception))
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_model_instance_version_files_success(self, mock_client):
+        mock_kaggle = MagicMock()
+        mock_response = ApiListModelInstanceVersionFilesResponse()
+        mock_response.next_page_token = "next-ver-file-token"
+        mock_kaggle.models.model_api_client.list_model_instance_version_files.return_value = mock_response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        import io
+        from contextlib import redirect_stdout
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = self.api.model_instance_version_files(
+                "owner/model/keras/instance/3",
+                page_token="token-789",
+                page_size=5
+            )
+
+        self.assertEqual(result, mock_response)
+        self.assertIn("Next Page Token = next-ver-file-token", f.getvalue())
+
+        mock_kaggle.models.model_api_client.list_model_instance_version_files.assert_called_once()
+        request = mock_kaggle.models.model_api_client.list_model_instance_version_files.call_args[0][0]
+        self.assertEqual(request.owner_slug, "owner")
+        self.assertEqual(request.model_slug, "model")
+        self.assertEqual(request.framework, ModelFramework.MODEL_FRAMEWORK_KERAS)
+        self.assertEqual(request.instance_slug, "instance")
+        self.assertEqual(request.version_number, 3)
+        self.assertEqual(request.page_size, 5)
+        self.assertEqual(request.page_token, "token-789")
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_model_instance_files_empty(self, mock_client):
+        mock_kaggle = MagicMock()
+        mock_kaggle.models.model_api_client.list_model_instance_version_files.return_value = None
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        import io
+        from contextlib import redirect_stdout
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = self.api.model_instance_files("owner/model/keras/instance")
+
+        self.assertIsInstance(result, FileList)
+        self.assertIn("No files found", f.getvalue())
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_model_instance_version_files_empty(self, mock_client):
+        mock_kaggle = MagicMock()
+        mock_kaggle.models.model_api_client.list_model_instance_version_files.return_value = None
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        import io
+        from contextlib import redirect_stdout
+        f = io.StringIO()
+        with redirect_stdout(f):
+            result = self.api.model_instance_version_files("owner/model/keras/instance/3")
+
+        self.assertIsNone(result)
+        self.assertIn("No files found", f.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_model_list.py
+++ b/tests/unit/test_model_list.py
@@ -23,18 +23,18 @@ class TestModelList(unittest.TestCase):
         self.api.already_printed_version_warning = True
 
     # model_list tests
-    def test_model_list_invalid_sort(self):
+    def test_model_list_invalid_sort_fails(self):
         with self.assertRaises(ValueError) as context:
             self.api.model_list(sort_by="invalid-sort")
         self.assertIn("Invalid sort by specified", str(context.exception))
 
-    def test_model_list_invalid_page_size(self):
+    def test_model_list_invalid_page_size_fails(self):
         with self.assertRaises(ValueError) as context:
             self.api.model_list(page_size=0)
         self.assertIn("Page size must be >= 1", str(context.exception))
 
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_model_list_success(self, mock_client):
+    def test_model_list_defaults_succeeds(self, mock_client):
         mock_kaggle = MagicMock()
         mock_response = MagicMock()
         mock_model = MagicMock()
@@ -65,18 +65,18 @@ class TestModelList(unittest.TestCase):
         self.assertEqual(request.page_token, "token-123")
 
     # model_instance_files tests
-    def test_model_instance_files_missing_instance(self):
+    def test_model_instance_files_missing_instance_fails(self):
         with self.assertRaises(ValueError) as context:
             self.api.model_instance_files(None)
         self.assertIn("A model_instance must be specified", str(context.exception))
 
-    def test_model_instance_files_invalid_format(self):
+    def test_model_instance_files_invalid_format_fails(self):
         with self.assertRaises(ValueError) as context:
             self.api.model_instance_files("owner/model/keras")
         self.assertIn("Model instance must be specified in the form of", str(context.exception))
 
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_model_instance_files_success(self, mock_client):
+    def test_model_instance_files_succeeds(self, mock_client):
         mock_kaggle = MagicMock()
         mock_response = MagicMock(spec=ApiListModelInstanceVersionFilesResponse)
         mock_response.next_page_token = "next-file-token"
@@ -110,18 +110,18 @@ class TestModelList(unittest.TestCase):
         self.assertEqual(request.page_token, "token-456")
 
     # model_instance_version_files tests
-    def test_model_instance_version_files_missing_version(self):
+    def test_model_instance_version_files_missing_version_fails(self):
         with self.assertRaises(ValueError) as context:
             self.api.model_instance_version_files(None)
         self.assertIn("A model_instance_version must be specified", str(context.exception))
 
-    def test_model_instance_version_files_invalid_format(self):
+    def test_model_instance_version_files_invalid_format_fails(self):
         with self.assertRaises(ValueError) as context:
             self.api.model_instance_version_files("owner/model/keras/instance")
         self.assertIn("Model instance version must be specified in the form of", str(context.exception))
 
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_model_instance_version_files_success(self, mock_client):
+    def test_model_instance_version_files_succeeds(self, mock_client):
         mock_kaggle = MagicMock()
         mock_response = ApiListModelInstanceVersionFilesResponse()
         mock_response.next_page_token = "next-ver-file-token"
@@ -152,7 +152,7 @@ class TestModelList(unittest.TestCase):
         self.assertEqual(request.page_token, "token-789")
 
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_model_instance_files_empty(self, mock_client):
+    def test_model_instance_files_empty_returns_empty_list(self, mock_client):
         mock_kaggle = MagicMock()
         mock_kaggle.models.model_api_client.list_model_instance_version_files.return_value = None
         mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
@@ -169,7 +169,7 @@ class TestModelList(unittest.TestCase):
         self.assertIn("No files found", f.getvalue())
 
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_model_instance_version_files_empty(self, mock_client):
+    def test_model_instance_version_files_empty_returns_none(self, mock_client):
         mock_kaggle = MagicMock()
         mock_kaggle.models.model_api_client.list_model_instance_version_files.return_value = None
         mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)

--- a/tests/unit/test_model_list.py
+++ b/tests/unit/test_model_list.py
@@ -46,14 +46,11 @@ class TestModelList(unittest.TestCase):
 
         import io
         from contextlib import redirect_stdout
+
         f = io.StringIO()
         with redirect_stdout(f):
             result = self.api.model_list(
-                sort_by="voteCount",
-                search="query",
-                owner="owner",
-                page_size=10,
-                page_token="token-123"
+                sort_by="voteCount", search="query", owner="owner", page_size=10, page_token="token-123"
             )
 
         self.assertEqual(result, [mock_model])
@@ -83,25 +80,22 @@ class TestModelList(unittest.TestCase):
         mock_kaggle = MagicMock()
         mock_response = MagicMock(spec=ApiListModelInstanceVersionFilesResponse)
         mock_response.next_page_token = "next-file-token"
-        
+
         mock_file = MagicMock()
         mock_file.name = "model.h5"
         mock_file.size = 1024
         mock_response.files = [mock_file]
-        
+
         mock_kaggle.models.model_api_client.list_model_instance_version_files.return_value = mock_response
         mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
         mock_client.return_value.__exit__ = MagicMock(return_value=False)
 
         import io
         from contextlib import redirect_stdout
+
         f = io.StringIO()
         with redirect_stdout(f):
-            result = self.api.model_instance_files(
-                "owner/model/keras/instance",
-                page_token="token-456",
-                page_size=50
-            )
+            result = self.api.model_instance_files("owner/model/keras/instance", page_token="token-456", page_size=50)
 
         self.assertIsInstance(result, FileList)
         self.assertIn("Next Page Token = next-file-token", f.getvalue())
@@ -137,12 +131,11 @@ class TestModelList(unittest.TestCase):
 
         import io
         from contextlib import redirect_stdout
+
         f = io.StringIO()
         with redirect_stdout(f):
             result = self.api.model_instance_version_files(
-                "owner/model/keras/instance/3",
-                page_token="token-789",
-                page_size=5
+                "owner/model/keras/instance/3", page_token="token-789", page_size=5
             )
 
         self.assertEqual(result, mock_response)
@@ -167,6 +160,7 @@ class TestModelList(unittest.TestCase):
 
         import io
         from contextlib import redirect_stdout
+
         f = io.StringIO()
         with redirect_stdout(f):
             result = self.api.model_instance_files("owner/model/keras/instance")
@@ -183,6 +177,7 @@ class TestModelList(unittest.TestCase):
 
         import io
         from contextlib import redirect_stdout
+
         f = io.StringIO()
         with redirect_stdout(f):
             result = self.api.model_instance_version_files("owner/model/keras/instance/3")


### PR DESCRIPTION
test: improve coverage for Models API (Phase 2)

Added unit tests for:
- model_instance_create & model_instance_update (validation, success, partial update, field mask)
- model_create_new & model_update (validation, success, partial update)
- model_instance_version_download (validation, cached, download needed, force, untar success/failure)
- model listing helpers (model_list, model_instance_files, model_instance_version_files)

Improves kaggle_api_extended.py coverage by ~5% (+250 lines).

TAG=agy
CONV=c0cb1f34-2aad-4606-a254-bd3618cb845f
