### PR TITLE
Add leaderboard subcommand to kaggle benchmarks

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -2,11 +2,13 @@
 
 Commands for interacting with Kaggle Benchmarks. Benchmarks let you define evaluation tasks as Python scripts, run them against one or more LLM models via the Kaggle Model Proxy, and download the results.
 
-The top-level command is `kaggle benchmarks` (alias: `kaggle b`), which has three sub-groups:
+The top-level command is `kaggle benchmarks` (alias: `kaggle b`), which has the following subcommands and groups:
 
 *   **`auth`** — Fetch Model Proxy credentials.
 *   **`init`** — Fetch credentials and default environment variables for local development.
+*   **`leaderboard`** — Get benchmark leaderboard information.
 *   **`tasks`** (alias: `t`) — Manage benchmark tasks (push, run, list, status, download, log, models, delete, publish).
+*   **`topics`** — Browse discussion topics for a benchmark.
 
 ## `kaggle benchmarks auth`
 
@@ -85,6 +87,55 @@ In addition to the three credential variables written by `auth`, `init` also wri
 *   **`kaggle_benchmarks_reference.md`** — A syntax reference document for the `kaggle-benchmarks` task API.
 
 If either file already exists, it is skipped without overwriting.
+
+---
+
+## `kaggle benchmarks leaderboard`
+
+Get benchmark leaderboard information.
+
+**Usage:**
+
+```bash
+kaggle benchmarks leaderboard <BENCHMARK> [options]
+```
+
+**Arguments:**
+
+*   `<BENCHMARK>`: Benchmark slug (e.g., `owner/benchmark-slug`).
+
+**Options:**
+
+*   `--version <VERSION>`: Benchmark version (optional).
+*   `-s, --show`: Show the leaderboard in the terminal.
+*   `-d, --download`: Download the leaderboard as a CSV file.
+*   `-p, --path <DIRECTORY>`: Folder where the leaderboard will be downloaded (defaults to current working directory).
+*   `-v, --csv`: Print results in CSV format (when used with `--show`).
+*   `--format <FORMAT>`: Print results in a specific format (e.g., `json`).
+
+**Examples:**
+
+1.  Show the leaderboard for a benchmark:
+
+    ```bash
+    kaggle b leaderboard owner/my-benchmark --show
+    ```
+
+2.  Download the leaderboard as CSV:
+
+    ```bash
+    kaggle b leaderboard owner/my-benchmark --download
+    ```
+
+3.  Show a specific version of the leaderboard in JSON format:
+
+    ```bash
+    kaggle b leaderboard owner/my-benchmark --version 2 --show --format json
+    ```
+
+**Purpose:**
+
+Displays or downloads the evaluation results for all models that have run tasks in the specified benchmark. The leaderboard is represented as a table where rows are model versions and columns are benchmark tasks, showing the score achieved by each model on each task.
 
 ---
 

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -21,6 +21,7 @@ import csv
 from datetime import datetime, timezone
 from enum import Enum
 import io
+from contextlib import redirect_stdout
 
 import json  # Needed by mypy.
 import logging
@@ -72,7 +73,11 @@ from kagglesdk.benchmarks.types.benchmark_tasks_api_service import (
     ApiPublishBenchmarkTaskRequest,
 )
 from kagglesdk.benchmarks.types.benchmark_types import BenchmarkTaskOptions
