### PR TITLE
Add parser tests for benchmarks commands

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -16,3 +16,70 @@ os.environ["KAGGLE_KEY"] = "testkey"
 
 with patch("kagglesdk.get_access_token_from_env", return_value=(None, None)):
     import kaggle  # noqa: F401 — triggers authenticate()
+
+
+import argparse
+from unittest.mock import MagicMock
+import pytest
+from kaggle.api.kaggle_api_extended import KaggleApi
+
+
+@pytest.fixture
+def api():
+    a = KaggleApi()
+    a.authenticate = MagicMock()
+    a.build_kaggle_client = MagicMock()
+    return a
+
+
+class KaggleParser:
+    def __init__(self, parser):
+        self._parser = parser
+
+    def dispatch(self, argv):
+        args = self._parser.parse_args(argv)
+        command_args = dict(vars(args))
+        del command_args["func"]
+        del command_args["command"]
+        return args.func, command_args
+
+
+@pytest.fixture
+def parser(monkeypatch, api):
+    import kaggle
+
+    monkeypatch.setattr(kaggle, "api", api)
+
+    from kaggle.cli import (
+        parse_quota,
+        parse_config,
+        parse_auth,
+        parse_files,
+        parse_competitions,
+        parse_datasets,
+        parse_kernels,
+        parse_models,
+        parse_forums,
+        parse_benchmarks,
+        Help,
+    )
+    import kaggle.cli
+
+    monkeypatch.setattr(kaggle.cli, "api", api)
+
+    root = argparse.ArgumentParser()
+    subparsers = root.add_subparsers(title="commands", dest="command")
+    subparsers.required = True
+    subparsers.choices = Help.kaggle_choices
+
+    parse_quota(subparsers)
+    parse_config(subparsers)
+    parse_auth(subparsers)
+    parse_files(subparsers)
+    parse_competitions(subparsers)
+    parse_datasets(subparsers)
+    parse_kernels(subparsers)
+    parse_models(subparsers)
+    parse_forums(subparsers)
+    parse_benchmarks(subparsers)
+    return KaggleParser(root)

