### PR TITLE
Add parser tests for datasets commands

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -16,3 +16,70 @@ os.environ["KAGGLE_KEY"] = "testkey"
 
 with patch("kagglesdk.get_access_token_from_env", return_value=(None, None)):
     import kaggle  # noqa: F401 — triggers authenticate()
+
+
+import argparse
+from unittest.mock import MagicMock
+import pytest
+from kaggle.api.kaggle_api_extended import KaggleApi
+
+
+@pytest.fixture
+def api():
+    a = KaggleApi()
+    a.authenticate = MagicMock()
+    a.build_kaggle_client = MagicMock()
+    return a
+
+
+class KaggleParser:
+    def __init__(self, parser):
+        self._parser = parser
+
+    def dispatch(self, argv):
+        args = self._parser.parse_args(argv)
+        command_args = dict(vars(args))
+        del command_args["func"]
+        del command_args["command"]
+        return args.func, command_args
+
+
+@pytest.fixture
+def parser(monkeypatch, api):
+    import kaggle
+
+    monkeypatch.setattr(kaggle, "api", api)
+
+    from kaggle.cli import (
+        parse_quota,
+        parse_config,
+        parse_auth,
+        parse_files,
+        parse_competitions,
+        parse_datasets,
+        parse_kernels,
+        parse_models,
+        parse_forums,
+        parse_benchmarks,
+        Help,
+    )
+    import kaggle.cli
+
+    monkeypatch.setattr(kaggle.cli, "api", api)
+
+    root = argparse.ArgumentParser()
+    subparsers = root.add_subparsers(title="commands", dest="command")
+    subparsers.required = True
+    subparsers.choices = Help.kaggle_choices
+
+    parse_quota(subparsers)
+    parse_config(subparsers)
+    parse_auth(subparsers)
+    parse_files(subparsers)
+    parse_competitions(subparsers)
+    parse_datasets(subparsers)
+    parse_kernels(subparsers)
+    parse_models(subparsers)
+    parse_forums(subparsers)
+    parse_benchmarks(subparsers)
+    return KaggleParser(root)

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -1,72 +1,24 @@
 # coding=utf-8
-import argparse
-from unittest.mock import MagicMock, patch
 import pytest
-from kaggle.api.kaggle_api_extended import KaggleApi
-
-
-@pytest.fixture
-def api():
-    a = KaggleApi()
-    a.authenticate = MagicMock()
-    a.build_kaggle_client = MagicMock()
-    return a
-
-
-@pytest.fixture
-def parser(monkeypatch, api):
-    import kaggle
-
-    monkeypatch.setattr(kaggle, "api", api)
-
-    from kaggle.cli import (
-        parse_quota,
-        parse_config,
-        parse_auth,
-        parse_files,
-        Help,
-    )
-    import kaggle.cli
-
-    monkeypatch.setattr(kaggle.cli, "api", api)
-
-    root = argparse.ArgumentParser()
-    subparsers = root.add_subparsers(title="commands", dest="command")
-    subparsers.required = True
-    subparsers.choices = Help.kaggle_choices
-
-    parse_quota(subparsers)
-    parse_config(subparsers)
-    parse_auth(subparsers)
-    parse_files(subparsers)
-    return root
-
-
-def _dispatch(parser, argv):
-    args = parser.parse_args(argv)
-    command_args = dict(vars(args))
-    del command_args["func"]
-    del command_args["command"]
-    return args.func, command_args
 
 
 # Task 1.1: Quota
 def test_quota_parser_default_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["quota"])
+    func, kwargs = parser.dispatch(["quota"])
     assert func.__name__ == "quota_view_cli"
     assert kwargs.get("csv_display") is False
     assert kwargs.get("output_format") is None
 
 
 def test_quota_parser_csv_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["quota", "--csv"])
+    func, kwargs = parser.dispatch(["quota", "--csv"])
     assert func.__name__ == "quota_view_cli"
     assert kwargs["csv_display"] is True
     assert kwargs.get("output_format") is None
 
 
 def test_quota_parser_format_json_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["quota", "--format", "json"])