-from kagglesdk.benchmarks.types.benchmarks_api_service import ApiListBenchmarkModelsRequest
+from kagglesdk.benchmarks.types.benchmarks_api_service import (
+    ApiListBenchmarkModelsRequest,
+    ApiGetBenchmarkLeaderboardRequest,
+    ApiBenchmarkLeaderboard,
+)
 from kagglesdk.competitions.types.competition_api_service import (
     ApiListCompetitionsRequest,
     ApiCreateCodeSubmissionRequest,
@@ -9725,6 +9730,122 @@ class KaggleApi:
                     print("Backing notebook also published.")
                 else:
                     print("Note: No backing notebook is associated with this task.", file=sys.stderr)
+
+    def benchmark_leaderboard_view(self, benchmark: str, version: Optional[int] = None) -> ApiBenchmarkLeaderboard:
+        """View a leaderboard based on a benchmark name.
+
+        Args:
+            benchmark (str): The benchmark name (owner/slug) to view leaderboard for.
+            version (Optional[int]): The benchmark version (optional).
+
+        Returns:
+            ApiBenchmarkLeaderboard: The leaderboard response.
+        """
+        owner_slug, benchmark_slug = self.split_benchmark_string(benchmark)
+        with self.build_kaggle_client() as kaggle:
+            request = ApiGetBenchmarkLeaderboardRequest()
+            request.owner_slug = owner_slug
+            request.benchmark_slug = benchmark_slug
+            if version is not None:
+                request.version_number = version
+            response = self.with_retry(kaggle.benchmarks.benchmarks_api_client.get_benchmark_leaderboard)(request)
+        return response
+
+    def benchmark_leaderboard_cli(
+        self,
+        benchmark,
+        version=None,
+        view=False,
+        download=False,
+        path=None,
+        csv_display=False,
+        output_format=None,
+        quiet=False,
+    ):
+        """A wrapper for benchmark_leaderboard_view that will print the results or download them.
+
+        Args:
+            benchmark (str): The benchmark name (owner/slug) to view leaderboard for.
+            version (Optional[int]): The benchmark version (optional).
+            view (bool): If True, show the results in the terminal.
+            download (bool): If True, download the leaderboard as CSV.
+            path (Optional[str]): Path to download folder.
+            csv_display (bool): If True, print CSV instead of table (legacy).
+            output_format (Optional[str]): The output format to use.
+            quiet (bool): Suppress verbose output.
+        """
+        if not view and not download:
+            raise ValueError("Either --show or --download must be specified")
+
+        owner_slug, benchmark_slug = self.split_benchmark_string(benchmark)
+
+        response = self.benchmark_leaderboard_view(benchmark, version)
+
+        if not response.rows:
+            if not quiet:
+                print("No results found")
+            return
+
+        # Flatten the response
+        tasks = {}  # slug -> name
+        for row in response.rows:
+            for result in row.task_results:
+                tasks[result.benchmark_task_slug] = result.benchmark_task_name
+
+        sorted_task_slugs = sorted(tasks.keys())
+
+        def slug_to_field(slug):
+            return slug.replace("-", "_")
+
+        fields = ["model"] + [slug_to_field(slug) for slug in sorted_task_slugs]
+        labels = ["Model"] + [tasks[slug] for slug in sorted_task_slugs]
+
+        items = []
+        for row in response.rows:
+            row_view = BenchmarkLeaderboardRowView(row.model_version_name)
+            for slug in sorted_task_slugs:
+                setattr(row_view, slug_to_field(slug), "N/A")
+            for result in row.task_results:
+                field_name = slug_to_field(result.benchmark_task_slug)
+                score = "N/A"
+                if result.result:
+                    if result.result.numeric_result:
+                        score = str(result.result.numeric_result.value)
+                    elif result.result.boolean_result is not None:
+                        score = "Pass" if result.result.boolean_result else "Fail"
+                setattr(row_view, field_name, score)
+            items.append(row_view)
+
+        if download:
+            if path is None:
+                effective_path = self.get_default_download_dir("benchmarks", benchmark_slug)
+            else:
+                effective_path = path
+
+            os.makedirs(effective_path, exist_ok=True)
+            file_name = benchmark_slug + "_leaderboard.csv"
+            outfile = os.path.join(effective_path, file_name)
+
+            with open(outfile, "w", newline="", encoding="utf-8") as f:
+                with redirect_stdout(f):
+                    self.print_csv(items, fields, labels)
+            if not quiet:
+                print(f"Leaderboard downloaded to {outfile}")
+
+        if view:
+            self.print_results(
+                items,
+                fields,
+                labels=labels,
+                csv_display=csv_display,
+                output_format=output_format,
+            )
+
+
+class BenchmarkLeaderboardRowView(object):
+
+    def __init__(self, model):
+        self.model = model
 
 
 class TqdmBufferedReader(io.BufferedReader):

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -1891,6 +1891,7 @@ def parse_benchmarks_leaderboard(subparsers) -> None:
         "-d", "--download", dest="download", action="store_true", help=Help.param_benchmarks_leaderboard_download
     )
     parser_leaderboard_optional.add_argument("-p", "--path", dest="path", help=Help.param_downfolder)