--- a/tests/unit/test_cli_benchmarks.py
+++ b/tests/unit/test_cli_benchmarks.py
@@ -1,0 +1,303 @@
+# coding=utf-8
+import pytest
+
+# --- Benchmarks Top-level Commands ---
+
+
+def test_benchmarks_auth_parser_default_succeeds(parser):
+    func, kwargs = parser.dispatch(["benchmarks", "auth"])
+    assert func.__name__ == "benchmarks_auth_cli"
+    assert kwargs.get("no_confirm") is False
+    assert kwargs.get("env_file") == ".env"
+
+
+def test_benchmarks_auth_parser_with_flags_succeeds(parser):
+    func, kwargs = parser.dispatch(["benchmarks", "auth", "-y", "--env-file", ".env.prod"])
+    assert func.__name__ == "benchmarks_auth_cli"
+    assert kwargs["no_confirm"] is True
+    assert kwargs["env_file"] == ".env.prod"
+
+
+def test_benchmarks_init_parser_default_succeeds(parser):
+    func, kwargs = parser.dispatch(["benchmarks", "init"])
+    assert func.__name__ == "benchmarks_init_cli"
+    assert kwargs.get("no_confirm") is False
+    assert kwargs.get("env_file") == ".env"
+    assert kwargs.get("example_file") == "example_task.py"
+
+
+def test_benchmarks_init_parser_with_flags_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        ["benchmarks", "init", "-y", "--env-file", ".env.prod", "--example-file", "my_example.py"]
+    )
+    assert func.__name__ == "benchmarks_init_cli"
+    assert kwargs["no_confirm"] is True
+    assert kwargs["env_file"] == ".env.prod"
+    assert kwargs["example_file"] == "my_example.py"
+
+
+def test_benchmarks_leaderboard_parser_missing_benchmark_fails(parser):
+    with pytest.raises(SystemExit):
+        parser.dispatch(["benchmarks", "leaderboard"])
+
+
+def test_benchmarks_leaderboard_parser_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "benchmarks",
+            "leaderboard",
+            "my-benchmark",
+            "--version",
+            "2",
+            "--show",
+            "--download",
+            "-p",
+            "/tmp/lead",
+            "--quiet",
+            "--format",
+            "json",
+        ]
+    )
+    assert func.__name__ == "benchmark_leaderboard_cli"
+    assert kwargs["benchmark"] == "my-benchmark"
+    assert kwargs["version"] == 2
+    assert kwargs["view"] is True
+    assert kwargs["download"] is True
+    assert kwargs["path"] == "/tmp/lead"
+    assert kwargs["quiet"] is True
+    assert kwargs["output_format"] == "json"
+    assert kwargs.get("csv_display") is False
+
+
+def test_benchmarks_topics_default_list_succeeds(parser):
+    func, kwargs = parser.dispatch(["benchmarks", "topics"])
+    assert func.__name__ == "benchmark_list_topics_cli"
+    assert kwargs.get("entity_ref") is None
+    assert kwargs.get("sort_by") is None
+    assert kwargs.get("search") is None
+
+
+def test_benchmarks_topics_list_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "benchmarks",
+            "topics",
+            "list",
+            "my-benchmark",
+            "--sort-by",
+            "new",
+            "-s",
+            "search term",
+        ]
+    )
+    assert func.__name__ == "benchmark_list_topics_cli"
+    assert kwargs["entity_ref"] == "my-benchmark"
+    assert kwargs["sort_by"] == "new"
+    assert kwargs["search"] == "search term"
+
+
+def test_benchmarks_topics_show_missing_topic_ref_fails(parser):
+    with pytest.raises(SystemExit):
+        parser.dispatch(["benchmarks", "topics", "show"])
+
+
+def test_benchmarks_topics_show_succeeds(parser):
+    func, kwargs = parser.dispatch(["benchmarks", "topics", "show", "topic-ref-url"])
+    assert func.__name__ == "forums_topic_show_cli"
+    assert kwargs["topic_ref"] == "topic-ref-url"
+    assert kwargs.get("topic_id_arg") is None
+
+
+def test_benchmarks_topics_show_two_args_succeeds(parser):
+    func, kwargs = parser.dispatch(["benchmarks", "topics", "show", "my-benchmark", "12345"])
+    assert func.__name__ == "forums_topic_show_cli"
+    assert kwargs["topic_ref"] == "my-benchmark"
+    assert kwargs["topic_id_arg"] == 12345
+
+
+# --- Benchmarks Tasks Commands ---
+
+
+def test_benchmarks_tasks_push_parser_missing_args_fails(parser):
+    with pytest.raises(SystemExit):
+        parser.dispatch(["benchmarks", "tasks", "push"])
+    with pytest.raises(SystemExit):
+        parser.dispatch(["benchmarks", "tasks", "push", "my-task"])  # missing -f
+
+
+def test_benchmarks_tasks_push_parser_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "benchmarks",
+            "tasks",
+            "push",
+            "my-task",
+            "-f",
+            "file.py",
+            "--wait",
+            "100",
+            "--poll-interval",
+            "30",
+            "-v",
+            "-d",
+            "dataset1",
+            "-d",
+            "dataset2",
+        ]
+    )
+    assert func.__name__ == "benchmarks_tasks_push_cli"
+    assert kwargs["task"] == "my-task"
+    assert kwargs["file"] == "file.py"
+    assert kwargs["wait"] == 100
+    assert kwargs["poll_interval"] == 30
+    assert kwargs["verbose"] is True
+    assert kwargs["kaggle_datasets"] == ["dataset1", "dataset2"]
+
+
+def test_benchmarks_tasks_push_parser_wait_no_value_succeeds(parser):
+    func, kwargs = parser.dispatch(["benchmarks", "tasks", "push", "my-task", "-f", "file.py", "--wait"])
+    assert kwargs["wait"] == 0  # const=0
+
+
+def test_benchmarks_tasks_run_parser_missing_task_fails(parser):
+    with pytest.raises(SystemExit):
+        parser.dispatch(["benchmarks", "tasks", "run"])
+
+
+def test_benchmarks_tasks_run_parser_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "benchmarks",
+            "tasks",
+            "run",
+            "my-task",
+            "-m",
+            "model1",
+            "-m",
+            "model2",
+            "--wait",
+            "100",
+            "--poll-interval",
+            "30",
+            "-v",
+        ]
+    )
+    assert func.__name__ == "benchmarks_tasks_run_cli"
+    assert kwargs["task"] == "my-task"
+    assert kwargs["model"] == ["model1", "model2"]
+    assert kwargs["wait"] == 100
+    assert kwargs["poll_interval"] == 30
+    assert kwargs["verbose"] is True
+
+
+def test_benchmarks_tasks_list_parser_default_succeeds(parser):
+    func, kwargs = parser.dispatch(["benchmarks", "tasks", "list"])
+    assert func.__name__ == "benchmarks_tasks_list_cli"
+    assert kwargs.get("name_regex") is None
+    assert kwargs.get("status") is None
+    assert kwargs.get("page_size") is None
+    assert kwargs.get("show_all") is False
+
+
+def test_benchmarks_tasks_list_parser_with_flags_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "benchmarks",
+            "tasks",
+            "list",
+            "--name-regex",
+            "test.*",
+            "--status",
+            "running",
+            "--page-size",
+            "10",
+            "--all",
+        ]
+    )
+    assert func.__name__ == "benchmarks_tasks_list_cli"
+    assert kwargs["name_regex"] == "test.*"
+    assert kwargs["status"] == "running"
+    assert kwargs["page_size"] == 10
+    assert kwargs["show_all"] is True
+
+
+def test_benchmarks_tasks_status_parser_missing_task_fails(parser):
+    with pytest.raises(SystemExit):
+        parser.dispatch(["benchmarks", "tasks", "status"])
+
+
+def test_benchmarks_tasks_status_parser_succeeds(parser):
+    func, kwargs = parser.dispatch(["benchmarks", "tasks", "status", "my-task", "-m", "model1"])
+    assert func.__name__ == "benchmarks_tasks_status_cli"
+    assert kwargs["task"] == "my-task"
+    assert kwargs["model"] == ["model1"]
+
+
+def test_benchmarks_tasks_download_parser_missing_task_fails(parser):
+    with pytest.raises(SystemExit):
+        parser.dispatch(["benchmarks", "tasks", "download"])
+
+
+def test_benchmarks_tasks_download_parser_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "benchmarks",
+            "tasks",
+            "download",
+            "my-task",
+            "-m",
+            "model1",
+            "-o",
+            "/tmp/out",
+            "--include-source",
+            "--force",
+        ]
+    )
+    assert func.__name__ == "benchmarks_tasks_download_cli"
+    assert kwargs["task"] == "my-task"
+    assert kwargs["model"] == ["model1"]
+    assert kwargs["output"] == "/tmp/out"
+    assert kwargs["include_source"] is True
+    assert kwargs["force"] is True
+
+
+def test_benchmarks_tasks_log_parser_missing_task_fails(parser):
+    with pytest.raises(SystemExit):
+        parser.dispatch(["benchmarks", "tasks", "log"])
+
+
+def test_benchmarks_tasks_log_parser_succeeds(parser):
+    func, kwargs = parser.dispatch(["benchmarks", "tasks", "log", "my-task", "-m", "model1"])
+    assert func.__name__ == "benchmarks_tasks_log_cli"
+    assert kwargs["task"] == "my-task"
+    assert kwargs["model"] == ["model1"]
+
+
+def test_benchmarks_tasks_models_parser_succeeds(parser):
+    func, kwargs = parser.dispatch(["benchmarks", "tasks", "models"])
+    assert func.__name__ == "benchmarks_tasks_models_cli"
+    assert kwargs == {}
+
+
+def test_benchmarks_tasks_delete_parser_missing_task_fails(parser):
+    with pytest.raises(SystemExit):
+        parser.dispatch(["benchmarks", "tasks", "delete"])
+
+
+def test_benchmarks_tasks_delete_parser_succeeds(parser):
+    func, kwargs = parser.dispatch(["benchmarks", "tasks", "delete", "my-task", "-y"])
+    assert func.__name__ == "benchmarks_tasks_delete_cli"
+    assert kwargs["task"] == "my-task"
+    assert kwargs["no_confirm"] is True
+
+
+def test_benchmarks_tasks_publish_parser_missing_task_fails(parser):
+    with pytest.raises(SystemExit):
+        parser.dispatch(["benchmarks", "tasks", "publish"])
+
+
+def test_benchmarks_tasks_publish_parser_succeeds(parser):
+    func, kwargs = parser.dispatch(["benchmarks", "tasks", "publish", "my-task", "--no-publish-backing-notebook"])
+    assert func.__name__ == "benchmarks_tasks_publish_cli"
+    assert kwargs["task"] == "my-task"
+    assert kwargs["publish_backing_notebook"] is False

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -1,72 +1,24 @@
 # coding=utf-8
