### PR TITLE
fix(cli): handle deleted comments in topics show

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -3928,11 +3928,11 @@ class KaggleApi:
         """Recursively print comments with indentation to show tree structure."""
         indent = "  " * depth
         for comment in comments or []:
-            author = getattr(comment, "author_name", "Unknown")
+            author = getattr(comment, "author_name", None) or "[deleted]"
             date = getattr(comment, "post_date", "")
             votes = getattr(comment, "votes", 0)
-            content = getattr(comment, "content", "")
-            if content:
+            content = getattr(comment, "content", None) or "[deleted]"
+            if content and content != "[deleted]":
                 content = bleach.clean(content, tags=[], strip=True).strip()
                 # Truncate long content for display
                 if len(content) > 200:

--- a/tests/unit/test_discussions_cli.py
+++ b/tests/unit/test_discussions_cli.py
@@ -706,3 +706,31 @@ class TestForumsTopicShowCliOutput:
         assert list(output["comments"][0].keys()) == ["content"]
         assert output["comments"][0]["content"] == "Comment Content"
         assert "id" not in output["comments"][0]
+
+    def test_text_output_with_deleted_comments(self, api, capsys):
+        mock_topic = MagicMock()
+        mock_topic.id = 123
+        mock_topic.title = "Test Title"
+        mock_topic.author_name = "test-author"
+        mock_topic.post_date = "2026-06-01"
+        mock_topic.votes = 5
+        mock_topic.comment_count = 1
+        mock_topic.content = "Test Content"
+
+        # Deleted comment (missing author_name and content)
+        mock_comment = MagicMock()
+        mock_comment.id = 456
+        mock_comment.author_name = None
+        mock_comment.content = None
+        mock_comment.post_date = "2026-06-02"
+        mock_comment.votes = 2
+        mock_comment.replies = []
+
+        api.forums_topic_show = MagicMock(return_value=(mock_topic, [mock_comment], ""))
+
+        api.forums_topic_show_cli(topic_ref="123")
+
+        captured = capsys.readouterr()
+
+        assert "├─ [deleted] (2026-06-02) [+2]" in captured.out
+        assert "│  [deleted]" in captured.out


### PR DESCRIPTION
Examine this issue: https://b.corp.google.com/issues/526710152

When showing discussion topics, some comments may have been deleted, resulting in missing 'author_name' and 'content' fields in the API response. Previously, the CLI would print 'None' for the author and skip the content, making it look broken.

Update the comment tree renderer to display '[deleted]' for missing authors and content, preserving the tree structure while clearly indicating deleted comments.

TAG=agy
CONV=2f825acd-64e3-43e4-8fe1-900728c8e126