+    parser_leaderboard_optional.add_argument("-q", "--quiet", dest="quiet", action="store_true", help=Help.param_quiet)
     _add_output_format_args(parser_leaderboard_optional)
     parser_leaderboard._action_groups.append(parser_leaderboard_optional)
     parser_leaderboard.set_defaults(func=api.benchmark_leaderboard_cli)

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -1784,6 +1784,7 @@ def parse_benchmarks(subparsers) -> None:
     parse_benchmark_tasks(subparsers_benchmarks)
     parse_benchmarks_auth(subparsers_benchmarks)
     parse_benchmarks_init(subparsers_benchmarks)
+    parse_benchmarks_leaderboard(subparsers_benchmarks)
 
     shared_topics = _get_shared_topics_parser()
 
@@ -1870,6 +1871,29 @@ def parse_benchmarks_init(subparsers) -> None:
     )
     parser_init._action_groups.append(parser_init_optional)
     parser_init.set_defaults(func=api.benchmarks_init_cli)
+
+
+def parse_benchmarks_leaderboard(subparsers) -> None:
+    parser_leaderboard = subparsers.add_parser(
+        "leaderboard",
+        formatter_class=argparse.RawTextHelpFormatter,
+        help=Help.command_benchmarks_leaderboard,
+    )
+    parser_leaderboard_optional = parser_leaderboard._action_groups.pop()
+    parser_leaderboard_optional.add_argument("benchmark", help=Help.param_benchmark)
+    parser_leaderboard_optional.add_argument(
+        "--version", dest="version", type=int, help=Help.param_benchmarks_leaderboard_version
+    )
+    parser_leaderboard_optional.add_argument(
+        "-s", "--show", dest="view", action="store_true", help=Help.param_benchmarks_leaderboard_view
+    )
+    parser_leaderboard_optional.add_argument(
+        "-d", "--download", dest="download", action="store_true", help=Help.param_benchmarks_leaderboard_download
+    )
+    parser_leaderboard_optional.add_argument("-p", "--path", dest="path", help=Help.param_downfolder)
+    _add_output_format_args(parser_leaderboard_optional)
+    parser_leaderboard._action_groups.append(parser_leaderboard_optional)
+    parser_leaderboard.set_defaults(func=api.benchmark_leaderboard_cli)
 
 
 def parse_benchmark_tasks(subparsers) -> None:
@@ -2344,7 +2368,7 @@ class Help(object):
     model_instances_choices = ["versions", "v", "get", "files", "list", "init", "create", "delete", "update"]
     model_instance_versions_choices = ["init", "create", "download", "delete", "files", "list"]
     files_choices = ["upload"]
