### PR TITLE
feat(cli): add competitions hosts list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See the [User documentation](docs/README.md) for more examples & tutorials.
 End-to-end host commands — scaffold a new competition, author its pages, and
 launch it — are documented in
 [docs/competition_creation.md](docs/competition_creation.md). Covers
-`kaggle competitions init`, `create`, `pages create`, and `launch`.
+`kaggle competitions init`, `create`, `pages create`, `hosts`, and `launch`.
 
 ## Development
 

--- a/docs/competition_creation.md
+++ b/docs/competition_creation.md
@@ -6,6 +6,7 @@ public competition-creation API endpoints (kagglesdk 0.1.31+):
 - [`kaggle competitions init`](#kaggle-competitions-init)
 - [`kaggle competitions create`](#kaggle-competitions-create)
 - [`kaggle competitions pages create`](#kaggle-competitions-pages-create)
+- [`kaggle competitions hosts`](#kaggle-competitions-hosts)
 - [`kaggle competitions launch`](#kaggle-competitions-launch)
 - [`kaggle competitions data update`](#kaggle-competitions-data-update)
 
@@ -307,6 +308,41 @@ deleted; attempting to delete one returns an error from the server.
 
 Deletion is not recoverable — there is no "undelete". List pages first with
 `kaggle competitions pages list <competition>` if you're unsure of the name.
+
+---
+
+## `kaggle competitions hosts`
+
+Lists the hosts (users with host access) for a competition. Useful for
+confirming who can edit settings, upload data, or launch — especially after
+adding or removing collaborators via the web UI.
+
+Also invocable as `kaggle competitions hosts list`.
+
+**Usage:**
+
+```bash
+kaggle competitions hosts <competition> [-v | --format json]
+```
+
+**Arguments:**
+
+- `<competition>`: The competition slug.
+
+**Examples:**
+
+```bash
+# Table output.
+kaggle competitions hosts my-comp
+
+# CSV — useful for piping into other tools.
+kaggle competitions hosts my-comp -v
+
+# JSON.
+kaggle competitions hosts my-comp --format json
+```
+
+Output columns: `userName`, `displayName`, `id`, `profileUrl`.
 
 ---
 

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -102,6 +102,7 @@ from kagglesdk.competitions.types.competition_api_service import (
     ApiDeleteCompetitionPageRequest,
     ApiUpdateCompetitionPageRequest,
     ApiGetCompetitionSettingsRequest,
+    ApiListCompetitionHostsRequest,
     ApiCreateCompetitionDataRequest,
     ApiCreateCompetitionDataResponse,
     ApiCompetitionDataFile,
@@ -883,6 +884,7 @@ class KaggleApi:
     episode_fields = ["id", "createTime", "endTime", "state", "type"]
     episode_agent_fields = ["submissionId", "index", "reward", "state", "teamName", "teamId"]
     competition_page_fields = ["name"]
+    competition_host_fields = ["userName", "displayName", "id", "profileUrl"]
     competition_topic_fields = ["id", "title", "authorName", "commentCount", "votes", "postDate"]
     competition_topic_message_fields = ["id", "authorName", "postDate", "votes", "content"]
     valid_topic_sort_by = ["hot", "top", "new", "recent", "active", "relevance"]
@@ -2394,6 +2396,49 @@ class KaggleApi:
             )
         else:
             print("No pages found")
+
+    def competition_list_hosts(self, competition: str):
+        """List hosts (users with host access) for a competition.
+
+        Args:
+            competition (str): The competition name (slug).
+
+        Returns:
+            list: A list of ApiCompetitionHost objects.
+        """
+        with self.build_kaggle_client() as kaggle:
+            request = ApiListCompetitionHostsRequest()
+            request.competition_name = competition
+            response = kaggle.competitions.competition_api_client.list_competition_hosts(request)
+            return response.hosts
+
+    def competition_list_hosts_cli(
+        self,
+        competition=None,
+        competition_opt=None,
+        csv_display=False,
+        quiet=False,
+        output_format=None,
+    ):
+        """CLI wrapper for competition_list_hosts."""
+        competition = competition or competition_opt
+        if competition is None:
+            competition = self.get_config_value(self.CONFIG_NAME_COMPETITION)
+            if competition is not None and not quiet:
+                print("Using competition: " + competition)
+        if competition is None:
+            raise ValueError("No competition specified")
+
+        hosts = self.competition_list_hosts(competition)
+        if hosts:
+            self.print_results(
+                hosts,
+                self.competition_host_fields,
+                csv_display=csv_display,
+                output_format=output_format,
+            )
+        else:
+            print("No hosts found")
 
     def competition_create_page(
         self,

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -564,6 +564,38 @@ def parse_competitions(subparsers) -> None:
     parser_competitions_pages_delete._action_groups.append(parser_competitions_pages_delete_optional)
     parser_competitions_pages_delete.set_defaults(func=api.competition_delete_page_cli)
 
+    # Competitions hosts (group: list)
+    shared_competition_hosts_list = argparse.ArgumentParser(add_help=False)
+    shared_competition_hosts_list.add_argument("competition", nargs="?", default=None, help=Help.param_competition)
+    shared_competition_hosts_list.add_argument(
+        "-c", "--competition", dest="competition_opt", required=False, help=argparse.SUPPRESS
+    )
+    _add_output_format_args(shared_competition_hosts_list)
+    shared_competition_hosts_list.add_argument(
+        "-q", "--quiet", dest="quiet", action="store_true", help=Help.param_quiet
+    )
+
+    parser_competitions_hosts = subparsers_competitions.add_parser(
+        "hosts",
+        formatter_class=argparse.RawTextHelpFormatter,
+        help=Help.command_competitions_hosts,
+        parents=[shared_competition_hosts_list],
+    )
+    subparsers_competitions_hosts = parser_competitions_hosts.add_subparsers(title="commands", dest="command")
+    subparsers_competitions_hosts.choices = Help.entity_hosts_choices
+
+    # Default action when no subcommand is given: list
+    parser_competitions_hosts.set_defaults(func=api.competition_list_hosts_cli)
+
+    # Competitions hosts list (explicit)
+    parser_competitions_hosts_list = subparsers_competitions_hosts.add_parser(
+        "list",
+        formatter_class=argparse.RawTextHelpFormatter,
+        help=Help.command_competitions_hosts,
+        parents=[shared_competition_hosts_list],
+    )
+    parser_competitions_hosts_list.set_defaults(func=api.competition_list_hosts_cli)
+
     # Competitions data (group: update)
     parser_competitions_data = subparsers_competitions.add_parser(
         "data",
@@ -2225,6 +2257,7 @@ class Help(object):
         "replay",
         "logs",
         "pages",
+        "hosts",
         "data",
         "settings",
         "launch",
@@ -2292,6 +2325,7 @@ class Help(object):
     forums_topics_choices = ["list", "show"]
     entity_topics_choices = ["list", "show"]
     entity_pages_choices = ["list", "create", "update", "delete"]
+    entity_hosts_choices = ["list"]
     entity_data_choices = ["update"]
     entity_settings_choices = ["get"]
     config_choices = ["view", "set", "unset"]
@@ -2369,6 +2403,7 @@ class Help(object):
     command_competitions_pages_create = "Create a new page on a competition you host"
     command_competitions_pages_update = "Update fields on an existing competition page"
     command_competitions_pages_delete = "Delete a page from a competition you host"
+    command_competitions_hosts = "List hosts (users with host access) for a competition"
     command_competitions_data = "Manage a competition's data files"
     command_competitions_data_update = "Update (version) the data files for a competition you host"
     command_competitions_settings = "Manage settings for a competition you host"

--- a/tests/unit/test_competition_list_hosts.py
+++ b/tests/unit/test_competition_list_hosts.py
@@ -1,0 +1,115 @@
+# coding=utf-8
+import io
+import sys
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, "../..")
+
+from kaggle.api.kaggle_api_extended import KaggleApi
+from kagglesdk.competitions.types.competition_api_service import ApiCompetitionHost
+
+
+def _make_host(id_, user_name, display_name="", profile_url=""):
+    h = ApiCompetitionHost()
+    h.id = id_
+    h.user_name = user_name
+    h.display_name = display_name
+    h.profile_url = profile_url
+    return h
+
+
+class TestCompetitionListHosts(unittest.TestCase):
+    """Tests for competition_list_hosts and its CLI wrapper."""
+
+    def setUp(self):
+        self.api = KaggleApi.__new__(KaggleApi)
+        self.api.config_values = {}
+
+    def _patch_client(self, mock_client, hosts=None):
+        mock_kaggle = MagicMock()
+        response = MagicMock()
+        response.hosts = hosts if hosts is not None else []
+        mock_kaggle.competitions.competition_api_client.list_competition_hosts.return_value = response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+        return mock_kaggle
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_list_hosts_builds_request_with_competition_name(self, mock_client):
+        mock_kaggle = self._patch_client(mock_client, [_make_host(1, "alice")])
+
+        result = self.api.competition_list_hosts("my-comp")
+
+        request = mock_kaggle.competitions.competition_api_client.list_competition_hosts.call_args[0][0]
+        self.assertEqual(request.competition_name, "my-comp")
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].user_name, "alice")
+
+    @patch.object(KaggleApi, "competition_list_hosts")
+    def test_cli_positional_competition(self, mock_list):
+        mock_list.return_value = [_make_host(1, "alice")]
+        with redirect_stdout(io.StringIO()):
+            self.api.competition_list_hosts_cli(competition="my-comp")
+        mock_list.assert_called_once_with("my-comp")
+
+    @patch.object(KaggleApi, "competition_list_hosts")
+    def test_cli_dash_c_option(self, mock_list):
+        mock_list.return_value = []
+        with redirect_stdout(io.StringIO()):
+            self.api.competition_list_hosts_cli(competition_opt="my-comp")
+        mock_list.assert_called_once_with("my-comp")
+
+    @patch.object(KaggleApi, "competition_list_hosts")
+    def test_cli_falls_back_to_config(self, mock_list):
+        mock_list.return_value = []
+        self.api.config_values = {self.api.CONFIG_NAME_COMPETITION: "from-config"}
+        with redirect_stdout(io.StringIO()):
+            self.api.competition_list_hosts_cli()
+        mock_list.assert_called_once_with("from-config")
+
+    def test_cli_missing_competition_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.api.competition_list_hosts_cli()
+        self.assertIn("No competition specified", str(ctx.exception))
+
+    @patch.object(KaggleApi, "competition_list_hosts")
+    def test_cli_empty_prints_no_hosts_found(self, mock_list):
+        mock_list.return_value = []
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            self.api.competition_list_hosts_cli(competition="my-comp")
+        self.assertIn("No hosts found", buf.getvalue())
+
+    @patch.object(KaggleApi, "competition_list_hosts")
+    def test_cli_table_output_lists_hosts(self, mock_list):
+        mock_list.return_value = [
+            _make_host(42, "alice", "Alice A", "https://www.kaggle.com/alice"),
+            _make_host(99, "bob", "Bob B", "https://www.kaggle.com/bob"),
+        ]
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            self.api.competition_list_hosts_cli(competition="my-comp")
+        out = buf.getvalue()
+        self.assertIn("userName", out)
+        self.assertIn("displayName", out)
+        self.assertIn("profileUrl", out)
+        self.assertIn("alice", out)
+        self.assertIn("bob", out)
+        self.assertIn("42", out)
+
+    @patch.object(KaggleApi, "competition_list_hosts")
+    def test_cli_csv_output(self, mock_list):
+        mock_list.return_value = [_make_host(42, "alice", "Alice A", "https://www.kaggle.com/alice")]
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            self.api.competition_list_hosts_cli(competition="my-comp", csv_display=True)
+        out = buf.getvalue()
+        # CSV header line
+        self.assertIn("userName,displayName,id,profileUrl", out)
+        self.assertIn("alice,Alice A,42,https://www.kaggle.com/alice", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds `kaggle competitions hosts [competition]` (aliased as `hosts list`) which wraps the SDK's list_competition_hosts endpoint and prints the users with host access to a competition. Uses the shared table/CSV/JSON output plumbing.