+    func, kwargs = parser.dispatch(["quota", "--format", "json"])
     assert func.__name__ == "quota_view_cli"
     assert kwargs["csv_display"] is False
     assert kwargs["output_format"] == "json"
@@ -74,66 +26,66 @@ def test_quota_parser_format_json_succeeds(parser):
 
 # Task 1.2: Config
 def test_config_view_parser_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["config", "view"])
+    func, kwargs = parser.dispatch(["config", "view"])
     assert func.__name__ == "print_config_values"
     assert kwargs == {}
 
 
 def test_config_set_parser_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["config", "set", "-n", "proxy", "-v", "http://proxy"])
+    func, kwargs = parser.dispatch(["config", "set", "-n", "proxy", "-v", "http://proxy"])
     assert func.__name__ == "set_config_value"
     assert kwargs["name"] == "proxy"
     assert kwargs["value"] == "http://proxy"
 
 
 def test_config_unset_parser_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["config", "unset", "-n", "proxy"])
+    func, kwargs = parser.dispatch(["config", "unset", "-n", "proxy"])
     assert func.__name__ == "unset_config_value"
     assert kwargs["name"] == "proxy"
 
 
 # Task 1.3: Auth
 def test_auth_login_parser_default_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["auth", "login"])
+    func, kwargs = parser.dispatch(["auth", "login"])
     assert func.__name__ == "auth_login_cli"
     assert kwargs["no_launch_browser"] is False
     assert kwargs["force"] is False
 
 
 def test_auth_login_parser_with_flags_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["auth", "login", "--no-launch-browser", "--force"])
+    func, kwargs = parser.dispatch(["auth", "login", "--no-launch-browser", "--force"])
     assert func.__name__ == "auth_login_cli"
     assert kwargs["no_launch_browser"] is True
     assert kwargs["force"] is True
 
 
 def test_auth_print_access_token_parser_default_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["auth", "print-access-token"])
+    func, kwargs = parser.dispatch(["auth", "print-access-token"])
     assert func.__name__ == "auth_print_access_token"
     assert kwargs["expiration_duration"] is None
 
 
 def test_auth_print_access_token_parser_with_expiration_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["auth", "print-access-token", "--expiration", "6h"])
+    func, kwargs = parser.dispatch(["auth", "print-access-token", "--expiration", "6h"])
     assert func.__name__ == "auth_print_access_token"
     assert kwargs["expiration_duration"] == "6h"
 
 
 def test_auth_revoke_token_parser_default_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["auth", "revoke"])
+    func, kwargs = parser.dispatch(["auth", "revoke"])
     assert func.__name__ == "auth_revoke_token"
     assert kwargs["reason"] is None
 
 
 def test_auth_revoke_token_parser_with_reason_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["auth", "revoke", "--reason", "compromised"])
+    func, kwargs = parser.dispatch(["auth", "revoke", "--reason", "compromised"])
     assert func.__name__ == "auth_revoke_token"
     assert kwargs["reason"] == "compromised"
 
 
 # Task 1.4: Files
 def test_files_upload_parser_default_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["files", "upload", "file1.zip", "file2.txt"])
+    func, kwargs = parser.dispatch(["files", "upload", "file1.zip", "file2.txt"])
     assert func.__name__ == "files_upload_cli"
     assert kwargs["local_paths"] == ["file1.zip", "file2.txt"]
     assert kwargs["inbox_path"] == ""
@@ -142,7 +94,7 @@ def test_files_upload_parser_default_succeeds(parser):
 
 
 def test_files_upload_parser_with_flags_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["files", "upload", "file1.zip", "-i", "my_inbox", "--no-resume", "--no-compress"])
+    func, kwargs = parser.dispatch(["files", "upload", "file1.zip", "-i", "my_inbox", "--no-resume", "--no-compress"])
     assert func.__name__ == "files_upload_cli"
     assert kwargs["local_paths"] == ["file1.zip"]
     assert kwargs["inbox_path"] == "my_inbox"

