### PR TITLE
Add parser tests for competitions commands

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -16,3 +16,70 @@ os.environ["KAGGLE_KEY"] = "testkey"
 
 with patch("kagglesdk.get_access_token_from_env", return_value=(None, None)):
     import kaggle  # noqa: F401 — triggers authenticate()
+
+
+import argparse
+from unittest.mock import MagicMock
+import pytest
+from kaggle.api.kaggle_api_extended import KaggleApi
+
+
+@pytest.fixture
+def api():
+    a = KaggleApi()
+    a.authenticate = MagicMock()
+    a.build_kaggle_client = MagicMock()
+    return a
+
+
+class KaggleParser:
+    def __init__(self, parser):
+        self._parser = parser
+
+    def dispatch(self, argv):
+        args = self._parser.parse_args(argv)
+        command_args = dict(vars(args))
+        del command_args["func"]
+        del command_args["command"]
+        return args.func, command_args
+
+
+@pytest.fixture
+def parser(monkeypatch, api):
+    import kaggle
+
+    monkeypatch.setattr(kaggle, "api", api)
+
+    from kaggle.cli import (
+        parse_quota,
+        parse_config,
+        parse_auth,
+        parse_files,
+        parse_competitions,
+        parse_datasets,
+        parse_kernels,
+        parse_models,
+        parse_forums,
+        parse_benchmarks,
+        Help,
+    )
+    import kaggle.cli
+
+    monkeypatch.setattr(kaggle.cli, "api", api)
+
+    root = argparse.ArgumentParser()
+    subparsers = root.add_subparsers(title="commands", dest="command")
+    subparsers.required = True
+    subparsers.choices = Help.kaggle_choices
+
+    parse_quota(subparsers)
+    parse_config(subparsers)
+    parse_auth(subparsers)
+    parse_files(subparsers)
+    parse_competitions(subparsers)
+    parse_datasets(subparsers)
+    parse_kernels(subparsers)
+    parse_models(subparsers)
+    parse_forums(subparsers)
+    parse_benchmarks(subparsers)
+    return KaggleParser(root)

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -1,72 +1,24 @@
 # coding=utf-8
-import argparse
-from unittest.mock import MagicMock, patch
 import pytest
-from kaggle.api.kaggle_api_extended import KaggleApi
-
-
-@pytest.fixture
-def api():
-    a = KaggleApi()
-    a.authenticate = MagicMock()
-    a.build_kaggle_client = MagicMock()
-    return a
-
-
-@pytest.fixture
-def parser(monkeypatch, api):
-    import kaggle
-
-    monkeypatch.setattr(kaggle, "api", api)
-
-    from kaggle.cli import (
-        parse_quota,
-        parse_config,
-        parse_auth,
-        parse_files,
-        Help,
-    )
-    import kaggle.cli
-
-    monkeypatch.setattr(kaggle.cli, "api", api)
-
-    root = argparse.ArgumentParser()
-    subparsers = root.add_subparsers(title="commands", dest="command")
-    subparsers.required = True
-    subparsers.choices = Help.kaggle_choices
-
-    parse_quota(subparsers)
-    parse_config(subparsers)
-    parse_auth(subparsers)
-    parse_files(subparsers)
-    return root
-
-
-def _dispatch(parser, argv):
-    args = parser.parse_args(argv)
-    command_args = dict(vars(args))
-    del command_args["func"]
-    del command_args["command"]
-    return args.func, command_args
 
 
 # Task 1.1: Quota
 def test_quota_parser_default_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["quota"])
+    func, kwargs = parser.dispatch(["quota"])
     assert func.__name__ == "quota_view_cli"
     assert kwargs.get("csv_display") is False
     assert kwargs.get("output_format") is None
 
 
 def test_quota_parser_csv_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["quota", "--csv"])
+    func, kwargs = parser.dispatch(["quota", "--csv"])
     assert func.__name__ == "quota_view_cli"
     assert kwargs["csv_display"] is True
     assert kwargs.get("output_format") is None
 
 
 def test_quota_parser_format_json_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["quota", "--format", "json"])
+    func, kwargs = parser.dispatch(["quota", "--format", "json"])
     assert func.__name__ == "quota_view_cli"
     assert kwargs["csv_display"] is False
     assert kwargs["output_format"] == "json"
@@ -74,66 +26,66 @@ def test_quota_parser_format_json_succeeds(parser):
 
 # Task 1.2: Config
 def test_config_view_parser_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["config", "view"])
