### PR TITLE
Add parser tests for models commands

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -16,3 +16,70 @@ os.environ["KAGGLE_KEY"] = "testkey"
 
 with patch("kagglesdk.get_access_token_from_env", return_value=(None, None)):
     import kaggle  # noqa: F401 — triggers authenticate()
+
+
+import argparse
+from unittest.mock import MagicMock
+import pytest
+from kaggle.api.kaggle_api_extended import KaggleApi
+
+
+@pytest.fixture
+def api():
+    a = KaggleApi()
+    a.authenticate = MagicMock()
+    a.build_kaggle_client = MagicMock()
+    return a
+
+
+class KaggleParser:
+    def __init__(self, parser):
+        self._parser = parser
+
+    def dispatch(self, argv):
+        args = self._parser.parse_args(argv)
+        command_args = dict(vars(args))
+        del command_args["func"]
+        del command_args["command"]
+        return args.func, command_args
+
+
+@pytest.fixture
+def parser(monkeypatch, api):
+    import kaggle
+
+    monkeypatch.setattr(kaggle, "api", api)
+
+    from kaggle.cli import (
+        parse_quota,
+        parse_config,
+        parse_auth,
+        parse_files,
+        parse_competitions,
+        parse_datasets,
+        parse_kernels,
+        parse_models,
+        parse_forums,
+        parse_benchmarks,
+        Help,
+    )
+    import kaggle.cli
+
+    monkeypatch.setattr(kaggle.cli, "api", api)
+
+    root = argparse.ArgumentParser()
+    subparsers = root.add_subparsers(title="commands", dest="command")
+    subparsers.required = True
+    subparsers.choices = Help.kaggle_choices
+
+    parse_quota(subparsers)
+    parse_config(subparsers)
+    parse_auth(subparsers)
+    parse_files(subparsers)
+    parse_competitions(subparsers)
+    parse_datasets(subparsers)
+    parse_kernels(subparsers)
+    parse_models(subparsers)
+    parse_forums(subparsers)
+    parse_benchmarks(subparsers)
+    return KaggleParser(root)

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -1,72 +1,24 @@
 # coding=utf-8
-import argparse
-from unittest.mock import MagicMock, patch
 import pytest
-from kaggle.api.kaggle_api_extended import KaggleApi
-
-
-@pytest.fixture
-def api():
-    a = KaggleApi()
-    a.authenticate = MagicMock()
-    a.build_kaggle_client = MagicMock()
-    return a
-
-
-@pytest.fixture
-def parser(monkeypatch, api):
-    import kaggle
-
-    monkeypatch.setattr(kaggle, "api", api)
-
-    from kaggle.cli import (
-        parse_quota,
-        parse_config,
-        parse_auth,
-        parse_files,
-        Help,
-    )
-    import kaggle.cli
-
-    monkeypatch.setattr(kaggle.cli, "api", api)
-
-    root = argparse.ArgumentParser()
-    subparsers = root.add_subparsers(title="commands", dest="command")
-    subparsers.required = True
-    subparsers.choices = Help.kaggle_choices
-
-    parse_quota(subparsers)
-    parse_config(subparsers)
-    parse_auth(subparsers)
-    parse_files(subparsers)
-    return root
-
-
-def _dispatch(parser, argv):
-    args = parser.parse_args(argv)
-    command_args = dict(vars(args))
-    del command_args["func"]
-    del command_args["command"]
-    return args.func, command_args
 
 
 # Task 1.1: Quota
 def test_quota_parser_default_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["quota"])
+    func, kwargs = parser.dispatch(["quota"])
     assert func.__name__ == "quota_view_cli"
     assert kwargs.get("csv_display") is False
     assert kwargs.get("output_format") is None
 
 
 def test_quota_parser_csv_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["quota", "--csv"])
+    func, kwargs = parser.dispatch(["quota", "--csv"])
     assert func.__name__ == "quota_view_cli"
     assert kwargs["csv_display"] is True
     assert kwargs.get("output_format") is None
 
 
 def test_quota_parser_format_json_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["quota", "--format", "json"])
+    func, kwargs = parser.dispatch(["quota", "--format", "json"])
     assert func.__name__ == "quota_view_cli"
     assert kwargs["csv_display"] is False
     assert kwargs["output_format"] == "json"
@@ -74,66 +26,66 @@ def test_quota_parser_format_json_succeeds(parser):
 
 # Task 1.2: Config
 def test_config_view_parser_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["config", "view"])