--- a/tests/unit/test_cli_datasets.py
+++ b/tests/unit/test_cli_datasets.py
@@ -1,0 +1,332 @@
+# coding=utf-8
+import pytest
+
+
+def test_datasets_list_parser_default_succeeds(parser):
+    func, kwargs = parser.dispatch(["datasets", "list"])
+    assert func.__name__ == "dataset_list_cli"
+    assert kwargs.get("sort_by") is None
+    assert kwargs.get("size") is None
+    assert kwargs.get("file_type") is None
+    assert kwargs.get("license_name") is None
+    assert kwargs.get("tag_ids") is None
+    assert kwargs.get("search") is None
+    assert kwargs.get("mine") is False
+    assert kwargs.get("user") is None
+    assert kwargs.get("page_size") is None
+    assert kwargs.get("page_token") is None
+    assert kwargs.get("page") is None
+    assert kwargs.get("csv_display") is False
+    assert kwargs.get("output_format") is None
+    assert kwargs.get("max_size") is None
+    assert kwargs.get("min_size") is None
+
+
+def test_datasets_list_parser_with_flags_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "datasets",
+            "list",
+            "--sort-by",
+            "votes",
+            "--size",
+            "100",
+            "--file-type",
+            "csv",
+            "--license",
+            "cc",
+            "--tags",
+            "tag1,tag2",
+            "--search",
+            "my search",
+            "--mine",
+            "--user",
+            "stevemessick",
+            "--page-size",
+            "50",
+            "--page-token",
+            "tok123",
+            "--page",
+            "2",
+            "--csv",
+            "--max-size",
+            "1000",
+            "--min-size",
+            "10",
+        ]
+    )
+    assert func.__name__ == "dataset_list_cli"
+    assert kwargs["sort_by"] == "votes"
+    assert kwargs["size"] == 100
+    assert kwargs["file_type"] == "csv"
+    assert kwargs["license_name"] == "cc"
+    assert kwargs["tag_ids"] == "tag1,tag2"
+    assert kwargs["search"] == "my search"
+    assert kwargs["mine"] is True
+    assert kwargs["user"] == "stevemessick"
+    assert kwargs["page_size"] == 50
+    assert kwargs["page_token"] == "tok123"
+    assert kwargs["page"] == 2
+    assert kwargs["csv_display"] is True
+    assert kwargs["max_size"] == 1000
+    assert kwargs["min_size"] == 10
+
+
+def test_datasets_files_parser_default_succeeds(parser):
+    func, kwargs = parser.dispatch(["datasets", "files"])
+    assert func.__name__ == "dataset_list_files_cli"
+    assert kwargs.get("dataset") is None
+    assert kwargs.get("dataset_opt") is None
+    assert kwargs.get("csv_display") is False
+    assert kwargs.get("output_format") is None
+    assert kwargs.get("page_token") is None
+    assert kwargs.get("page_size") == 20
+
+
+def test_datasets_files_parser_with_positional_dataset_succeeds(parser):
+    func, kwargs = parser.dispatch(["datasets", "files", "owner/dataset-name"])
+    assert func.__name__ == "dataset_list_files_cli"
+    assert kwargs["dataset"] == "owner/dataset-name"
+    assert kwargs.get("dataset_opt") is None
+
+
+def test_datasets_files_parser_with_option_dataset_succeeds(parser):
+    func, kwargs = parser.dispatch(["datasets", "files", "-d", "owner/dataset-name"])
+    assert func.__name__ == "dataset_list_files_cli"
+    assert kwargs.get("dataset") is None
+    assert kwargs["dataset_opt"] == "owner/dataset-name"
+
+
+def test_datasets_files_parser_with_flags_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "datasets",
+            "files",
+            "owner/dataset-name",
+            "--page-token",
+            "tok",
+            "--page-size",
+            "50",
+            "--format",
+            "json",
+        ]
+    )
+    assert func.__name__ == "dataset_list_files_cli"
+    assert kwargs["dataset"] == "owner/dataset-name"
+    assert kwargs["page_token"] == "tok"
+    assert kwargs["page_size"] == 50
+    assert kwargs["output_format"] == "json"
+
+
+def test_datasets_download_parser_default_succeeds(parser):
+    func, kwargs = parser.dispatch(["datasets", "download"])
+    assert func.__name__ == "dataset_download_cli"
+    assert kwargs.get("dataset") is None
+    assert kwargs.get("dataset_opt") is None
+    assert kwargs.get("file_name") is None
+    assert kwargs.get("path") is None
+    assert kwargs.get("unzip") is False
+    assert kwargs.get("force") is False
+    assert kwargs.get("quiet") is False
+
+
+def test_datasets_download_parser_with_flags_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "datasets",
+            "download",
+            "owner/dataset-name",
+            "-f",
+            "file.csv",
+            "-p",
+            "/tmp/download",
+            "--unzip",
+            "--force",
+            "--quiet",
+        ]
+    )
+    assert func.__name__ == "dataset_download_cli"
+    assert kwargs["dataset"] == "owner/dataset-name"
+    assert kwargs["file_name"] == "file.csv"
+    assert kwargs["path"] == "/tmp/download"
+    assert kwargs["unzip"] is True
+    assert kwargs["force"] is True
+    assert kwargs["quiet"] is True
+
+
+def test_datasets_download_parser_wp_flag_succeeds(parser):
+    func, kwargs = parser.dispatch(["datasets", "download", "-w"])
+    assert kwargs["path"] == "."
+
+
+def test_datasets_create_parser_default_succeeds(parser):
+    func, kwargs = parser.dispatch(["datasets", "create"])
+    assert func.__name__ == "dataset_create_new_cli"
+    assert kwargs.get("folder") is None
+    assert kwargs.get("public") is False
+    assert kwargs.get("quiet") is False
+    assert kwargs.get("convert_to_csv") is True
+    assert kwargs.get("dir_mode") == "skip"
+
+
+def test_datasets_create_parser_with_flags_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "datasets",
+            "create",
+            "-p",
+            "/path/to/data",
+            "--public",
+            "--quiet",
+            "-t",
+            "-r",
+            "zip",
+        ]
+    )
+    assert func.__name__ == "dataset_create_new_cli"
+    assert kwargs["folder"] == "/path/to/data"
+    assert kwargs["public"] is True
+    assert kwargs["quiet"] is True
+    assert kwargs["convert_to_csv"] is False
+    assert kwargs["dir_mode"] == "zip"
+
+
+def test_datasets_version_parser_missing_message_fails(parser):
+    with pytest.raises(SystemExit):
+        parser.dispatch(["datasets", "version", "-p", "/path/to/data"])
+
+
+def test_datasets_version_parser_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "datasets",
+            "version",
+            "-m",
+            "version message",
+            "-p",
+            "/path/to/data",
+            "--quiet",
+            "-t",
+            "-r",
+            "tar",
+            "-d",
+        ]
+    )
+    assert func.__name__ == "dataset_create_version_cli"
+    assert kwargs["version_notes"] == "version message"
+    assert kwargs["folder"] == "/path/to/data"
+    assert kwargs["quiet"] is True
+    assert kwargs["convert_to_csv"] is False
+    assert kwargs["dir_mode"] == "tar"
+    assert kwargs["delete_old_versions"] is True
+
+
+def test_datasets_init_parser_default_succeeds(parser):
+    func, kwargs = parser.dispatch(["datasets", "init"])
+    assert func.__name__ == "dataset_initialize_cli"
+    assert kwargs.get("folder") is None
+
+
+def test_datasets_init_parser_with_path_succeeds(parser):
+    func, kwargs = parser.dispatch(["datasets", "init", "-p", "/path/to/data"])
+    assert func.__name__ == "dataset_initialize_cli"
+    assert kwargs["folder"] == "/path/to/data"
+
+
+def test_datasets_metadata_parser_default_succeeds(parser):
+    func, kwargs = parser.dispatch(["datasets", "metadata"])
+    assert func.__name__ == "dataset_metadata_cli"
+    assert kwargs.get("dataset") is None
+    assert kwargs.get("dataset_opt") is None
+    assert kwargs.get("update") is False
+    assert kwargs.get("path") is None
+
+
+def test_datasets_metadata_parser_with_flags_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "datasets",
+            "metadata",
+            "owner/dataset-name",
+            "--update",
+            "-p",
+            "/path/to/metadata",
+        ]
+    )
+    assert func.__name__ == "dataset_metadata_cli"
+    assert kwargs["dataset"] == "owner/dataset-name"
+    assert kwargs["update"] is True
+    assert kwargs["path"] == "/path/to/metadata"
+
+
+def test_datasets_status_parser_default_succeeds(parser):
+    func, kwargs = parser.dispatch(["datasets", "status"])
+    assert func.__name__ == "dataset_status_cli"
+    assert kwargs.get("dataset") is None
+    assert kwargs.get("dataset_opt") is None
+    assert kwargs.get("format") is None
+
+
+def test_datasets_status_parser_with_flags_succeeds(parser):
+    func, kwargs = parser.dispatch(["datasets", "status", "owner/dataset-name", "--format", "json"])
+    assert func.__name__ == "dataset_status_cli"
+    assert kwargs["dataset"] == "owner/dataset-name"
+    assert kwargs["format"] == "json"
+
+
+def test_datasets_delete_parser_missing_dataset_fails(parser):
+    with pytest.raises(SystemExit):
+        parser.dispatch(["datasets", "delete"])
+
+
+def test_datasets_delete_parser_succeeds(parser):
+    func, kwargs = parser.dispatch(["datasets", "delete", "owner/dataset-name", "-y"])
+    assert func.__name__ == "dataset_delete_cli"
+    assert kwargs["dataset"] == "owner/dataset-name"
+    assert kwargs["no_confirm"] is True
+
+
+def test_datasets_topics_default_list_succeeds(parser):
+    func, kwargs = parser.dispatch(["datasets", "topics"])
+    assert func.__name__ == "dataset_list_topics_cli"
+    assert kwargs.get("entity_ref") is None
+    assert kwargs.get("sort_by") is None
+    assert kwargs.get("search") is None
+
+
+def test_datasets_topics_list_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "datasets",
+            "topics",
+            "list",
+            "owner/dataset-name",
+            "--sort-by",
+            "new",
+            "-s",
+            "search term",
+        ]
+    )
+    assert func.__name__ == "dataset_list_topics_cli"
+    assert kwargs["entity_ref"] == "owner/dataset-name"
+    assert kwargs["sort_by"] == "new"
+    assert kwargs["search"] == "search term"
+
+
+def test_datasets_topics_show_missing_topic_ref_fails(parser):
+    with pytest.raises(SystemExit):
+        parser.dispatch(["datasets", "topics", "show"])
+
+
+def test_datasets_topics_show_succeeds(parser):
+    func, kwargs = parser.dispatch(["datasets", "topics", "show", "topic-ref-url"])
+    assert func.__name__ == "forums_topic_show_cli"
+    assert kwargs["topic_ref"] == "topic-ref-url"
+    assert kwargs.get("topic_id_arg") is None
+
+
+def test_datasets_topics_show_two_args_succeeds(parser):
+    func, kwargs = parser.dispatch(["datasets", "topics", "show", "owner/dataset-name", "12345"])
+    assert func.__name__ == "forums_topic_show_cli"
+    assert kwargs["topic_ref"] == "owner/dataset-name"
+    assert kwargs["topic_id_arg"] == 12345


### PR DESCRIPTION
Implement comprehensive parser tests for all datasets subcommands and options in tests/unit/test_cli_datasets.py.