### PR TITLE
refactor(cli): reuse _resolve_projection in dataset_status

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -4647,17 +4647,10 @@ class KaggleApi:
             # a plain string instead of JSON.
             selected_fields = ["status"]
         else:
-            format_name, fields = _parse_format(format)
+            format_name, _ = _parse_format(format)
             if format_name != "json":
                 raise ValueError(f"Unsupported format value: {format!r}. Supported formats: json")
-            if fields:
-                unknown = [f for f in fields if f not in self._DATASET_STATUS_FIELDS]
-                if unknown:
-                    raise ValueError(f"Unknown field(s) in format: {', '.join(unknown)}")
-                selected_fields = list(fields)
-            else:
-                # No projection: include all fields.
-                selected_fields = list(self._DATASET_STATUS_FIELDS)
+            selected_fields, _ = self._resolve_projection(format, list(self._DATASET_STATUS_FIELDS))
 
         if "/" in dataset:
             self.validate_dataset_string(dataset)


### PR DESCRIPTION
This PR addresses the task in https://b.corp.google.com/issues/524332679.

It refactors `dataset_status` to reuse the shared `_resolve_projection` helper method for validating and resolving projection fields from the `--format` option, instead of using custom validation logic.

This reduces code duplication and ensures consistent behavior for format projection parsing.

TAG=agy
CONV=2f825acd-64e3-43e4-8fe1-900728c8e126