+    func, kwargs = parser.dispatch(["config", "view"])
     assert func.__name__ == "print_config_values"
     assert kwargs == {}
 
 
 def test_config_set_parser_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["config", "set", "-n", "proxy", "-v", "http://proxy"])
+    func, kwargs = parser.dispatch(["config", "set", "-n", "proxy", "-v", "http://proxy"])
     assert func.__name__ == "set_config_value"
     assert kwargs["name"] == "proxy"
     assert kwargs["value"] == "http://proxy"
 
 
 def test_config_unset_parser_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["config", "unset", "-n", "proxy"])
+    func, kwargs = parser.dispatch(["config", "unset", "-n", "proxy"])
     assert func.__name__ == "unset_config_value"
     assert kwargs["name"] == "proxy"
 
 
 # Task 1.3: Auth
 def test_auth_login_parser_default_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["auth", "login"])
+    func, kwargs = parser.dispatch(["auth", "login"])
     assert func.__name__ == "auth_login_cli"
     assert kwargs["no_launch_browser"] is False
     assert kwargs["force"] is False
 
 
 def test_auth_login_parser_with_flags_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["auth", "login", "--no-launch-browser", "--force"])
+    func, kwargs = parser.dispatch(["auth", "login", "--no-launch-browser", "--force"])
     assert func.__name__ == "auth_login_cli"
     assert kwargs["no_launch_browser"] is True
     assert kwargs["force"] is True
 
 
 def test_auth_print_access_token_parser_default_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["auth", "print-access-token"])
+    func, kwargs = parser.dispatch(["auth", "print-access-token"])
     assert func.__name__ == "auth_print_access_token"
     assert kwargs["expiration_duration"] is None
 
 
 def test_auth_print_access_token_parser_with_expiration_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["auth", "print-access-token", "--expiration", "6h"])
+    func, kwargs = parser.dispatch(["auth", "print-access-token", "--expiration", "6h"])
     assert func.__name__ == "auth_print_access_token"
     assert kwargs["expiration_duration"] == "6h"
 
 
 def test_auth_revoke_token_parser_default_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["auth", "revoke"])
+    func, kwargs = parser.dispatch(["auth", "revoke"])
     assert func.__name__ == "auth_revoke_token"
     assert kwargs["reason"] is None
 
 
 def test_auth_revoke_token_parser_with_reason_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["auth", "revoke", "--reason", "compromised"])
+    func, kwargs = parser.dispatch(["auth", "revoke", "--reason", "compromised"])
     assert func.__name__ == "auth_revoke_token"
     assert kwargs["reason"] == "compromised"
 
 
 # Task 1.4: Files
 def test_files_upload_parser_default_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["files", "upload", "file1.zip", "file2.txt"])
+    func, kwargs = parser.dispatch(["files", "upload", "file1.zip", "file2.txt"])
     assert func.__name__ == "files_upload_cli"
     assert kwargs["local_paths"] == ["file1.zip", "file2.txt"]
     assert kwargs["inbox_path"] == ""
@@ -142,7 +94,7 @@ def test_files_upload_parser_default_succeeds(parser):
 
 
 def test_files_upload_parser_with_flags_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["files", "upload", "file1.zip", "-i", "my_inbox", "--no-resume", "--no-compress"])
+    func, kwargs = parser.dispatch(["files", "upload", "file1.zip", "-i", "my_inbox", "--no-resume", "--no-compress"])
     assert func.__name__ == "files_upload_cli"
     assert kwargs["local_paths"] == ["file1.zip"]
     assert kwargs["inbox_path"] == "my_inbox"