-    benchmarks_choices = ["tasks", "t", "auth", "init", "topics"]
+    benchmarks_choices = ["tasks", "t", "auth", "init", "topics", "leaderboard"]
     benchmarks_tasks_choices = [
         "push",
         "run",
@@ -2493,6 +2517,7 @@ class Help(object):
     # Benchmarks commands
     command_benchmarks_auth = "Fetch and persist Model Proxy credential information"
     command_benchmarks_topics = "List discussion topics for a benchmark"
+    command_benchmarks_leaderboard = "Get benchmark leaderboard information"
     command_benchmarks_init = (
         "Fetch and persist  Model Proxy credentials and other Kaggle Benchmarks environment variables"
     )
@@ -2769,6 +2794,9 @@ class Help(object):
         "Omitting this on a re-push detaches previously-attached datasets."
     )
     param_benchmarks_no_publish_backing_notebook = "Do not publish the backing notebook (it is published by default)."
+    param_benchmarks_leaderboard_view = "Show the leaderboard"
+    param_benchmarks_leaderboard_download = "Download leaderboard"
+    param_benchmarks_leaderboard_version = "Benchmark version"
 
     # Files params
     param_files_upload_inbox_path = "Virtual path on the server where the uploaded files will be stored"

--- a/tests/unit/test_benchmarks_leaderboard.py
+++ b/tests/unit/test_benchmarks_leaderboard.py
@@ -1,0 +1,224 @@
+import argparse
+from unittest.mock import MagicMock, patch
+import pytest
+import os
+from contextlib import redirect_stdout
+import io
+
+from kaggle.api.kaggle_api_extended import KaggleApi
+from kagglesdk.benchmarks.types.benchmarks_api_service import ApiBenchmarkLeaderboard
+
+
+@pytest.fixture
+def api():
+    a = KaggleApi()
+    a.authenticate = MagicMock()
+    mock_client = MagicMock()
+    a.build_kaggle_client = MagicMock()
+    a.build_kaggle_client.return_value.__enter__.return_value = mock_client
+    a._mock_client = mock_client
+    a._mock_benchmarks = mock_client.benchmarks.benchmarks_api_client
+    return a
+
+
+def _make_leaderboard_response(rows_data):
+    response = MagicMock(spec=ApiBenchmarkLeaderboard)
+    rows = []
+    for r_data in rows_data:
+        row = MagicMock()
+        row.model_version_name = r_data["model_name"]
+        row.model_version_slug = r_data["model_slug"]
+
+        task_results = []
+        for t_data in r_data["results"]:
+            tr = MagicMock()
+            tr.benchmark_task_name = t_data["task_name"]
+            tr.benchmark_task_slug = t_data["task_slug"]
+            tr.task_version = 1
+
+            res = MagicMock()
+            if "score" in t_data:
+                res.numeric_result.value = t_data["score"]
+                res.boolean_result = None
+            elif "pass" in t_data:
+                res.numeric_result = None
+                res.boolean_result = t_data["pass"]
+            else:
+                res.numeric_result = None
+                res.boolean_result = None
+            tr.result = res
+            task_results.append(tr)
+
+        row.task_results = task_results
+        rows.append(row)
+    response.rows = rows
+    return response
+
+
+class TestBenchmarksLeaderboard:
+
+    def test_benchmark_leaderboard_view_success(self, api):
+        # Arrange
+        mock_response = _make_leaderboard_response([])
+        api._mock_benchmarks.get_benchmark_leaderboard.return_value = mock_response
+
+        # Act
+        response = api.benchmark_leaderboard_view("owner/benchmark-slug", version=2)
+
+        # Assert
+        api._mock_benchmarks.get_benchmark_leaderboard.assert_called_once()
+        request = api._mock_benchmarks.get_benchmark_leaderboard.call_args[0][0]
+        assert request.owner_slug == "owner"
+        assert request.benchmark_slug == "benchmark-slug"
+        assert request.version_number == 2
+        assert response == mock_response
+
+    def test_benchmark_leaderboard_cli_show_table(self, api, capsys):
+        # Arrange
+        rows_data = [
+            {
+                "model_name": "Model A",
+                "model_slug": "model-a",
+                "results": [
+                    {"task_name": "Task 1", "task_slug": "task-1", "score": 0.85},
+                    {"task_name": "Task 2", "task_slug": "task-2", "score": 0.92},
+                ],
+            },
+            {
+                "model_name": "Model B",
+                "model_slug": "model-b",
+                "results": [
+                    {"task_name": "Task 1", "task_slug": "task-1", "score": 0.70},
+                ],
+            },
+        ]
+        mock_response = _make_leaderboard_response(rows_data)
+        api._mock_benchmarks.get_benchmark_leaderboard.return_value = mock_response
+
+        # Act
+        api.benchmark_leaderboard_cli("owner/benchmark-slug", view=True)
+
+        # Assert
+        captured = capsys.readouterr()
+        # Verify headers
+        assert "Model" in captured.out
+        assert "Task 1" in captured.out
+        assert "Task 2" in captured.out
+        # Verify values
+        assert "Model A" in captured.out
+        assert "0.85" in captured.out
+        assert "0.92" in captured.out
+        assert "Model B" in captured.out
+        assert "0.7" in captured.out
+
+        lines = captured.out.split("\n")
+        model_b_line = [l for l in lines if "Model B" in l][0]
+        assert "N/A" in model_b_line
+
+    def test_benchmark_leaderboard_cli_show_csv(self, api, capsys):
+        # Arrange
+        rows_data = [
+            {
+                "model_name": "Model A",
+                "model_slug": "model-a",
+                "results": [
+                    {"task_name": "Task 1", "task_slug": "task-1", "score": 0.85},
+                ],
+            }
+        ]
+        mock_response = _make_leaderboard_response(rows_data)
+        api._mock_benchmarks.get_benchmark_leaderboard.return_value = mock_response
+
+        # Act
+        api.benchmark_leaderboard_cli("owner/benchmark-slug", view=True, csv_display=True)
+
+        # Assert
+        captured = capsys.readouterr()
+        lines = [l.strip() for l in captured.out.strip().split("\n")]
+        assert lines[0] == "Model,Task 1"
+        assert lines[1] == "Model A,0.85"
+
+    def test_benchmark_leaderboard_cli_download(self, api, tmp_path):
+        # Arrange
+        rows_data = [
+            {
+                "model_name": "Model A",
+                "model_slug": "model-a",
+                "results": [
+                    {"task_name": "Task 1", "task_slug": "task-1", "score": 0.85},
+                ],
+            }
+        ]
+        mock_response = _make_leaderboard_response(rows_data)
+        api._mock_benchmarks.get_benchmark_leaderboard.return_value = mock_response
+
+        # Act
+        api.benchmark_leaderboard_cli("owner/benchmark-slug", download=True, path=str(tmp_path))
+
+        # Assert
+        expected_file = tmp_path / "benchmark-slug_leaderboard.csv"
+        assert expected_file.exists()
+        content = expected_file.read_text()
+        lines = [l.strip() for l in content.strip().split("\n")]
+        assert lines[0] == "Model,Task 1"
+        assert lines[1] == "Model A,0.85"
+
+    def test_benchmark_leaderboard_cli_no_show_or_download_raises_value_error(self, api):
+        with pytest.raises(ValueError, match="Either --show or --download must be specified"):
+            api.benchmark_leaderboard_cli("owner/benchmark-slug")
+
+
+class TestCliArgParsing:
+
+    def setup_method(self):
+        self.parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
+        subparsers = self.parser.add_subparsers(title="commands", dest="command")
+        subparsers.required = True
+        from kaggle.cli import parse_benchmarks
+
+        parse_benchmarks(subparsers)
+
+    def _parse(self, arg_string):
+        return self.parser.parse_args(arg_string.split())
+
+    @pytest.mark.parametrize(
+        "cmd, expected",
+        [
+            (
+                "benchmarks leaderboard owner/benchmark-slug -s",
+                {
+                    "command": "leaderboard",
+                    "benchmark": "owner/benchmark-slug",
+                    "view": True,
+                    "download": False,
+                    "version": None,
+                    "path": None,
+                },
+            ),
+            (
+                "benchmarks leaderboard owner/benchmark-slug --download --path /tmp/down",
+                {
+                    "command": "leaderboard",
+                    "benchmark": "owner/benchmark-slug",
+                    "view": False,
+                    "download": True,
+                    "version": None,
+                    "path": "/tmp/down",
+                },
+            ),
+            (
+                "benchmarks leaderboard owner/benchmark-slug --version 3 -s -d",
+                {
+                    "command": "leaderboard",
+                    "benchmark": "owner/benchmark-slug",
+                    "view": True,
+                    "download": True,
+                    "version": 3,
+                },
+            ),
+        ],
+    )
+    def test_cli_parsing(self, cmd, expected):
+        args = self._parse(cmd)
+        for k, v in expected.items():
+            assert getattr(args, k) == v