-import argparse
-from unittest.mock import MagicMock, patch
 import pytest
-from kaggle.api.kaggle_api_extended import KaggleApi
-
-
-@pytest.fixture
-def api():
-    a = KaggleApi()
-    a.authenticate = MagicMock()
-    a.build_kaggle_client = MagicMock()
-    return a
-
-
-@pytest.fixture
-def parser(monkeypatch, api):
-    import kaggle
-
-    monkeypatch.setattr(kaggle, "api", api)
-
-    from kaggle.cli import (
-        parse_quota,
-        parse_config,
-        parse_auth,
-        parse_files,
-        Help,
-    )
-    import kaggle.cli
-
-    monkeypatch.setattr(kaggle.cli, "api", api)
-
-    root = argparse.ArgumentParser()
-    subparsers = root.add_subparsers(title="commands", dest="command")
-    subparsers.required = True
-    subparsers.choices = Help.kaggle_choices
-
-    parse_quota(subparsers)
-    parse_config(subparsers)
-    parse_auth(subparsers)
-    parse_files(subparsers)
-    return root
-
-
-def _dispatch(parser, argv):
-    args = parser.parse_args(argv)
-    command_args = dict(vars(args))
-    del command_args["func"]
-    del command_args["command"]
-    return args.func, command_args
 
 
 # Task 1.1: Quota
 def test_quota_parser_default_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["quota"])