+    func, kwargs = parser.dispatch(["config", "view"])
     assert func.__name__ == "print_config_values"
     assert kwargs == {}
 
 
 def test_config_set_parser_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["config", "set", "-n", "proxy", "-v", "http://proxy"])
+    func, kwargs = parser.dispatch(["config", "set", "-n", "proxy", "-v", "http://proxy"])
     assert func.__name__ == "set_config_value"
     assert kwargs["name"] == "proxy"
     assert kwargs["value"] == "http://proxy"
 
 
 def test_config_unset_parser_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["config", "unset", "-n", "proxy"])
+    func, kwargs = parser.dispatch(["config", "unset", "-n", "proxy"])
     assert func.__name__ == "unset_config_value"
     assert kwargs["name"] == "proxy"
 
 
 # Task 1.3: Auth
 def test_auth_login_parser_default_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["auth", "login"])
+    func, kwargs = parser.dispatch(["auth", "login"])
     assert func.__name__ == "auth_login_cli"
     assert kwargs["no_launch_browser"] is False
     assert kwargs["force"] is False
 
 
 def test_auth_login_parser_with_flags_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["auth", "login", "--no-launch-browser", "--force"])
+    func, kwargs = parser.dispatch(["auth", "login", "--no-launch-browser", "--force"])
     assert func.__name__ == "auth_login_cli"
     assert kwargs["no_launch_browser"] is True
     assert kwargs["force"] is True
 
 
 def test_auth_print_access_token_parser_default_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["auth", "print-access-token"])
+    func, kwargs = parser.dispatch(["auth", "print-access-token"])
     assert func.__name__ == "auth_print_access_token"
     assert kwargs["expiration_duration"] is None
 
 
 def test_auth_print_access_token_parser_with_expiration_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["auth", "print-access-token", "--expiration", "6h"])
+    func, kwargs = parser.dispatch(["auth", "print-access-token", "--expiration", "6h"])
     assert func.__name__ == "auth_print_access_token"
     assert kwargs["expiration_duration"] == "6h"
 
 
 def test_auth_revoke_token_parser_default_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["auth", "revoke"])
+    func, kwargs = parser.dispatch(["auth", "revoke"])
     assert func.__name__ == "auth_revoke_token"
     assert kwargs["reason"] is None
 
 
 def test_auth_revoke_token_parser_with_reason_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["auth", "revoke", "--reason", "compromised"])
+    func, kwargs = parser.dispatch(["auth", "revoke", "--reason", "compromised"])
     assert func.__name__ == "auth_revoke_token"
     assert kwargs["reason"] == "compromised"
 
 
 # Task 1.4: Files
 def test_files_upload_parser_default_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["files", "upload", "file1.zip", "file2.txt"])
+    func, kwargs = parser.dispatch(["files", "upload", "file1.zip", "file2.txt"])
     assert func.__name__ == "files_upload_cli"
     assert kwargs["local_paths"] == ["file1.zip", "file2.txt"]
     assert kwargs["inbox_path"] == ""
@@ -142,7 +94,7 @@ def test_files_upload_parser_default_succeeds(parser):
 
 
 def test_files_upload_parser_with_flags_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["files", "upload", "file1.zip", "-i", "my_inbox", "--no-resume", "--no-compress"])
+    func, kwargs = parser.dispatch(["files", "upload", "file1.zip", "-i", "my_inbox", "--no-resume", "--no-compress"])
     assert func.__name__ == "files_upload_cli"
     assert kwargs["local_paths"] == ["file1.zip"]
     assert kwargs["inbox_path"] == "my_inbox"