--- a/tests/unit/test_cli_models.py
+++ b/tests/unit/test_cli_models.py
@@ -1,0 +1,425 @@
+# coding=utf-8
+import pytest
+
+# --- Models Top-level Commands ---
+
+
+def test_models_get_parser_missing_model_fails(parser):
+    with pytest.raises(SystemExit):
+        parser.dispatch(["models", "get"])
+
+
+def test_models_get_parser_succeeds(parser):
+    func, kwargs = parser.dispatch(["models", "get", "owner/model-name", "-p", "/tmp/model"])
+    assert func.__name__ == "model_get_cli"
+    assert kwargs["model"] == "owner/model-name"
+    assert kwargs["folder"] == "/tmp/model"
+
+
+def test_models_list_parser_default_succeeds(parser):
+    func, kwargs = parser.dispatch(["models", "list"])
+    assert func.__name__ == "model_list_cli"
+    assert kwargs.get("sort_by") is None
+    assert kwargs.get("search") is None
+    assert kwargs.get("owner") is None
+    assert kwargs.get("page_size") == 20
+    assert kwargs.get("page_token") is None
+    assert kwargs.get("csv_display") is False
+    assert kwargs.get("output_format") is None
+
+
+def test_models_list_parser_with_flags_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "models",
+            "list",
+            "--sort-by",
+            "votes",
+            "-s",
+            "search term",
+            "--owner",
+            "stevemessick",
+            "--page-size",
+            "50",
+            "--page-token",
+            "tok",
+            "--csv",
+        ]
+    )
+    assert func.__name__ == "model_list_cli"
+    assert kwargs["sort_by"] == "votes"
+    assert kwargs["search"] == "search term"
+    assert kwargs["owner"] == "stevemessick"
+    assert kwargs["page_size"] == 50
+    assert kwargs["page_token"] == "tok"
+    assert kwargs["csv_display"] is True
+
+
+def test_models_init_parser_default_succeeds(parser):
+    func, kwargs = parser.dispatch(["models", "init"])
+    assert func.__name__ == "model_initialize_cli"
+    assert kwargs.get("folder") is None
+
+
+def test_models_init_parser_with_path_succeeds(parser):
+    func, kwargs = parser.dispatch(["models", "init", "-p", "/path/to/model"])
+    assert func.__name__ == "model_initialize_cli"
+    assert kwargs["folder"] == "/path/to/model"
+
+
+def test_models_create_parser_default_succeeds(parser):
+    func, kwargs = parser.dispatch(["models", "create"])
+    assert func.__name__ == "model_create_new_cli"
+    assert kwargs.get("folder") is None
+
+
+def test_models_create_parser_with_path_succeeds(parser):
+    func, kwargs = parser.dispatch(["models", "create", "-p", "/path/to/model"])
+    assert func.__name__ == "model_create_new_cli"
+    assert kwargs["folder"] == "/path/to/model"
+
+
+def test_models_delete_parser_missing_model_fails(parser):
+    with pytest.raises(SystemExit):
+        parser.dispatch(["models", "delete"])
+
+
+def test_models_delete_parser_succeeds(parser):
+    func, kwargs = parser.dispatch(["models", "delete", "owner/model-name", "-y"])
+    assert func.__name__ == "model_delete_cli"
+    assert kwargs["model"] == "owner/model-name"
+    assert kwargs["no_confirm"] is True
+
+
+def test_models_update_parser_default_succeeds(parser):
+    func, kwargs = parser.dispatch(["models", "update"])
+    assert func.__name__ == "model_update_cli"
+    assert kwargs.get("folder") is None
+
+
+def test_models_update_parser_with_path_succeeds(parser):
+    func, kwargs = parser.dispatch(["models", "update", "-p", "/path/to/model"])
+    assert func.__name__ == "model_update_cli"
+    assert kwargs["folder"] == "/path/to/model"
+
+
+def test_models_topics_default_list_succeeds(parser):
+    func, kwargs = parser.dispatch(["models", "topics"])
+    assert func.__name__ == "model_list_topics_cli"
+    assert kwargs.get("entity_ref") is None
+    assert kwargs.get("sort_by") is None
+    assert kwargs.get("search") is None
+
+
+def test_models_topics_list_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "models",
+            "topics",
+            "list",
+            "owner/model-name",
+            "--sort-by",
+            "new",
+            "-s",
+            "search term",
+        ]
+    )
+    assert func.__name__ == "model_list_topics_cli"
+    assert kwargs["entity_ref"] == "owner/model-name"
+    assert kwargs["sort_by"] == "new"
+    assert kwargs["search"] == "search term"
+
+
+def test_models_topics_show_missing_topic_ref_fails(parser):
+    with pytest.raises(SystemExit):
+        parser.dispatch(["models", "topics", "show"])
+
+
+def test_models_topics_show_succeeds(parser):
+    func, kwargs = parser.dispatch(["models", "topics", "show", "topic-ref-url"])
+    assert func.__name__ == "forums_topic_show_cli"
+    assert kwargs["topic_ref"] == "topic-ref-url"
+    assert kwargs.get("topic_id_arg") is None
+
+
+def test_models_topics_show_two_args_succeeds(parser):
+    func, kwargs = parser.dispatch(["models", "topics", "show", "owner/model-name", "12345"])
+    assert func.__name__ == "forums_topic_show_cli"
+    assert kwargs["topic_ref"] == "owner/model-name"
+    assert kwargs["topic_id_arg"] == 12345
+
+
+# --- Model Instances Commands ---
+
+
+def test_model_instances_get_parser_missing_instance_fails(parser):
+    with pytest.raises(SystemExit):
+        parser.dispatch(["models", "instances", "get"])
+
+
+def test_model_instances_get_parser_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        ["models", "instances", "get", "owner/model/framework/variation", "-p", "/tmp/instance"]
+    )
+    assert func.__name__ == "model_instance_get_cli"
+    assert kwargs["model_instance"] == "owner/model/framework/variation"
+    assert kwargs["folder"] == "/tmp/instance"
+
+
+def test_model_instances_init_parser_default_succeeds(parser):
+    func, kwargs = parser.dispatch(["models", "instances", "init"])
+    assert func.__name__ == "model_instance_initialize_cli"
+    assert kwargs.get("folder") is None
+
+
+def test_model_instances_init_parser_with_path_succeeds(parser):
+    func, kwargs = parser.dispatch(["models", "instances", "init", "-p", "/path/to/instance"])
+    assert func.__name__ == "model_instance_initialize_cli"
+    assert kwargs["folder"] == "/path/to/instance"
+
+
+def test_model_instances_create_parser_default_succeeds(parser):
+    func, kwargs = parser.dispatch(["models", "instances", "create"])
+    assert func.__name__ == "model_instance_create_cli"
+    assert kwargs.get("folder") is None
+    assert kwargs.get("quiet") is False
+    assert kwargs.get("dir_mode") == "skip"
+
+
+def test_model_instances_create_parser_with_flags_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "models",
+            "instances",
+            "create",
+            "-p",
+            "/path/to/instance",
+            "--quiet",
+            "-r",
+            "zip",
+        ]
+    )
+    assert func.__name__ == "model_instance_create_cli"
+    assert kwargs["folder"] == "/path/to/instance"
+    assert kwargs["quiet"] is True
+    assert kwargs["dir_mode"] == "zip"
+
+
+def test_model_instances_files_parser_missing_instance_fails(parser):
+    with pytest.raises(SystemExit):
+        parser.dispatch(["models", "instances", "files"])
+
+
+def test_model_instances_files_parser_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "models",
+            "instances",
+            "files",
+            "owner/model/framework/variation",
+            "--page-size",
+            "50",
+            "--page-token",
+            "tok",
+            "--format",
+            "json",
+        ]
+    )
+    assert func.__name__ == "model_instance_files_cli"
+    assert kwargs["model_instance"] == "owner/model/framework/variation"
+    assert kwargs["page_size"] == 50
+    assert kwargs["page_token"] == "tok"
+    assert kwargs["output_format"] == "json"
+
+
+def test_model_instances_list_parser_missing_instance_fails(parser):
+    # Wait, 'list' requires model_instance?
+    # In cli.py:
+    # parser_model_instances_list_optional.add_argument("model_instance", help=Help.param_model_instance)
+    # Yes, it is positional and not nargs='?', so it is REQUIRED.
+    with pytest.raises(SystemExit):
+        parser.dispatch(["models", "instances", "list"])
+
+
+def test_model_instances_list_parser_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "models",
+            "instances",
+            "list",
+            "owner/model/framework/variation",
+            "--page-size",
+            "50",
+            "--page-token",
+            "tok",
+            "--format",
+            "json",
+        ]
+    )
+    assert func.__name__ == "model_instances_list_cli"
+    assert kwargs["model_instance"] == "owner/model/framework/variation"
+    assert kwargs["page_size"] == 50
+    assert kwargs["page_token"] == "tok"
+    assert kwargs["output_format"] == "json"
+
+
+def test_model_instances_delete_parser_missing_instance_fails(parser):
+    with pytest.raises(SystemExit):
+        parser.dispatch(["models", "instances", "delete"])
+
+
+def test_model_instances_delete_parser_succeeds(parser):
+    func, kwargs = parser.dispatch(["models", "instances", "delete", "owner/model/framework/variation", "-y"])
+    assert func.__name__ == "model_instance_delete_cli"
+    assert kwargs["model_instance"] == "owner/model/framework/variation"
+    assert kwargs["no_confirm"] is True
+
+
+def test_model_instances_update_parser_default_succeeds(parser):
+    func, kwargs = parser.dispatch(["models", "instances", "update"])
+    assert func.__name__ == "model_instance_update_cli"
+    assert kwargs.get("folder") is None
+
+
+def test_model_instances_update_parser_with_path_succeeds(parser):
+    func, kwargs = parser.dispatch(["models", "instances", "update", "-p", "/path/to/instance"])
+    assert func.__name__ == "model_instance_update_cli"
+    assert kwargs["folder"] == "/path/to/instance"
+
+
+# --- Model Instance Versions Commands ---
+
+
+def test_model_instance_versions_list_parser_missing_instance_fails(parser):
+    with pytest.raises(SystemExit):
+        parser.dispatch(["models", "instances", "versions", "list"])
+
+
+def test_model_instance_versions_list_parser_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "models",
+            "instances",
+            "versions",
+            "list",
+            "owner/model/framework/variation",
+            "--page-size",
+            "50",
+            "--page-token",
+            "tok",
+            "--format",
+            "json",
+        ]
+    )
+    assert func.__name__ == "model_instance_versions_list_cli"
+    assert kwargs["model_instance"] == "owner/model/framework/variation"
+    assert kwargs["page_size"] == 50
+    assert kwargs["page_token"] == "tok"
+    assert kwargs["output_format"] == "json"
+
+
+def test_model_instance_versions_create_parser_missing_instance_fails(parser):
+    with pytest.raises(SystemExit):
+        parser.dispatch(["models", "instances", "versions", "create"])
+
+
+def test_model_instance_versions_create_parser_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "models",
+            "instances",
+            "versions",
+            "create",
+            "owner/model/framework/variation",
+            "-p",
+            "/path/to/version",
+            "-n",
+            "version notes",
+            "--quiet",
+            "-r",
+            "tar",
+        ]
+    )
+    assert func.__name__ == "model_instance_version_create_cli"
+    assert kwargs["model_instance"] == "owner/model/framework/variation"
+    assert kwargs["folder"] == "/path/to/version"
+    assert kwargs["version_notes"] == "version notes"
+    assert kwargs["quiet"] is True
+    assert kwargs["dir_mode"] == "tar"
+
+
+def test_model_instance_versions_download_parser_missing_version_fails(parser):
+    with pytest.raises(SystemExit):
+        parser.dispatch(["models", "instances", "versions", "download"])
+
+
+def test_model_instance_versions_download_parser_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "models",
+            "instances",
+            "versions",
+            "download",
+            "owner/model/framework/variation/1",
+            "-p",
+            "/tmp/download",
+            "--untar",
+            "--force",
+            "--quiet",
+        ]
+    )
+    assert func.__name__ == "model_instance_version_download_cli"
+    assert kwargs["model_instance_version"] == "owner/model/framework/variation/1"
+    assert kwargs["path"] == "/tmp/download"
+    assert kwargs["untar"] is True
+    assert kwargs["force"] is True
+    assert kwargs["quiet"] is True
+
+
+def test_model_instance_versions_files_parser_missing_version_fails(parser):
+    with pytest.raises(SystemExit):
+        parser.dispatch(["models", "instances", "versions", "files"])
+
+
+def test_model_instance_versions_files_parser_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "models",
+            "instances",
+            "versions",
+            "files",
+            "owner/model/framework/variation/1",
+            "--page-size",
+            "50",
+            "--page-token",
+            "tok",
+            "--format",
+            "json",
+        ]
+    )
+    assert func.__name__ == "model_instance_version_files_cli"
+    assert kwargs["model_instance_version"] == "owner/model/framework/variation/1"
+    assert kwargs["page_size"] == 50
+    assert kwargs["page_token"] == "tok"
+    assert kwargs["output_format"] == "json"
+
+
+def test_model_instance_versions_delete_parser_missing_version_fails(parser):
+    with pytest.raises(SystemExit):
+        parser.dispatch(["models", "instances", "versions", "delete"])
+
+
+def test_model_instance_versions_delete_parser_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "models",
+            "instances",
+            "versions",
+            "delete",
+            "owner/model/framework/variation/1",
+            "-y",
+        ]
+    )
+    assert func.__name__ == "model_instance_version_delete_cli"
+    assert kwargs["model_instance_version"] == "owner/model/framework/variation/1"
+    assert kwargs["no_confirm"] is True


### PR DESCRIPTION
Implement comprehensive parser tests for all models subcommands (including instances and versions) and options in tests/unit/test_cli_models.py.