### PR TITLE
fix(auth): avoid skipping auth for programmatic imports

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -1130,11 +1130,36 @@ class KaggleApi:
     def _authenticate_anonymously(self) -> bool:
         """Check if the command can run anonymously.
 
+        Anonymous access is derived from ``sys.argv``, which is only a Kaggle
+        command when the Kaggle CLI itself is the running program. When the
+        library is merely imported by another application, ``sys.argv`` belongs
+        to that host script (e.g. ``python my_script.py -h``) and must not be
+        interpreted as a Kaggle CLI command.
+
         Returns:
             bool: True if anonymous access is allowed.
         """
+        if not self._invoked_as_cli():
+            return False
         api_command = " ".join(sys.argv[1:])
         return self._command_allows_logged_out(api_command)
+
+    @staticmethod
+    def _invoked_as_cli() -> bool:
+        """Whether the current process is the Kaggle CLI rather than a host
+        application that imported the library.
+
+        Recognizes the installed console entry point (``kaggle`` /
+        ``kaggle.exe``) and ``python -m kaggle`` (which runs
+        ``kaggle/__main__.py``).
+
+        Returns:
+            bool: True if running as the Kaggle CLI.
+        """
+        prog = (sys.argv[0] if sys.argv else "").replace("\\", "/")
+        if os.path.splitext(os.path.basename(prog))[0] == "kaggle":
+            return True
+        return prog.endswith("/kaggle/__main__.py")
 
     def _authenticate_with_access_token(self) -> bool:
         access_token, source = get_access_token_from_env()

--- a/tests/unit/test_help_version_auth.py
+++ b/tests/unit/test_help_version_auth.py
@@ -37,6 +37,49 @@ class TestHelpOrVersionAuth(unittest.TestCase):
         with patch.object(sys, "argv", ["kaggle", "quota", "-v"]):
             self.assertFalse(self.api._command_allows_logged_out("quota -v"))
 
+    def _assert_anonymous(self, argv, expected):
+        with patch.object(sys, "argv", argv):
+            self.assertEqual(self.api._authenticate_anonymously(), expected)
+
+    # --- CLI invocation: help/version must bypass authentication ---
+
+    def test_cli_help_and_version_bypass_auth(self):
+        # Installed console entry point (`kaggle` / `kaggle.exe`).
+        self._assert_anonymous(["kaggle", "-h"], True)
+        self._assert_anonymous(["kaggle", "--help"], True)
+        self._assert_anonymous(["kaggle", "-v"], True)
+        self._assert_anonymous(["kaggle", "--version"], True)
+        self._assert_anonymous(["/usr/local/bin/kaggle", "-h"], True)
+        self._assert_anonymous(["C:\\Python\\Scripts\\kaggle.exe", "--version"], True)
+
+    def test_python_dash_m_kaggle_help_bypasses_auth(self):
+        # `python -m kaggle` runs kaggle/__main__.py.
+        self._assert_anonymous(["/site-packages/kaggle/__main__.py", "-h"], True)
+        self._assert_anonymous(["C:\\site-packages\\kaggle\\__main__.py", "--version"], True)
+
+    # --- Host script importing the library: never bypass auth via host args ---
+
+    def test_plain_python_script_does_not_bypass_auth(self):
+        # `python my_script.py` (no flags) never allowed anonymous anyway.
+        self._assert_anonymous(["my_script.py"], False)
+
+    def test_host_script_help_version_flags_do_not_bypass_auth(self):
+        # `python my_script.py -h/--help/-v/--version` must NOT be read as a
+        # Kaggle CLI help/version command.
+        self._assert_anonymous(["my_script.py", "-h"], False)
+        self._assert_anonymous(["my_script.py", "--help"], False)
+        self._assert_anonymous(["my_script.py", "-v"], False)
+        self._assert_anonymous(["my_script.py", "--version"], False)
+        self._assert_anonymous(["/home/user/my_script.py", "--help"], False)
+
+    def test_normal_import_without_argv_flags_does_not_bypass_auth(self):
+        # A plain `import kaggle` from an interpreter/host with unrelated argv.
+        self._assert_anonymous(["/home/user/app.py", "serve", "--port", "8080"], False)
+
+    def test_other_module_dash_m_is_not_kaggle_cli(self):
+        # A different `python -m otherpkg` whose __main__.py imports kaggle.
+        self._assert_anonymous(["/site-packages/otherpkg/__main__.py", "-h"], False)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

When `kaggle` is imported, it runs authentication during initialization. The current logic checks `sys.argv` to determine whether authentication can be skipped for help/version commands.

This works for the CLI, but it also affects normal Python programs. For example, running:

    python my_script.py -h

causes the library to treat the host script's `-h` flag as if it were a Kaggle CLI help command. Authentication is skipped, `_authenticated` is set to `True`, and later API calls fail with a 401 error.

## Fix

Only apply the help/version authentication bypass when the current process is actually the Kaggle CLI. This keeps the existing CLI behavior unchanged while preventing host script arguments from affecting programmatic imports.

## Tests

Added unit tests covering:
- `kaggle -h` / `--help` / `-v` / `--version`
- `python -m kaggle`
- Programmatic imports from host scripts with help/version flags