--- a/tests/unit/test_cli_competitions.py
+++ b/tests/unit/test_cli_competitions.py
@@ -1,0 +1,500 @@
+# coding=utf-8
+import pytest
+
+
+def test_competitions_list_parser_default_succeeds(parser):
+    func, kwargs = parser.dispatch(["competitions", "list"])
+    assert func.__name__ == "competitions_list_cli"
+    assert kwargs.get("group") is None
+    assert kwargs.get("category") is None
+    assert kwargs.get("sort_by") is None
+    assert kwargs.get("page") == -1
+    assert kwargs.get("search") is None
+    assert kwargs.get("csv_display") is False
+    assert kwargs.get("page_size") is None
+    assert kwargs.get("page_token") is None
+    assert kwargs.get("output_format") is None
+
+
+def test_competitions_list_parser_with_flags_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "competitions",
+            "list",
+            "--group",
+            "entered",
+            "--category",
+            "featured",
+            "--sort-by",
+            "prize",
+            "--page",
+            "3",
+            "--search",
+            "test",
+            "--csv",
+            "--page-size",
+            "50",
+        ]
+    )
+    assert func.__name__ == "competitions_list_cli"
+    assert kwargs["group"] == "entered"
+    assert kwargs["category"] == "featured"
+    assert kwargs["sort_by"] == "prize"
+    assert kwargs["page"] == 3
+    assert kwargs["search"] == "test"
+    assert kwargs["csv_display"] is True
+    assert kwargs["page_size"] == 50
+    assert kwargs.get("page_token") is None
+    assert kwargs.get("output_format") is None
+
+
+def test_competitions_list_parser_with_page_token_succeeds(parser):
+    func, kwargs = parser.dispatch(["competitions", "list", "--page-token", "token123", "--format", "json"])
+    assert func.__name__ == "competitions_list_cli"
+    assert kwargs["page_token"] == "token123"
+    assert kwargs["output_format"] == "json"
+    assert kwargs["csv_display"] is False
+    assert kwargs["page"] == -1
+
+
+def test_competitions_files_parser_default_succeeds(parser):
+    func, kwargs = parser.dispatch(["competitions", "files"])
+    assert func.__name__ == "competition_list_files_cli"
+    assert kwargs.get("competition") is None
+    assert kwargs.get("competition_opt") is None
+    assert kwargs.get("csv_display") is False
+    assert kwargs.get("output_format") is None
+    assert kwargs.get("quiet") is False
+    assert kwargs.get("page_token") is None
+    assert kwargs.get("page_size") == 20
+
+
+def test_competitions_files_parser_with_flags_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "competitions",
+            "files",
+            "my-competition",
+            "--quiet",
+            "--page-size",
+            "50",
+            "--page-token",
+            "tok",
+        ]
+    )
+    assert func.__name__ == "competition_list_files_cli"
+    assert kwargs["competition"] == "my-competition"
+    assert kwargs["quiet"] is True
+    assert kwargs["page_size"] == 50
+    assert kwargs["page_token"] == "tok"
+
+
+def test_competitions_download_parser_default_succeeds(parser):
+    func, kwargs = parser.dispatch(["competitions", "download"])
+    assert func.__name__ == "competition_download_cli"
+    assert kwargs.get("competition") is None
+    assert kwargs.get("file_name") is None
+    assert kwargs.get("path") is None
+    assert kwargs.get("force") is False
+    assert kwargs.get("quiet") is False
+
+
+def test_competitions_download_parser_with_flags_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "competitions",
+            "download",
+            "my-competition",
+            "-f",
+            "file.csv",
+            "-p",
+            "/tmp/download",
+            "--force",
+            "--quiet",
+        ]
+    )
+    assert func.__name__ == "competition_download_cli"
+    assert kwargs["competition"] == "my-competition"
+    assert kwargs["file_name"] == "file.csv"
+    assert kwargs["path"] == "/tmp/download"
+    assert kwargs["force"] is True
+    assert kwargs["quiet"] is True
+
+
+def test_competitions_download_parser_wp_flag_succeeds(parser):
+    func, kwargs = parser.dispatch(["competitions", "download", "-w"])
+    assert kwargs["path"] == "."
+
+
+def test_competitions_submit_parser_missing_message_fails(parser):
+    with pytest.raises(SystemExit):
+        parser.dispatch(["competitions", "submit", "my-comp", "-f", "sub.csv"])
+
+
+def test_competitions_submit_parser_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "competitions",
+            "submit",
+            "my-comp",
+            "-f",
+            "sub.csv",
+            "-m",
+            "my message",
+            "--sandbox",
+        ]
+    )
+    assert func.__name__ == "competition_submit_cli"
+    assert kwargs["competition"] == "my-comp"
+    assert kwargs["file_name"] == "sub.csv"
+    assert kwargs["message"] == "my message"
+    assert kwargs["sandbox"] is True
+    assert kwargs.get("kernel") is None
+    assert kwargs.get("version") is None
+
+
+def test_competitions_submissions_parser_default_succeeds(parser):
+    func, kwargs = parser.dispatch(["competitions", "submissions"])
+    assert func.__name__ == "competition_submissions_cli"
+    assert kwargs.get("competition") is None
+    assert kwargs.get("csv_display") is False
+    assert kwargs.get("page_size") is None
+
+
+def test_competitions_submissions_parser_with_flags_succeeds(parser):
+    func, kwargs = parser.dispatch(["competitions", "submissions", "my-comp", "--page-size", "10", "--csv"])
+    assert func.__name__ == "competition_submissions_cli"
+    assert kwargs["competition"] == "my-comp"
+    assert kwargs["page_size"] == 10
+    assert kwargs["csv_display"] is True
+
+
+def test_competitions_leaderboard_parser_default_succeeds(parser):
+    func, kwargs = parser.dispatch(["competitions", "leaderboard"])
+    assert func.__name__ == "competition_leaderboard_cli"
+    assert kwargs.get("competition") is None
+    assert kwargs.get("view") is False
+    assert kwargs.get("download") is False
+    assert kwargs.get("path") is None
+
+
+def test_competitions_leaderboard_parser_with_flags_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        ["competitions", "leaderboard", "my-comp", "--show", "--download", "-p", "/tmp/lead"]
+    )
+    assert func.__name__ == "competition_leaderboard_cli"
+    assert kwargs["competition"] == "my-comp"
+    assert kwargs["view"] is True
+    assert kwargs["download"] is True
+    assert kwargs["path"] == "/tmp/lead"
+
+
+def test_competitions_team_submissions_parser_missing_team_id_fails(parser):
+    with pytest.raises(SystemExit):
+        parser.dispatch(["competitions", "team-submissions"])
+
+
+def test_competitions_team_submissions_parser_succeeds(parser):
+    func, kwargs = parser.dispatch(["competitions", "team-submissions", "12345"])
+    assert func.__name__ == "competition_team_submissions_cli"
+    assert kwargs["team_id"] == 12345
+
+
+def test_competitions_episodes_parser_missing_sub_id_fails(parser):
+    with pytest.raises(SystemExit):
+        parser.dispatch(["competitions", "episodes"])
+
+
+def test_competitions_episodes_parser_succeeds(parser):
+    func, kwargs = parser.dispatch(["competitions", "episodes", "123", "--csv"])
+    assert func.__name__ == "competition_list_episodes_cli"
+    assert kwargs["submission_id"] == 123
+    assert kwargs["csv_display"] is True
+
+
+def test_competitions_replay_parser_missing_episode_id_fails(parser):
+    with pytest.raises(SystemExit):
+        parser.dispatch(["competitions", "replay"])
+
+
+def test_competitions_replay_parser_succeeds(parser):
+    func, kwargs = parser.dispatch(["competitions", "replay", "456", "-p", "/tmp/replay"])
+    assert func.__name__ == "competition_episode_replay_cli"
+    assert kwargs["episode_id"] == 456
+    assert kwargs["path"] == "/tmp/replay"
+
+
+def test_competitions_logs_parser_missing_args_fails(parser):
+    with pytest.raises(SystemExit):
+        parser.dispatch(["competitions", "logs"])
+    with pytest.raises(SystemExit):
+        parser.dispatch(["competitions", "logs", "456"])
+
+
+def test_competitions_logs_parser_succeeds(parser):
+    func, kwargs = parser.dispatch(["competitions", "logs", "456", "1", "-p", "/tmp/logs"])
+    assert func.__name__ == "competition_episode_agent_logs_cli"
+    assert kwargs["episode_id"] == 456
+    assert kwargs["agent_index"] == 1
+    assert kwargs["path"] == "/tmp/logs"
+
+
+def test_competitions_pages_default_list_succeeds(parser):
+    func, kwargs = parser.dispatch(["competitions", "pages", "-c", "my-comp"])
+    assert func.__name__ == "competition_list_pages_cli"
+    assert kwargs.get("competition") is None
+    assert kwargs["competition_opt"] == "my-comp"
+    assert kwargs["content"] is False
+    assert kwargs["page_name"] is None
+
+
+def test_competitions_pages_list_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "competitions",
+            "pages",
+            "list",
+            "-c",
+            "my-comp",
+            "--content",
+            "--page-name",
+            "rules",
+        ]
+    )
+    assert func.__name__ == "competition_list_pages_cli"
+    assert kwargs.get("competition") is None
+    assert kwargs["competition_opt"] == "my-comp"
+    assert kwargs["content"] is True
+    assert kwargs["page_name"] == "rules"
+
+
+def test_competitions_pages_create_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "competitions",
+            "pages",
+            "create",
+            "-c",
+            "my-comp",
+            "--page-name",
+            "rules",
+            "-f",
+            "rules.html",
+            "--mime-type",
+            "text/html",
+            "--post-title",
+            "Rules",
+            "--publish",
+        ]
+    )
+    assert func.__name__ == "competition_create_page_cli"
+    assert kwargs.get("competition") is None
+    assert kwargs["competition_opt"] == "my-comp"
+    assert kwargs["page_name"] == "rules"
+    assert kwargs["file_path"] == "rules.html"
+    assert kwargs["mime_type"] == "text/html"
+    assert kwargs["post_title"] == "Rules"
+    assert kwargs["publish"] is True
+
+
+def test_competitions_pages_update_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "competitions",
+            "pages",
+            "update",
+            "-c",
+            "my-comp",
+            "--page-name",
+            "rules",
+            "-f",
+            "new_rules.html",
+            "--new-name",
+            "new-rules",
+            "--publish",
+        ]
+    )
+    assert func.__name__ == "competition_update_page_cli"
+    assert kwargs.get("competition") is None
+    assert kwargs["competition_opt"] == "my-comp"
+    assert kwargs["page_name"] == "rules"
+    assert kwargs["file_path"] == "new_rules.html"
+    assert kwargs["new_name"] == "new-rules"
+    assert kwargs["publish"] is True
+    assert kwargs.get("unpublish") is False
+
+
+def test_competitions_pages_delete_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        ["competitions", "pages", "delete", "-c", "my-comp", "--page-name", "rules", "--yes", "--quiet"]
+    )
+    assert func.__name__ == "competition_delete_page_cli"
+    assert kwargs.get("competition") is None
+    assert kwargs["competition_opt"] == "my-comp"
+    assert kwargs["page_name"] == "rules"
+    assert kwargs["no_confirm"] is True
+    assert kwargs["quiet"] is True
+
+
+def test_competitions_hosts_default_list_succeeds(parser):
+    func, kwargs = parser.dispatch(["competitions", "hosts", "-c", "my-comp"])
+    assert func.__name__ == "competition_list_hosts_cli"
+    assert kwargs.get("competition") is None
+    assert kwargs["competition_opt"] == "my-comp"
+
+
+def test_competitions_hosts_list_succeeds(parser):
+    func, kwargs = parser.dispatch(["competitions", "hosts", "list", "-c", "my-comp"])
+    assert func.__name__ == "competition_list_hosts_cli"
+    assert kwargs.get("competition") is None
+    assert kwargs["competition_opt"] == "my-comp"
+
+
+def test_competitions_data_update_missing_args_fails(parser):
+    with pytest.raises(SystemExit):
+        parser.dispatch(["competitions", "data", "update", "my-comp"])
+
+
+def test_competitions_data_update_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "competitions",
+            "data",
+            "update",
+            "my-comp",
+            "-p",
+            "/path/to/data",
+            "-m",
+            "update msg",
+            "--rerun",
+            "--include-hidden",
+        ]
+    )
+    assert func.__name__ == "competition_data_update_cli"
+    assert kwargs["competition"] == "my-comp"
+    assert kwargs["path"] == "/path/to/data"
+    assert kwargs["version_notes"] == "update msg"
+    assert kwargs["rerun"] is True
+    assert kwargs["include_hidden"] is True
+
+
+def test_competitions_settings_get_succeeds(parser):
+    func, kwargs = parser.dispatch(["competitions", "settings", "get", "my-comp", "--json"])
+    assert func.__name__ == "competition_get_settings_cli"
+    assert kwargs["competition"] == "my-comp"
+    assert kwargs["json_output"] is True
+
+
+def test_competitions_settings_update_missing_file_fails(parser):
+    with pytest.raises(SystemExit):
+        parser.dispatch(["competitions", "settings", "update", "my-comp"])
+
+
+def test_competitions_settings_update_succeeds(parser):
+    func, kwargs = parser.dispatch(["competitions", "settings", "update", "my-comp", "-f", "settings.json", "--json"])
+    assert func.__name__ == "competition_update_settings_cli"
+    assert kwargs["competition"] == "my-comp"
+    assert kwargs["file_path"] == "settings.json"
+    assert kwargs["json_output"] is True
+
+
+def test_competitions_launch_parser_default_succeeds(parser):
+    func, kwargs = parser.dispatch(["competitions", "launch", "my-comp"])
+    assert func.__name__ == "competition_launch_cli"
+    assert kwargs["competition"] == "my-comp"
+    assert kwargs.get("at") is None
+
+
+def test_competitions_launch_parser_with_flags_succeeds(parser):
+    func, kwargs = parser.dispatch(["competitions", "launch", "my-comp", "--at", "2027-01-01T00:00:00Z"])
+    assert func.__name__ == "competition_launch_cli"
+    assert kwargs["competition"] == "my-comp"
+    assert kwargs["at"] == "2027-01-01T00:00:00Z"
+
+
+def test_competitions_init_parser_default_succeeds(parser):
+    func, kwargs = parser.dispatch(["competitions", "init"])
+    assert func.__name__ == "competition_initialize_cli"
+    assert kwargs.get("folder") is None
+
+
+def test_competitions_init_parser_with_folder_succeeds(parser):
+    func, kwargs = parser.dispatch(["competitions", "init", "my-folder"])
+    assert func.__name__ == "competition_initialize_cli"
+    assert kwargs["folder"] == "my-folder"
+
+
+def test_competitions_create_parser_default_succeeds(parser):
+    func, kwargs = parser.dispatch(["competitions", "create"])
+    assert func.__name__ == "competition_create_new_cli"
+    assert kwargs.get("folder") is None
+
+
+def test_competitions_create_parser_with_path_succeeds(parser):
+    func, kwargs = parser.dispatch(["competitions", "create", "-p", "my-path"])
+    assert func.__name__ == "competition_create_new_cli"
+    assert kwargs["folder"] == "my-path"
+
+
+def test_competitions_topics_default_list_succeeds(parser):
+    func, kwargs = parser.dispatch(["competitions", "topics"])
+    assert func.__name__ == "competition_list_topics_cli"
+    assert kwargs.get("competition") is None
+    assert kwargs.get("sort_by") is None
+
+
+def test_competitions_topics_list_succeeds(parser):
+    func, kwargs = parser.dispatch(["competitions", "topics", "list", "my-comp", "--sort-by", "new"])
+    assert func.__name__ == "competition_list_topics_cli"
+    assert kwargs["competition"] == "my-comp"
+    assert kwargs["sort_by"] == "new"
+
+
+def test_competitions_topics_show_missing_topic_ref_fails(parser):
+    with pytest.raises(SystemExit):
+        parser.dispatch(["competitions", "topics", "show"])
+
+
+def test_competitions_topics_show_succeeds(parser):
+    func, kwargs = parser.dispatch(["competitions", "topics", "show", "topic-ref-url"])
+    assert func.__name__ == "forums_topic_show_cli"
+    assert kwargs["topic_ref"] == "topic-ref-url"
+    assert kwargs.get("topic_id_arg") is None
+
+
+def test_competitions_topics_show_two_args_succeeds(parser):
+    func, kwargs = parser.dispatch(["competitions", "topics", "show", "my-comp", "12345"])
+    assert func.__name__ == "forums_topic_show_cli"
+    assert kwargs["topic_ref"] == "my-comp"
+    assert kwargs["topic_id_arg"] == 12345
+
+
+def test_competitions_topic_messages_parser_default_succeeds(parser):
+    func, kwargs = parser.dispatch(["competitions", "topic-messages"])
+    assert func.__name__ == "competition_list_topic_messages_cli"
+    assert kwargs.get("competition") is None
+    assert kwargs.get("topic_id") is None
+    assert kwargs.get("sort_by") is None
+    assert kwargs.get("page_size") is None
+
+
+def test_competitions_topic_messages_parser_with_flags_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "competitions",
+            "topic-messages",
+            "my-comp",
+            "123",
+            "--sort-by",
+            "top",
+            "--page-size",
+            "10",
+            "--csv",
+        ]
+    )
+    assert func.__name__ == "competition_list_topic_messages_cli"
+    assert kwargs["competition"] == "my-comp"
+    assert kwargs["topic_id"] == 123
+    assert kwargs["sort_by"] == "top"
+    assert kwargs["page_size"] == 10
+    assert kwargs["csv_display"] is True


### PR DESCRIPTION
Implement comprehensive parser tests for all competitions subcommands and options in tests/unit/test_cli_competitions.py.