--- a/tests/unit/test_benchmarks_leaderboard.py
+++ b/tests/unit/test_benchmarks_leaderboard.py
@@ -167,6 +167,42 @@ class TestBenchmarksLeaderboard:
         with pytest.raises(ValueError, match="Either --show or --download must be specified"):
             api.benchmark_leaderboard_cli("owner/benchmark-slug")
 
+    def test_benchmark_leaderboard_cli_no_results_quiet(self, api, capsys):
+        # Arrange
+        mock_response = _make_leaderboard_response([])
+        api._mock_benchmarks.get_benchmark_leaderboard.return_value = mock_response
+
+        # Act
+        api.benchmark_leaderboard_cli("owner/benchmark-slug", view=True, quiet=True)
+
+        # Assert
+        captured = capsys.readouterr()
+        assert "No results found" not in captured.out
+
+    def test_benchmark_leaderboard_cli_download_quiet(self, api, tmp_path, capsys):
+        # Arrange
+        rows_data = [
+            {
+                "model_name": "Model A",
+                "model_slug": "model-a",
+                "results": [
+                    {"task_name": "Task 1", "task_slug": "task-1", "score": 0.85},
+                ],
+            }
+        ]
+        mock_response = _make_leaderboard_response(rows_data)
+        api._mock_benchmarks.get_benchmark_leaderboard.return_value = mock_response
+
+        # Act
+        api.benchmark_leaderboard_cli("owner/benchmark-slug", download=True, path=str(tmp_path), quiet=True)
+
+        # Assert
+        captured = capsys.readouterr()
+        assert "Leaderboard downloaded to" not in captured.out
+
+        expected_file = tmp_path / "benchmark-slug_leaderboard.csv"
+        assert expected_file.exists()
+
 
 class TestCliArgParsing:
 
@@ -214,6 +250,30 @@ class TestCliArgParsing:
                     "view": True,
                     "download": True,
                     "version": 3,
+                },
+            ),
+            (
+                "benchmarks leaderboard owner/benchmark-slug -s -q",
+                {
+                    "command": "leaderboard",
+                    "benchmark": "owner/benchmark-slug",
+                    "view": True,
+                    "download": False,
+                    "version": None,
+                    "path": None,
+                    "quiet": True,
+                },
+            ),
+            (
+                "benchmarks leaderboard owner/benchmark-slug -s --quiet",
+                {
+                    "command": "leaderboard",
+                    "benchmark": "owner/benchmark-slug",
+                    "view": True,
+                    "download": False,
+                    "version": None,
+                    "path": None,
+                    "quiet": True,
                 },
             ),
         ],


### PR DESCRIPTION
- Implement benchmark_leaderboard_view and benchmark_leaderboard_cli in KaggleApi.
- Add leaderboard parser to benchmarks CLI group in cli.py.
- Add unit tests for the new subcommand.
- Update benchmarks.md documentation.

TAG=agy
CONV=c0cb1f34-2aad-4606-a254-bd3618cb845f