+    func, kwargs = parser.dispatch(["quota"])
     assert func.__name__ == "quota_view_cli"
     assert kwargs.get("csv_display") is False
     assert kwargs.get("output_format") is None
 
 
 def test_quota_parser_csv_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["quota", "--csv"])
+    func, kwargs = parser.dispatch(["quota", "--csv"])
     assert func.__name__ == "quota_view_cli"
     assert kwargs["csv_display"] is True
     assert kwargs.get("output_format") is None
 
 
 def test_quota_parser_format_json_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["quota", "--format", "json"])
+    func, kwargs = parser.dispatch(["quota", "--format", "json"])
     assert func.__name__ == "quota_view_cli"
     assert kwargs["csv_display"] is False
     assert kwargs["output_format"] == "json"
@@ -74,66 +26,66 @@ def test_quota_parser_format_json_succeeds(parser):
 
 # Task 1.2: Config
 def test_config_view_parser_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["config", "view"])
+    func, kwargs = parser.dispatch(["config", "view"])
     assert func.__name__ == "print_config_values"
     assert kwargs == {}
 
 
 def test_config_set_parser_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["config", "set", "-n", "proxy", "-v", "http://proxy"])
+    func, kwargs = parser.dispatch(["config", "set", "-n", "proxy", "-v", "http://proxy"])
     assert func.__name__ == "set_config_value"
     assert kwargs["name"] == "proxy"
     assert kwargs["value"] == "http://proxy"
 
 
 def test_config_unset_parser_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["config", "unset", "-n", "proxy"])
+    func, kwargs = parser.dispatch(["config", "unset", "-n", "proxy"])
     assert func.__name__ == "unset_config_value"
     assert kwargs["name"] == "proxy"
 
 
 # Task 1.3: Auth
 def test_auth_login_parser_default_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["auth", "login"])
+    func, kwargs = parser.dispatch(["auth", "login"])
     assert func.__name__ == "auth_login_cli"
     assert kwargs["no_launch_browser"] is False
     assert kwargs["force"] is False
 
 
 def test_auth_login_parser_with_flags_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["auth", "login", "--no-launch-browser", "--force"])
+    func, kwargs = parser.dispatch(["auth", "login", "--no-launch-browser", "--force"])
     assert func.__name__ == "auth_login_cli"
     assert kwargs["no_launch_browser"] is True
     assert kwargs["force"] is True
 
 
 def test_auth_print_access_token_parser_default_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["auth", "print-access-token"])
+    func, kwargs = parser.dispatch(["auth", "print-access-token"])
     assert func.__name__ == "auth_print_access_token"
     assert kwargs["expiration_duration"] is None
 
 
 def test_auth_print_access_token_parser_with_expiration_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["auth", "print-access-token", "--expiration", "6h"])
+    func, kwargs = parser.dispatch(["auth", "print-access-token", "--expiration", "6h"])
     assert func.__name__ == "auth_print_access_token"
     assert kwargs["expiration_duration"] == "6h"
 
 
 def test_auth_revoke_token_parser_default_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["auth", "revoke"])
+    func, kwargs = parser.dispatch(["auth", "revoke"])
     assert func.__name__ == "auth_revoke_token"
     assert kwargs["reason"] is None
 
 
 def test_auth_revoke_token_parser_with_reason_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["auth", "revoke", "--reason", "compromised"])
+    func, kwargs = parser.dispatch(["auth", "revoke", "--reason", "compromised"])
     assert func.__name__ == "auth_revoke_token"
     assert kwargs["reason"] == "compromised"
 
 
 # Task 1.4: Files
 def test_files_upload_parser_default_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["files", "upload", "file1.zip", "file2.txt"])
+    func, kwargs = parser.dispatch(["files", "upload", "file1.zip", "file2.txt"])
     assert func.__name__ == "files_upload_cli"
     assert kwargs["local_paths"] == ["file1.zip", "file2.txt"]
     assert kwargs["inbox_path"] == ""
@@ -142,7 +94,7 @@ def test_files_upload_parser_default_succeeds(parser):
 
 
 def test_files_upload_parser_with_flags_succeeds(parser):
-    func, kwargs = _dispatch(parser, ["files", "upload", "file1.zip", "-i", "my_inbox", "--no-resume", "--no-compress"])
+    func, kwargs = parser.dispatch(["files", "upload", "file1.zip", "-i", "my_inbox", "--no-resume", "--no-compress"])
     assert func.__name__ == "files_upload_cli"
     assert kwargs["local_paths"] == ["file1.zip"]
     assert kwargs["inbox_path"] == "my_inbox"


### PR DESCRIPTION
Implement comprehensive parser tests for all benchmarks subcommands (including tasks) and options in tests/unit/test_cli_benchmarks.py.