### PR TITLE
Integrate ignore_patterns into Datasets upload

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -7184,9 +7184,7 @@ class KaggleApi:
                 response = cast(ApiCreateModelResponse, self.with_retry(message)(request))
                 return response
 
-    def model_instance_create_cli(
-        self, folder, quiet=False, dir_mode="skip", ignore_patterns=None
-    ):
+    def model_instance_create_cli(self, folder, quiet=False, dir_mode="skip", ignore_patterns=None):
         """A client wrapper for creating a new model instance.
 
         Args:
@@ -7196,9 +7194,7 @@ class KaggleApi:
             ignore_patterns: Patterns of files/dirs to ignore.
         """
         folder = folder or os.getcwd()
-        result = self.model_instance_create(
-            folder, quiet, dir_mode, ignore_patterns
-        )
+        result = self.model_instance_create(folder, quiet, dir_mode, ignore_patterns)
 
         if result.id:
             print("Your model instance was created. Id={}. Url={}".format(result.id, result.url))
@@ -8113,10 +8109,7 @@ class KaggleApi:
         new_file.token = file.token
         new_file.description = file.description
         if file.columns:
-            new_file.columns = [
-                ApiDatasetColumn.from_dict(file.to_dict())
-                for file in file.columns
-            ]
+            new_file.columns = [ApiDatasetColumn.from_dict(file.to_dict()) for file in file.columns]
         return new_file
 
     def _upload_file_or_folder(
@@ -8127,9 +8120,7 @@ class KaggleApi:
         upload_context: ResumableUploadContext,
         dir_mode: str,
         quiet: bool = False,
-        resources: Optional[
-            List[Dict[str, Union[str, Dict[str, List[Dict[str, str]]]]]]
-        ] = None,
+        resources: Optional[List[Dict[str, Union[str, Dict[str, List[Dict[str, str]]]]]]] = None,
         ignore_patterns: Optional[List[str]] = None,
     ) -> Union[UploadFile, None]:
         full_path = os.path.join(parent_path, file_or_folder_name)
@@ -8145,9 +8136,7 @@ class KaggleApi:
             )
         elif os.path.isdir(full_path):
             if dir_mode in ["zip", "tar"]:
-                with DirectoryArchive(
-                    full_path, dir_mode, ignore_patterns=ignore_patterns
-                ) as archive:
+                with DirectoryArchive(full_path, dir_mode, ignore_patterns=ignore_patterns) as archive:
                     upload_file = self._upload_file(
                         archive.name,
                         archive.path,
@@ -8157,11 +8146,7 @@ class KaggleApi:
                         resources,
                     )
             elif not quiet:
-                print(
-                    "Skipping folder: "
-                    + file_or_folder_name
-                    + "; use '--dir-mode' to upload folders"
-                )
+                print("Skipping folder: " + file_or_folder_name + "; use '--dir-mode' to upload folders")
         else:
             if not quiet:
                 print("Skipping: " + file_or_folder_name)

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -416,29 +416,118 @@ class OutputFormat(Enum):
         return self.value
 
 
+DEFAULT_IGNORE_PATTERNS = [
+    ".git/",
+    "*/.git/",
+    ".cache/",
+    ".huggingface/",
+]
+
+
+def should_ignore(rel_path: str, is_dir: bool, patterns: List[str]) -> bool:
+    """Helper to check if a path should be ignored based on patterns."""
+    import fnmatch
+
+    rel_path = rel_path.replace(os.path.sep, "/")
+    match_path = (
+        rel_path + "/" if is_dir and not rel_path.endswith("/") else rel_path
+    )
+
+    for pattern in patterns:
+        pattern = pattern.replace(os.path.sep, "/")
+        if pattern.endswith("/"):
+            if not is_dir:
+                continue
+        if fnmatch.fnmatch(match_path, pattern):
+            return True
+    return False
+
+
 class DirectoryArchive(object):
-    """
-    Context manager for handling directory archives.
+    """Context manager for handling directory archives with filtering.
 
-    This class provides a context manager for working with directory archives in various formats.
-    It manages the lifecycle of the archive, including opening and closing resources as needed.
+    This class provides a context manager for working with directory archives in
+    various formats. It manages the lifecycle of the archive, including opening
+    and closing resources as needed. It supports filtering files based on
+    ignore patterns.
     """
 
-    def __init__(self, fullpath, fmt):
+    def __init__(self, fullpath, fmt, ignore_patterns=None):
         self._fullpath = fullpath
         self._format = fmt
+        self._ignore_patterns = ignore_patterns or []
         self.name = None
         self.path = None
 
     def __enter__(self):
         self._temp_dir = tempfile.mkdtemp()
         _, dir_name = os.path.split(self._fullpath)
-        self.path = shutil.make_archive(os.path.join(self._temp_dir, dir_name), self._format, self._fullpath)
+        archive_base_path = os.path.join(self._temp_dir, dir_name)
+
+        if self._ignore_patterns:
+            self.path = self._create_archive_with_filters(archive_base_path)
+        else:
+            self.path = shutil.make_archive(
+                archive_base_path, self._format, self._fullpath
+            )
+
         _, self.name = os.path.split(self.path)
         return self
 
     def __exit__(self, *args):
         shutil.rmtree(self._temp_dir)
+
+    def _create_archive_with_filters(self, base_name):
+        if self._format == "zip":
+            archive_path = base_name + ".zip"
+            with zipfile.ZipFile(
+                archive_path, "w", zipfile.ZIP_DEFLATED
+            ) as zipf:
+                for root, dirs, files in os.walk(self._fullpath):
+                    dirs[:] = [
+                        d
+                        for d in dirs
+                        if not should_ignore(
+                            os.path.relpath(
+                                os.path.join(root, d), self._fullpath
+                            ),
+                            True,
+                            self._ignore_patterns,
+                        )
+                    ]
+                    for file in files:
+                        file_path = os.path.join(root, file)
+                        rel_path = os.path.relpath(file_path, self._fullpath)
+                        if not should_ignore(
+                            rel_path, False, self._ignore_patterns
+                        ):
+                            zipf.write(file_path, rel_path)
+            return archive_path
+        elif self._format == "tar":
+            archive_path = base_name + ".tar"
+            with tarfile.open(archive_path, "w") as tarf:
+                for root, dirs, files in os.walk(self._fullpath):
+                    dirs[:] = [
+                        d
+                        for d in dirs
+                        if not should_ignore(
+                            os.path.relpath(
+                                os.path.join(root, d), self._fullpath
+                            ),
+                            True,
+                            self._ignore_patterns,
+                        )
+                    ]
+                    for file in files:
+                        file_path = os.path.join(root, file)
+                        rel_path = os.path.relpath(file_path, self._fullpath)
+                        if not should_ignore(
+                            rel_path, False, self._ignore_patterns
+                        ):
+                            tarf.add(file_path, rel_path)
+            return archive_path
+        else:
+            raise ValueError(f"Unsupported archive format: {self._format}")
 
 
 class ResumableUploadContext(object):

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -5399,9 +5399,7 @@ class KaggleApi:
             ignore_patterns: Patterns of files/dirs to ignore.
         """
         folder = folder or os.getcwd()
-        result = self.dataset_create_new(
-            folder, public, quiet, convert_to_csv, dir_mode, ignore_patterns
-        )
+        result = self.dataset_create_new(folder, public, quiet, convert_to_csv, dir_mode, ignore_patterns)
         if result.invalidTags:
             print(
                 "The following are not valid tags and could not be added to " "the dataset: " + str(result.invalidTags)

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -5026,6 +5026,7 @@ class KaggleApi:
         convert_to_csv: bool = True,
         delete_old_versions: bool = False,
         dir_mode: str = "skip",
+        ignore_patterns: Optional[List[str]] = None,
     ) -> ApiCreateDatasetResponse:
         """Creates a new version of a dataset.
 
@@ -5093,12 +5094,28 @@ class KaggleApi:
                 message = kaggle.datasets.dataset_api_client.create_dataset_version
             request.body = body
             with ResumableUploadContext() as upload_context:
-                self.upload_files(body, resources, folder, ApiBlobType.DATASET, upload_context, quiet, dir_mode)
+                self.upload_files(
+                    body,
+                    resources,
+                    folder,
+                    ApiBlobType.DATASET,
+                    upload_context,
+                    quiet,
+                    dir_mode,
+                    ignore_patterns,
+                )
                 response = cast(ApiCreateDatasetResponse, self.with_retry(message)(request))
                 return response
 
     def dataset_create_version_cli(
-        self, folder, version_notes, quiet=False, convert_to_csv=True, delete_old_versions=False, dir_mode="skip"
+        self,
+        folder,
+        version_notes,
+        quiet=False,
+        convert_to_csv=True,
+        delete_old_versions=False,
+        dir_mode="skip",
+        ignore_patterns=None,
     ):
         """A client wrapper for creating a new version of a dataset.
 
@@ -5109,6 +5126,7 @@ class KaggleApi:
             convert_to_csv: If True, convert data to CSV on upload.
             delete_old_versions: If True, delete old versions of the dataset.
             dir_mode: What to do with directories: "skip" - ignore; "zip" - compress and upload.
+            ignore_patterns: Patterns of files/dirs to ignore.
         """
         folder = folder or os.getcwd()
         result = self.dataset_create_version(
@@ -5118,6 +5136,7 @@ class KaggleApi:
             convert_to_csv=convert_to_csv,
             delete_old_versions=delete_old_versions,
             dir_mode=dir_mode,
+            ignore_patterns=ignore_patterns,
         )
 
         if result is None:
@@ -5253,6 +5272,7 @@ class KaggleApi:
         quiet: bool = False,
         convert_to_csv: bool = True,
         dir_mode: str = "skip",
+        ignore_patterns: Optional[List[str]] = None,
     ) -> ApiCreateDatasetResponse:
         """Creates a new dataset.
 
@@ -5331,7 +5351,16 @@ class KaggleApi:
         request.category_ids = keywords
 
         with ResumableUploadContext() as upload_context:
-            self.upload_files(request, resources, folder, ApiBlobType.DATASET, upload_context, quiet, dir_mode)
+            self.upload_files(
+                request,
+                resources,
+                folder,
+                ApiBlobType.DATASET,
+                upload_context,
+                quiet,
+                dir_mode,
+                ignore_patterns,
+            )
 
             with self.build_kaggle_client() as kaggle:
                 retry_request = ApiCreateDatasetRequest()
@@ -5350,7 +5379,15 @@ class KaggleApi:
                     result.error = None
                 return result
 
-    def dataset_create_new_cli(self, folder=None, public=False, quiet=False, convert_to_csv=True, dir_mode="skip"):
+    def dataset_create_new_cli(
+        self,
+        folder=None,
+        public=False,
+        quiet=False,
+        convert_to_csv=True,
+        dir_mode="skip",
+        ignore_patterns=None,
+    ):
         """A client wrapper for creating a new dataset.
 
         Args:
@@ -5359,9 +5396,12 @@ class KaggleApi:
             quiet: Suppress verbose output (default is False).
             convert_to_csv: If True, convert data to comma-separated values.
             dir_mode: What to do with directories: "skip" - ignore; "zip" - compress and upload.
+            ignore_patterns: Patterns of files/dirs to ignore.
         """
         folder = folder or os.getcwd()
-        result = self.dataset_create_new(folder, public, quiet, convert_to_csv, dir_mode)
+        result = self.dataset_create_new(
+            folder, public, quiet, convert_to_csv, dir_mode, ignore_patterns
+        )
         if result.invalidTags:
             print(
                 "The following are not valid tags and could not be added to " "the dataset: " + str(result.invalidTags)

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -7095,7 +7095,13 @@ class KaggleApi:
         folder = folder or os.getcwd()
         self.model_instance_initialize(folder)
 
-    def model_instance_create(self, folder: str, quiet: bool = False, dir_mode: str = "skip") -> ApiCreateModelResponse:
+    def model_instance_create(
+        self,
+        folder: str,
+        quiet: bool = False,
+        dir_mode: str = "skip",
+        ignore_patterns: Optional[List[str]] = None,
+    ) -> ApiCreateModelResponse:
         """Creates a new model instance.
 
         Args:
@@ -7165,20 +7171,34 @@ class KaggleApi:
             request.body = body
             message = kaggle.models.model_api_client.create_model_instance
             with ResumableUploadContext() as upload_context:
-                self.upload_files(body, None, folder, ApiBlobType.MODEL, upload_context, quiet, dir_mode)
+                self.upload_files(
+                    body,
+                    None,
+                    folder,
+                    ApiBlobType.MODEL,
+                    upload_context,
+                    quiet,
+                    dir_mode,
+                    ignore_patterns,
+                )
                 response = cast(ApiCreateModelResponse, self.with_retry(message)(request))
                 return response
 
-    def model_instance_create_cli(self, folder, quiet=False, dir_mode="skip"):
+    def model_instance_create_cli(
+        self, folder, quiet=False, dir_mode="skip", ignore_patterns=None
+    ):
         """A client wrapper for creating a new model instance.
 
         Args:
             folder: The folder from which to get the metadata file.
             quiet: Suppress verbose output (default is False).
             dir_mode: What to do with directories: "skip" - ignore; "zip" - compress and upload.
+            ignore_patterns: Patterns of files/dirs to ignore.
         """
         folder = folder or os.getcwd()
-        result = self.model_instance_create(folder, quiet, dir_mode)
+        result = self.model_instance_create(
+            folder, quiet, dir_mode, ignore_patterns
+        )
 
         if result.id:
             print("Your model instance was created. Id={}. Url={}".format(result.id, result.url))
@@ -7433,7 +7453,13 @@ class KaggleApi:
             print("Model update error: " + result.error)
 
     def model_instance_version_create(
-        self, model_instance: str, folder: str, version_notes: str = "", quiet: bool = False, dir_mode: str = "skip"
+        self,
+        model_instance: str,
+        folder: str,
+        version_notes: str = "",
+        quiet: bool = False,
+        dir_mode: str = "skip",
+        ignore_patterns: Optional[List[str]] = None,
     ) -> ApiCreateModelResponse:
         """Creates a new model instance version.
 
@@ -7460,11 +7486,28 @@ class KaggleApi:
         with self.build_kaggle_client() as kaggle:
             message = kaggle.models.model_api_client.create_model_instance_version
             with ResumableUploadContext() as upload_context:
-                self.upload_files(body, None, folder, ApiBlobType.MODEL, upload_context, quiet, dir_mode)
+                self.upload_files(
+                    body,
+                    None,
+                    folder,
+                    ApiBlobType.MODEL,
+                    upload_context,
+                    quiet,
+                    dir_mode,
+                    ignore_patterns,
+                )
                 response = cast(ApiCreateModelResponse, self.with_retry(message)(request))
                 return response
 
-    def model_instance_version_create_cli(self, model_instance, folder, version_notes="", quiet=False, dir_mode="skip"):
+    def model_instance_version_create_cli(
+        self,
+        model_instance,
+        folder,
+        version_notes="",
+        quiet=False,
+        dir_mode="skip",
+        ignore_patterns=None,
+    ):
         """A client wrapper for creating a new version of a model instance.
 
         Args:
@@ -7474,8 +7517,11 @@ class KaggleApi:
             version_notes: The version notes to record for this new version.
             quiet: Suppress verbose output (default is False).
             dir_mode: What to do with directories: "skip" - ignore; "zip" - compress and upload.
+            ignore_patterns: Patterns of files/dirs to ignore.
         """
-        result = self.model_instance_version_create(model_instance, folder, version_notes, quiet, dir_mode)
+        result = self.model_instance_version_create(
+            model_instance, folder, version_notes, quiet, dir_mode, ignore_patterns
+        )
 
         if result.id != 0:
             print("Your model instance version was created. Url={}".format(result.url))
@@ -8013,6 +8059,7 @@ class KaggleApi:
         upload_context: ResumableUploadContext,
         quiet: bool = False,
         dir_mode: str = "skip",
+        ignore_patterns: Optional[List[str]] = None,
     ) -> None:
         """Uploads files in a folder.
 
@@ -8024,10 +8071,12 @@ class KaggleApi:
             upload_context (ResumableUploadContext): The context for resumable uploads.
             quiet (bool): Suppress verbose output (default is False).
             dir_mode (str): What to do with directories: "skip" - ignore; "zip" - compress and upload.
+            ignore_patterns (Optional[List[str]]): Patterns of files/dirs to ignore.
 
         Returns:
             None:
         """
+        patterns = DEFAULT_IGNORE_PATTERNS + (ignore_patterns or [])
         for file_name in os.listdir(folder):
             if file_name in [
                 self.DATASET_METADATA_FILE,
@@ -8038,8 +8087,21 @@ class KaggleApi:
                 self.MODEL_INSTANCE_METADATA_FILE,
             ]:
                 continue
+
+            full_path = os.path.join(folder, file_name)
+            is_dir = os.path.isdir(full_path)
+            if should_ignore(file_name, is_dir, patterns):
+                continue
+
             upload_file = self._upload_file_or_folder(
-                folder, file_name, blob_type, upload_context, dir_mode, quiet, resources
+                folder,
+                file_name,
+                blob_type,
+                upload_context,
+                dir_mode,
+                quiet,
+                resources,
+                patterns,
             )
             if upload_file is not None:
                 files = request.files
@@ -8051,7 +8113,10 @@ class KaggleApi:
         new_file.token = file.token
         new_file.description = file.description
         if file.columns:
-            new_file.columns = [ApiDatasetColumn.from_dict(file.to_dict()) for file in file.columns]
+            new_file.columns = [
+                ApiDatasetColumn.from_dict(file.to_dict())
+                for file in file.columns
+            ]
         return new_file
 
     def _upload_file_or_folder(
@@ -8062,20 +8127,41 @@ class KaggleApi:
         upload_context: ResumableUploadContext,
         dir_mode: str,
         quiet: bool = False,
-        resources: Optional[List[Dict[str, Union[str, Dict[str, List[Dict[str, str]]]]]]] = None,
+        resources: Optional[
+            List[Dict[str, Union[str, Dict[str, List[Dict[str, str]]]]]]
+        ] = None,
+        ignore_patterns: Optional[List[str]] = None,
     ) -> Union[UploadFile, None]:
         full_path = os.path.join(parent_path, file_or_folder_name)
         upload_file = None
         if os.path.isfile(full_path):
-            upload_file = self._upload_file(file_or_folder_name, full_path, blob_type, upload_context, quiet, resources)
+            upload_file = self._upload_file(
+                file_or_folder_name,
+                full_path,
+                blob_type,
+                upload_context,
+                quiet,
+                resources,
+            )
         elif os.path.isdir(full_path):
             if dir_mode in ["zip", "tar"]:
-                with DirectoryArchive(full_path, dir_mode) as archive:
+                with DirectoryArchive(
+                    full_path, dir_mode, ignore_patterns=ignore_patterns
+                ) as archive:
                     upload_file = self._upload_file(
-                        archive.name, archive.path, blob_type, upload_context, quiet, resources
+                        archive.name,
+                        archive.path,
+                        blob_type,
+                        upload_context,
+                        quiet,
+                        resources,
                     )
             elif not quiet:
-                print("Skipping folder: " + file_or_folder_name + "; use '--dir-mode' to upload folders")
+                print(
+                    "Skipping folder: "
+                    + file_or_folder_name
+                    + "; use '--dir-mode' to upload folders"
+                )
         else:
             if not quiet:
                 print("Skipping: " + file_or_folder_name)

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -429,9 +429,7 @@ def should_ignore(rel_path: str, is_dir: bool, patterns: List[str]) -> bool:
     import fnmatch
 
     rel_path = rel_path.replace(os.path.sep, "/")
-    match_path = (
-        rel_path + "/" if is_dir and not rel_path.endswith("/") else rel_path
-    )
+    match_path = rel_path + "/" if is_dir and not rel_path.endswith("/") else rel_path
 
     for pattern in patterns:
         pattern = pattern.replace(os.path.sep, "/")
@@ -467,9 +465,7 @@ class DirectoryArchive(object):
         if self._ignore_patterns:
             self.path = self._create_archive_with_filters(archive_base_path)
         else:
-            self.path = shutil.make_archive(
-                archive_base_path, self._format, self._fullpath
-            )
+            self.path = shutil.make_archive(archive_base_path, self._format, self._fullpath)
 
         _, self.name = os.path.split(self.path)
         return self
@@ -480,17 +476,13 @@ class DirectoryArchive(object):
     def _create_archive_with_filters(self, base_name):
         if self._format == "zip":
             archive_path = base_name + ".zip"
-            with zipfile.ZipFile(
-                archive_path, "w", zipfile.ZIP_DEFLATED
-            ) as zipf:
+            with zipfile.ZipFile(archive_path, "w", zipfile.ZIP_DEFLATED) as zipf:
                 for root, dirs, files in os.walk(self._fullpath):
                     dirs[:] = [
                         d
                         for d in dirs
                         if not should_ignore(
-                            os.path.relpath(
-                                os.path.join(root, d), self._fullpath
-                            ),
+                            os.path.relpath(os.path.join(root, d), self._fullpath),
                             True,
                             self._ignore_patterns,
                         )
@@ -498,9 +490,7 @@ class DirectoryArchive(object):
                     for file in files:
                         file_path = os.path.join(root, file)
                         rel_path = os.path.relpath(file_path, self._fullpath)
-                        if not should_ignore(
-                            rel_path, False, self._ignore_patterns
-                        ):
+                        if not should_ignore(rel_path, False, self._ignore_patterns):
                             zipf.write(file_path, rel_path)
             return archive_path
         elif self._format == "tar":
@@ -511,9 +501,7 @@ class DirectoryArchive(object):
                         d
                         for d in dirs
                         if not should_ignore(
-                            os.path.relpath(
-                                os.path.join(root, d), self._fullpath
-                            ),
+                            os.path.relpath(os.path.join(root, d), self._fullpath),
                             True,
                             self._ignore_patterns,
                         )
@@ -521,9 +509,7 @@ class DirectoryArchive(object):
                     for file in files:
                         file_path = os.path.join(root, file)
                         rel_path = os.path.relpath(file_path, self._fullpath)
-                        if not should_ignore(
-                            rel_path, False, self._ignore_patterns
-                        ):
+                        if not should_ignore(rel_path, False, self._ignore_patterns):
                             tarf.add(file_path, rel_path)
             return archive_path
         else:

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -996,6 +996,13 @@ def parse_datasets(subparsers) -> None:
     parser_datasets_create_optional.add_argument(
         "-r", "--dir-mode", dest="dir_mode", choices=["skip", "zip", "tar"], default="skip", help=Help.param_dir_mode
     )
+    parser_datasets_create_optional.add_argument(
+        "--ignore-patterns",
+        dest="ignore_patterns",
+        action="append",
+        required=False,
+        help="Patterns to ignore when uploading files/dirs",
+    )
     parser_datasets_create._action_groups.append(parser_datasets_create_optional)
     parser_datasets_create.set_defaults(func=api.dataset_create_new_cli)
 
@@ -1026,6 +1033,13 @@ def parse_datasets(subparsers) -> None:
         dest="delete_old_versions",
         action="store_true",
         help=Help.param_delete_old_version,
+    )
+    parser_datasets_version_optional.add_argument(
+        "--ignore-patterns",
+        dest="ignore_patterns",
+        action="append",
+        required=False,
+        help="Patterns to ignore when uploading files/dirs",
     )
     parser_datasets_version._action_groups.append(parser_datasets_version_optional)
     parser_datasets_version.set_defaults(func=api.dataset_create_version_cli)

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -1571,6 +1571,13 @@ def parse_model_instances(subparsers) -> None:
     parser_model_instances_create_optional.add_argument(
         "-r", "--dir-mode", dest="dir_mode", choices=["skip", "zip", "tar"], default="skip", help=Help.param_dir_mode
     )
+    parser_model_instances_create_optional.add_argument(
+        "--ignore-patterns",
+        dest="ignore_patterns",
+        action="append",
+        required=False,
+        help="Patterns to ignore when uploading files/dirs",
+    )
     parser_model_instances_create._action_groups.append(parser_model_instances_create_optional)
     parser_model_instances_create.set_defaults(func=api.model_instance_create_cli)
 
@@ -1675,6 +1682,13 @@ def parse_model_instance_versions(subparsers) -> None:
     )
     parser_model_instance_versions_create_optional.add_argument(
         "-r", "--dir-mode", dest="dir_mode", choices=["skip", "zip", "tar"], default="skip", help=Help.param_dir_mode
+    )
+    parser_model_instance_versions_create_optional.add_argument(
+        "--ignore-patterns",
+        dest="ignore_patterns",
+        action="append",
+        required=False,
+        help="Patterns to ignore when uploading files/dirs",
     )
     parser_model_instance_versions_create._action_groups.append(parser_model_instance_versions_create_optional)
     parser_model_instance_versions_create.set_defaults(func=api.model_instance_version_create_cli)

--- a/tests/unit/test_cli_datasets.py
+++ b/tests/unit/test_cli_datasets.py
@@ -189,6 +189,22 @@ def test_datasets_create_parser_with_flags_succeeds(parser):
     assert kwargs["quiet"] is True
     assert kwargs["convert_to_csv"] is False
     assert kwargs["dir_mode"] == "zip"
+    assert kwargs.get("ignore_patterns") is None
+
+
+def test_datasets_create_parser_with_ignore_patterns_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "datasets",
+            "create",
+            "--ignore-patterns",
+            "*.tmp",
+            "--ignore-patterns",
+            "temp/",
+        ]
+    )
+    assert func.__name__ == "dataset_create_new_cli"
+    assert kwargs["ignore_patterns"] == ["*.tmp", "temp/"]
 
 
 def test_datasets_version_parser_missing_message_fails(parser):
@@ -219,6 +235,25 @@ def test_datasets_version_parser_succeeds(parser):
     assert kwargs["convert_to_csv"] is False
     assert kwargs["dir_mode"] == "tar"
     assert kwargs["delete_old_versions"] is True
+    assert kwargs.get("ignore_patterns") is None
+
+
+def test_datasets_version_parser_with_ignore_patterns_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "datasets",
+            "version",
+            "-m",
+            "version message",
+            "--ignore-patterns",
+            "*.tmp",
+            "--ignore-patterns",
+            "temp/",
+        ]
+    )
+    assert func.__name__ == "dataset_create_version_cli"
+    assert kwargs["version_notes"] == "version message"
+    assert kwargs["ignore_patterns"] == ["*.tmp", "temp/"]
 
 
 def test_datasets_init_parser_default_succeeds(parser):

--- a/tests/unit/test_cli_models.py
+++ b/tests/unit/test_cli_models.py
@@ -203,6 +203,23 @@ def test_model_instances_create_parser_with_flags_succeeds(parser):
     assert kwargs["folder"] == "/path/to/instance"
     assert kwargs["quiet"] is True
     assert kwargs["dir_mode"] == "zip"
+    assert kwargs.get("ignore_patterns") is None
+
+
+def test_model_instances_create_parser_with_ignore_patterns_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "models",
+            "instances",
+            "create",
+            "--ignore-patterns",
+            "*.tmp",
+            "--ignore-patterns",
+            "temp/",
+        ]
+    )
+    assert func.__name__ == "model_instance_create_cli"
+    assert kwargs["ignore_patterns"] == ["*.tmp", "temp/"]
 
 
 def test_model_instances_files_parser_missing_instance_fails(parser):
@@ -346,6 +363,28 @@ def test_model_instance_versions_create_parser_succeeds(parser):
     assert kwargs["version_notes"] == "version notes"
     assert kwargs["quiet"] is True
     assert kwargs["dir_mode"] == "tar"
+    assert kwargs.get("ignore_patterns") is None
+
+
+def test_model_instance_versions_create_parser_with_ignore_patterns_succeeds(
+    parser,
+):
+    func, kwargs = parser.dispatch(
+        [
+            "models",
+            "instances",
+            "versions",
+            "create",
+            "owner/model/framework/variation",
+            "--ignore-patterns",
+            "*.tmp",
+            "--ignore-patterns",
+            "temp/",
+        ]
+    )
+    assert func.__name__ == "model_instance_version_create_cli"
+    assert kwargs["model_instance"] == "owner/model/framework/variation"
+    assert kwargs["ignore_patterns"] == ["*.tmp", "temp/"]
 
 
 def test_model_instance_versions_download_parser_missing_version_fails(parser):

--- a/tests/unit/test_dataset_create.py
+++ b/tests/unit/test_dataset_create.py
@@ -10,6 +10,8 @@ from requests.exceptions import HTTPError
 sys.path.insert(0, "../..")
 
 from kaggle.api.kaggle_api_extended import KaggleApi
+from kagglesdk.blobs.types.blob_api_service import ApiBlobType
+
 
 
 class TestDatasetCreate(unittest.TestCase):
@@ -177,6 +179,36 @@ class TestDatasetCreate(unittest.TestCase):
     @patch.object(KaggleApi, "dataset_status")
     @patch.object(KaggleApi, "upload_files")
     @patch.object(KaggleApi, "build_kaggle_client")
+    def test_dataset_create_new_with_ignore_patterns_succeeds(
+        self, mock_client, mock_upload, mock_status
+    ):
+        mock_status.side_effect = HTTPError()
+        mock_kaggle = MagicMock()
+        mock_response = MagicMock()
+        mock_response.error = ""
+        mock_kaggle.datasets.dataset_api_client.create_dataset.return_value = mock_response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        metadata = self._get_valid_metadata()
+        ignore_patterns = ["*.tmp", "temp/"]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            response = self.api.dataset_create_new(
+                tmpdir, ignore_patterns=ignore_patterns
+            )
+
+            self.assertEqual(response, mock_response)
+            mock_upload.assert_called_once()
+            call_args = mock_upload.call_args[0]
+            self.assertEqual(call_args[2], tmpdir)
+            self.assertEqual(call_args[3], ApiBlobType.DATASET)
+            self.assertEqual(call_args[7], ignore_patterns)
+
+    @patch.object(KaggleApi, "dataset_status")
+    @patch.object(KaggleApi, "upload_files")
+    @patch.object(KaggleApi, "build_kaggle_client")
     def test_dataset_create_new_with_valid_resources_succeeds(self, mock_client, mock_upload, mock_status):
         mock_status.side_effect = HTTPError()
         mock_kaggle = MagicMock()
@@ -323,6 +355,37 @@ class TestDatasetCreate(unittest.TestCase):
             self.assertEqual(body.subtitle, "This is a valid subtitle with enough length")
 
             self.assertEqual(response, mock_response)
+
+    @patch.object(KaggleApi, "upload_files")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_dataset_create_version_with_ignore_patterns_succeeds(
+        self, mock_client, mock_upload
+    ):
+        mock_kaggle = MagicMock()
+        mock_response = MagicMock()
+        mock_kaggle.datasets.dataset_api_client.create_dataset_version.return_value = (
+            mock_response
+        )
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        metadata = self._get_valid_metadata()
+        ignore_patterns = ["*.tmp", "temp/"]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            response = self.api.dataset_create_version(
+                tmpdir,
+                "version notes here",
+                ignore_patterns=ignore_patterns,
+            )
+
+            self.assertEqual(response, mock_response)
+            mock_upload.assert_called_once()
+            call_args = mock_upload.call_args[0]
+            self.assertEqual(call_args[2], tmpdir)
+            self.assertEqual(call_args[3], ApiBlobType.DATASET)
+            self.assertEqual(call_args[7], ignore_patterns)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_dataset_create.py
+++ b/tests/unit/test_dataset_create.py
@@ -13,7 +13,6 @@ from kaggle.api.kaggle_api_extended import KaggleApi
 from kagglesdk.blobs.types.blob_api_service import ApiBlobType
 
 
-
 class TestDatasetCreate(unittest.TestCase):
     """Tests for dataset_create_new and dataset_create_version."""
 
@@ -179,9 +178,7 @@ class TestDatasetCreate(unittest.TestCase):
     @patch.object(KaggleApi, "dataset_status")
     @patch.object(KaggleApi, "upload_files")
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_dataset_create_new_with_ignore_patterns_succeeds(
-        self, mock_client, mock_upload, mock_status
-    ):
+    def test_dataset_create_new_with_ignore_patterns_succeeds(self, mock_client, mock_upload, mock_status):
         mock_status.side_effect = HTTPError()
         mock_kaggle = MagicMock()
         mock_response = MagicMock()
@@ -195,9 +192,7 @@ class TestDatasetCreate(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             self._write_metadata(tmpdir, metadata)
-            response = self.api.dataset_create_new(
-                tmpdir, ignore_patterns=ignore_patterns
-            )
+            response = self.api.dataset_create_new(tmpdir, ignore_patterns=ignore_patterns)
 
             self.assertEqual(response, mock_response)
             mock_upload.assert_called_once()
@@ -358,14 +353,10 @@ class TestDatasetCreate(unittest.TestCase):
 
     @patch.object(KaggleApi, "upload_files")
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_dataset_create_version_with_ignore_patterns_succeeds(
-        self, mock_client, mock_upload
-    ):
+    def test_dataset_create_version_with_ignore_patterns_succeeds(self, mock_client, mock_upload):
         mock_kaggle = MagicMock()
         mock_response = MagicMock()
-        mock_kaggle.datasets.dataset_api_client.create_dataset_version.return_value = (
-            mock_response
-        )
+        mock_kaggle.datasets.dataset_api_client.create_dataset_version.return_value = mock_response
         mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
         mock_client.return_value.__exit__ = MagicMock(return_value=False)
 

--- a/tests/unit/test_ignore_patterns.py
+++ b/tests/unit/test_ignore_patterns.py
@@ -1,0 +1,182 @@
+import os
+import shutil
+import tempfile
+import unittest
+import zipfile
+import tarfile
+
+from kaggle.api.kaggle_api_extended import should_ignore, DirectoryArchive, DEFAULT_IGNORE_PATTERNS
+
+
+class TestIgnorePatterns(unittest.TestCase):
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def test_should_ignore_default_patterns(self):
+        # .git/ at root should be ignored
+        self.assertTrue(should_ignore(".git", True, DEFAULT_IGNORE_PATTERNS))
+        self.assertTrue(should_ignore(".git/", True, DEFAULT_IGNORE_PATTERNS))
+
+        # .git/ in sub dir should be ignored (due to */.git/)
+        self.assertTrue(should_ignore("sub/.git", True, DEFAULT_IGNORE_PATTERNS))
+        self.assertTrue(
+            should_ignore("sub/.git/", True, DEFAULT_IGNORE_PATTERNS)
+        )
+        self.assertTrue(
+            should_ignore("sub/dir/.git", True, DEFAULT_IGNORE_PATTERNS)
+        )
+
+        # .git file (not dir) should NOT be ignored
+        self.assertFalse(should_ignore(".git", False, DEFAULT_IGNORE_PATTERNS))
+        self.assertFalse(
+            should_ignore("sub/.git", False, DEFAULT_IGNORE_PATTERNS)
+        )
+
+        # .cache/ at root should be ignored
+        self.assertTrue(should_ignore(".cache", True, DEFAULT_IGNORE_PATTERNS))
+
+        # .cache/ in sub dir should NOT be ignored (no */.cache/ in defaults)
+        self.assertFalse(
+            should_ignore("sub/.cache", True, DEFAULT_IGNORE_PATTERNS)
+        )
+
+        # .huggingface/ at root should be ignored
+        self.assertTrue(
+            should_ignore(".huggingface", True, DEFAULT_IGNORE_PATTERNS)
+        )
+
+        # .huggingface/ in sub dir should NOT be ignored
+        self.assertFalse(
+            should_ignore("sub/.huggingface", True, DEFAULT_IGNORE_PATTERNS)
+        )
+
+    def test_should_ignore_custom_patterns(self):
+        patterns = ["*.tmp", "ignore_dir/", "*/nested_ignore_dir/", "exact_file.txt"]
+
+        # Wildcard file pattern
+        self.assertTrue(should_ignore("foo.tmp", False, patterns))
+        self.assertTrue(should_ignore("sub/foo.tmp", False, patterns))
+        self.assertFalse(should_ignore("foo.tmp.bak", False, patterns))
+
+        # Directory pattern (root only)
+        self.assertTrue(should_ignore("ignore_dir", True, patterns))
+        self.assertFalse(should_ignore("sub/ignore_dir", True, patterns))
+        # Directory pattern (root only) should not match file
+        self.assertFalse(should_ignore("ignore_dir", False, patterns))
+
+        # Directory pattern (nested)
+        self.assertTrue(should_ignore("sub/nested_ignore_dir", True, patterns))
+        self.assertTrue(
+            should_ignore("sub/dir/nested_ignore_dir", True, patterns)
+        )
+        self.assertFalse(should_ignore("nested_ignore_dir", True, patterns))
+
+        # Exact file pattern
+        self.assertTrue(should_ignore("exact_file.txt", False, patterns))
+        # fnmatch "exact_file.txt" will not match "sub/exact_file.txt" if we don't have wildcard
+        # Wait, fnmatch("sub/exact_file.txt", "exact_file.txt") is False.
+        self.assertFalse(should_ignore("sub/exact_file.txt", False, patterns))
+
+    def test_directory_archive_zip_filtering(self):
+        # Create dummy directory structure
+        src_dir = os.path.join(self.temp_dir, "src")
+        os.makedirs(src_dir)
+        os.makedirs(os.path.join(src_dir, ".git"))
+        os.makedirs(os.path.join(src_dir, "sub"))
+        os.makedirs(os.path.join(src_dir, "sub", ".git"))
+        os.makedirs(os.path.join(src_dir, "ignore_dir"))
+
+        # Create files
+        self._create_file(os.path.join(src_dir, "keep.txt"))
+        self._create_file(os.path.join(src_dir, ".git", "config"))
+        self._create_file(os.path.join(src_dir, "sub", "keep2.txt"))
+        self._create_file(os.path.join(src_dir, "sub", ".git", "config"))
+        self._create_file(os.path.join(src_dir, "sub", "temp.tmp"))
+        self._create_file(os.path.join(src_dir, "ignore_dir", "file.txt"))
+
+        patterns = DEFAULT_IGNORE_PATTERNS + ["*.tmp", "ignore_dir/"]
+
+        # Archive
+        with DirectoryArchive(src_dir, "zip", ignore_patterns=patterns) as ar:
+            archive_path = ar.path
+            self.assertTrue(os.path.exists(archive_path))
+
+            # Extract and verify
+            extract_dir = os.path.join(self.temp_dir, "extract")
+            os.makedirs(extract_dir)
+            with zipfile.ZipFile(archive_path, "r") as zip_ref:
+                zip_ref.extractall(extract_dir)
+
+            # Check files
+            self.assertTrue(os.path.exists(os.path.join(extract_dir, "keep.txt")))
+            self.assertTrue(
+                os.path.exists(os.path.join(extract_dir, "sub", "keep2.txt"))
+            )
+
+            # Checked ignored
+            self.assertFalse(os.path.exists(os.path.join(extract_dir, ".git")))
+            self.assertFalse(
+                os.path.exists(os.path.join(extract_dir, "sub", ".git"))
+            )
+            self.assertFalse(
+                os.path.exists(os.path.join(extract_dir, "sub", "temp.tmp"))
+            )
+            self.assertFalse(
+                os.path.exists(os.path.join(extract_dir, "ignore_dir"))
+            )
+
+    def test_directory_archive_tar_filtering(self):
+        # Create dummy directory structure
+        src_dir = os.path.join(self.temp_dir, "src")
+        os.makedirs(src_dir)
+        os.makedirs(os.path.join(src_dir, ".git"))
+        os.makedirs(os.path.join(src_dir, "sub"))
+        os.makedirs(os.path.join(src_dir, "sub", ".git"))
+        os.makedirs(os.path.join(src_dir, "ignore_dir"))
+
+        # Create files
+        self._create_file(os.path.join(src_dir, "keep.txt"))
+        self._create_file(os.path.join(src_dir, ".git", "config"))
+        self._create_file(os.path.join(src_dir, "sub", "keep2.txt"))
+        self._create_file(os.path.join(src_dir, "sub", ".git", "config"))
+        self._create_file(os.path.join(src_dir, "sub", "temp.tmp"))
+        self._create_file(os.path.join(src_dir, "ignore_dir", "file.txt"))
+
+        patterns = DEFAULT_IGNORE_PATTERNS + ["*.tmp", "ignore_dir/"]
+
+        # Archive
+        with DirectoryArchive(src_dir, "tar", ignore_patterns=patterns) as ar:
+            archive_path = ar.path
+            self.assertTrue(os.path.exists(archive_path))
+
+            # Extract and verify
+            extract_dir = os.path.join(self.temp_dir, "extract")
+            os.makedirs(extract_dir)
+            with tarfile.open(archive_path, "r") as tar_ref:
+                tar_ref.extractall(extract_dir)
+
+            # Check files
+            self.assertTrue(os.path.exists(os.path.join(extract_dir, "keep.txt")))
+            self.assertTrue(
+                os.path.exists(os.path.join(extract_dir, "sub", "keep2.txt"))
+            )
+
+            # Checked ignored
+            self.assertFalse(os.path.exists(os.path.join(extract_dir, ".git")))
+            self.assertFalse(
+                os.path.exists(os.path.join(extract_dir, "sub", ".git"))
+            )
+            self.assertFalse(
+                os.path.exists(os.path.join(extract_dir, "sub", "temp.tmp"))
+            )
+            self.assertFalse(
+                os.path.exists(os.path.join(extract_dir, "ignore_dir"))
+            )
+
+    def _create_file(self, path):
+        with open(path, "w") as f:
+            f.write("dummy content")

--- a/tests/unit/test_ignore_patterns.py
+++ b/tests/unit/test_ignore_patterns.py
@@ -23,36 +23,24 @@ class TestIgnorePatterns(unittest.TestCase):
 
         # .git/ in sub dir should be ignored (due to */.git/)
         self.assertTrue(should_ignore("sub/.git", True, DEFAULT_IGNORE_PATTERNS))
-        self.assertTrue(
-            should_ignore("sub/.git/", True, DEFAULT_IGNORE_PATTERNS)
-        )
-        self.assertTrue(
-            should_ignore("sub/dir/.git", True, DEFAULT_IGNORE_PATTERNS)
-        )
+        self.assertTrue(should_ignore("sub/.git/", True, DEFAULT_IGNORE_PATTERNS))
+        self.assertTrue(should_ignore("sub/dir/.git", True, DEFAULT_IGNORE_PATTERNS))
 
         # .git file (not dir) should NOT be ignored
         self.assertFalse(should_ignore(".git", False, DEFAULT_IGNORE_PATTERNS))
-        self.assertFalse(
-            should_ignore("sub/.git", False, DEFAULT_IGNORE_PATTERNS)
-        )
+        self.assertFalse(should_ignore("sub/.git", False, DEFAULT_IGNORE_PATTERNS))
 
         # .cache/ at root should be ignored
         self.assertTrue(should_ignore(".cache", True, DEFAULT_IGNORE_PATTERNS))
 
         # .cache/ in sub dir should NOT be ignored (no */.cache/ in defaults)
-        self.assertFalse(
-            should_ignore("sub/.cache", True, DEFAULT_IGNORE_PATTERNS)
-        )
+        self.assertFalse(should_ignore("sub/.cache", True, DEFAULT_IGNORE_PATTERNS))
 
         # .huggingface/ at root should be ignored
-        self.assertTrue(
-            should_ignore(".huggingface", True, DEFAULT_IGNORE_PATTERNS)
-        )
+        self.assertTrue(should_ignore(".huggingface", True, DEFAULT_IGNORE_PATTERNS))
 
         # .huggingface/ in sub dir should NOT be ignored
-        self.assertFalse(
-            should_ignore("sub/.huggingface", True, DEFAULT_IGNORE_PATTERNS)
-        )
+        self.assertFalse(should_ignore("sub/.huggingface", True, DEFAULT_IGNORE_PATTERNS))
 
     def test_should_ignore_custom_patterns(self):
         patterns = ["*.tmp", "ignore_dir/", "*/nested_ignore_dir/", "exact_file.txt"]
@@ -70,9 +58,7 @@ class TestIgnorePatterns(unittest.TestCase):
 
         # Directory pattern (nested)
         self.assertTrue(should_ignore("sub/nested_ignore_dir", True, patterns))
-        self.assertTrue(
-            should_ignore("sub/dir/nested_ignore_dir", True, patterns)
-        )
+        self.assertTrue(should_ignore("sub/dir/nested_ignore_dir", True, patterns))
         self.assertFalse(should_ignore("nested_ignore_dir", True, patterns))
 
         # Exact file pattern
@@ -113,21 +99,13 @@ class TestIgnorePatterns(unittest.TestCase):
 
             # Check files
             self.assertTrue(os.path.exists(os.path.join(extract_dir, "keep.txt")))
-            self.assertTrue(
-                os.path.exists(os.path.join(extract_dir, "sub", "keep2.txt"))
-            )
+            self.assertTrue(os.path.exists(os.path.join(extract_dir, "sub", "keep2.txt")))
 
             # Checked ignored
             self.assertFalse(os.path.exists(os.path.join(extract_dir, ".git")))
-            self.assertFalse(
-                os.path.exists(os.path.join(extract_dir, "sub", ".git"))
-            )
-            self.assertFalse(
-                os.path.exists(os.path.join(extract_dir, "sub", "temp.tmp"))
-            )
-            self.assertFalse(
-                os.path.exists(os.path.join(extract_dir, "ignore_dir"))
-            )
+            self.assertFalse(os.path.exists(os.path.join(extract_dir, "sub", ".git")))
+            self.assertFalse(os.path.exists(os.path.join(extract_dir, "sub", "temp.tmp")))
+            self.assertFalse(os.path.exists(os.path.join(extract_dir, "ignore_dir")))
 
     def test_directory_archive_tar_filtering(self):
         # Create dummy directory structure
@@ -161,21 +139,13 @@ class TestIgnorePatterns(unittest.TestCase):
 
             # Check files
             self.assertTrue(os.path.exists(os.path.join(extract_dir, "keep.txt")))
-            self.assertTrue(
-                os.path.exists(os.path.join(extract_dir, "sub", "keep2.txt"))
-            )
+            self.assertTrue(os.path.exists(os.path.join(extract_dir, "sub", "keep2.txt")))
 
             # Checked ignored
             self.assertFalse(os.path.exists(os.path.join(extract_dir, ".git")))
-            self.assertFalse(
-                os.path.exists(os.path.join(extract_dir, "sub", ".git"))
-            )
-            self.assertFalse(
-                os.path.exists(os.path.join(extract_dir, "sub", "temp.tmp"))
-            )
-            self.assertFalse(
-                os.path.exists(os.path.join(extract_dir, "ignore_dir"))
-            )
+            self.assertFalse(os.path.exists(os.path.join(extract_dir, "sub", ".git")))
+            self.assertFalse(os.path.exists(os.path.join(extract_dir, "sub", "temp.tmp")))
+            self.assertFalse(os.path.exists(os.path.join(extract_dir, "ignore_dir")))
 
     def _create_file(self, path):
         with open(path, "w") as f:

--- a/tests/unit/test_model_create.py
+++ b/tests/unit/test_model_create.py
@@ -156,6 +156,38 @@ class TestModelCreate(unittest.TestCase):
             self.assertEqual(body.base_model_instance, "base-instance")
             self.assertEqual(body.external_base_model_url, "http://example.com")
 
+    @patch.object(KaggleApi, "upload_files")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_model_instance_create_with_ignore_patterns_succeeds(
+        self, mock_client, mock_upload
+    ):
+        mock_kaggle = MagicMock()
+        mock_response = ApiCreateModelResponse()
+        mock_kaggle.models.model_api_client.create_model_instance.return_value = mock_response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        metadata = self._get_valid_instance_metadata()
+        ignore_patterns = ["*.tmp", "temp/"]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata)
+            response = self.api.model_instance_create(
+                tmpdir,
+                quiet=True,
+                dir_mode="zip",
+                ignore_patterns=ignore_patterns,
+            )
+
+            self.assertEqual(response, mock_response)
+            mock_upload.assert_called_once()
+            call_args = mock_upload.call_args[0]
+            self.assertEqual(call_args[2], tmpdir)
+            self.assertEqual(call_args[3], ApiBlobType.MODEL)
+            self.assertTrue(call_args[5])
+            self.assertEqual(call_args[6], "zip")
+            self.assertEqual(call_args[7], ignore_patterns)
+
     def test_model_instance_update_invalid_folder_fails(self):
         with self.assertRaises(ValueError) as context:
             self.api.model_instance_update("/non/existent/folder")
@@ -488,6 +520,94 @@ class TestModelCreate(unittest.TestCase):
 
             self.assertIsNotNone(request.update_mask)
             self.assertEqual(list(request.update_mask.paths), ["title"])
+class TestModelInstanceVersionCreate(unittest.TestCase):
+    """Tests for model_instance_version_create."""
+
+    def setUp(self):
+        self.api = KaggleApi.__new__(KaggleApi)
+        self.api.config_values = {"username": "testuser"}
+        self.api.already_printed_version_warning = True
+
+    @patch.object(KaggleApi, "upload_files")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_model_instance_version_create_succeeds(
+        self, mock_client, mock_upload
+    ):
+        mock_kaggle = MagicMock()
+        mock_response = ApiCreateModelResponse()
+        mock_kaggle.models.model_api_client.create_model_instance_version.return_value = (
+            mock_response
+        )
+        mock_client.return_value.__enter__ = MagicMock(
+            return_value=mock_kaggle
+        )
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        model_instance = "testuser/test-model/keras/test-instance"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            response = self.api.model_instance_version_create(
+                model_instance,
+                tmpdir,
+                version_notes="test version",
+                quiet=True,
+                dir_mode="zip",
+            )
+
+            self.assertEqual(response, mock_response)
+            mock_upload.assert_called_once()
+            call_args = mock_upload.call_args[0]
+            self.assertEqual(call_args[2], tmpdir)
+            self.assertEqual(call_args[3], ApiBlobType.MODEL)
+            self.assertTrue(call_args[5])
+            self.assertEqual(call_args[6], "zip")
+            self.assertIsNone(mock_upload.call_args[1].get("ignore_patterns"))
+
+            mock_kaggle.models.model_api_client.create_model_instance_version.assert_called_once()
+            request = mock_kaggle.models.model_api_client.create_model_instance_version.call_args[
+                0
+            ][0]
+            self.assertEqual(request.owner_slug, "testuser")
+            self.assertEqual(request.model_slug, "test-model")
+            self.assertEqual(request.instance_slug, "test-instance")
+            self.assertEqual(request.body.version_notes, "test version")
+
+    @patch.object(KaggleApi, "upload_files")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_model_instance_version_create_with_ignore_patterns_succeeds(
+        self, mock_client, mock_upload
+    ):
+        mock_kaggle = MagicMock()
+        mock_response = ApiCreateModelResponse()
+        mock_kaggle.models.model_api_client.create_model_instance_version.return_value = (
+            mock_response
+        )
+        mock_client.return_value.__enter__ = MagicMock(
+            return_value=mock_kaggle
+        )
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        model_instance = "testuser/test-model/keras/test-instance"
+        ignore_patterns = ["*.tmp", "temp/"]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            response = self.api.model_instance_version_create(
+                model_instance,
+                tmpdir,
+                version_notes="test version",
+                quiet=True,
+                dir_mode="zip",
+                ignore_patterns=ignore_patterns,
+            )
+
+            self.assertEqual(response, mock_response)
+            mock_upload.assert_called_once()
+            call_args = mock_upload.call_args[0]
+            self.assertEqual(call_args[2], tmpdir)
+            self.assertEqual(call_args[3], ApiBlobType.MODEL)
+            self.assertTrue(call_args[5])
+            self.assertEqual(call_args[6], "zip")
+            self.assertEqual(call_args[7], ignore_patterns)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_model_create.py
+++ b/tests/unit/test_model_create.py
@@ -158,9 +158,7 @@ class TestModelCreate(unittest.TestCase):
 
     @patch.object(KaggleApi, "upload_files")
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_model_instance_create_with_ignore_patterns_succeeds(
-        self, mock_client, mock_upload
-    ):
+    def test_model_instance_create_with_ignore_patterns_succeeds(self, mock_client, mock_upload):
         mock_kaggle = MagicMock()
         mock_response = ApiCreateModelResponse()
         mock_kaggle.models.model_api_client.create_model_instance.return_value = mock_response
@@ -520,6 +518,8 @@ class TestModelCreate(unittest.TestCase):
 
             self.assertIsNotNone(request.update_mask)
             self.assertEqual(list(request.update_mask.paths), ["title"])
+
+
 class TestModelInstanceVersionCreate(unittest.TestCase):
     """Tests for model_instance_version_create."""
 
@@ -530,17 +530,11 @@ class TestModelInstanceVersionCreate(unittest.TestCase):
 
     @patch.object(KaggleApi, "upload_files")
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_model_instance_version_create_succeeds(
-        self, mock_client, mock_upload
-    ):
+    def test_model_instance_version_create_succeeds(self, mock_client, mock_upload):
         mock_kaggle = MagicMock()
         mock_response = ApiCreateModelResponse()
-        mock_kaggle.models.model_api_client.create_model_instance_version.return_value = (
-            mock_response
-        )
-        mock_client.return_value.__enter__ = MagicMock(
-            return_value=mock_kaggle
-        )
+        mock_kaggle.models.model_api_client.create_model_instance_version.return_value = mock_response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
         mock_client.return_value.__exit__ = MagicMock(return_value=False)
 
         model_instance = "testuser/test-model/keras/test-instance"
@@ -564,9 +558,7 @@ class TestModelInstanceVersionCreate(unittest.TestCase):
             self.assertIsNone(mock_upload.call_args[1].get("ignore_patterns"))
 
             mock_kaggle.models.model_api_client.create_model_instance_version.assert_called_once()
-            request = mock_kaggle.models.model_api_client.create_model_instance_version.call_args[
-                0
-            ][0]
+            request = mock_kaggle.models.model_api_client.create_model_instance_version.call_args[0][0]
             self.assertEqual(request.owner_slug, "testuser")
             self.assertEqual(request.model_slug, "test-model")
             self.assertEqual(request.instance_slug, "test-instance")
@@ -574,17 +566,11 @@ class TestModelInstanceVersionCreate(unittest.TestCase):
 
     @patch.object(KaggleApi, "upload_files")
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_model_instance_version_create_with_ignore_patterns_succeeds(
-        self, mock_client, mock_upload
-    ):
+    def test_model_instance_version_create_with_ignore_patterns_succeeds(self, mock_client, mock_upload):
         mock_kaggle = MagicMock()
         mock_response = ApiCreateModelResponse()
-        mock_kaggle.models.model_api_client.create_model_instance_version.return_value = (
-            mock_response
-        )
-        mock_client.return_value.__enter__ = MagicMock(
-            return_value=mock_kaggle
-        )
+        mock_kaggle.models.model_api_client.create_model_instance_version.return_value = mock_response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
         mock_client.return_value.__exit__ = MagicMock(return_value=False)
 
         model_instance = "testuser/test-model/keras/test-instance"


### PR DESCRIPTION
This PR integrates `ignore_patterns` into the datasets upload workflow.

Changes:
- Update `dataset_create_new` and `dataset_create_version` (and CLI wrappers) to accept and pass `ignore_patterns`.
- Add `--ignore-patterns` CLI argument to datasets create and version commands.
- Add unit tests and CLI parser tests.

Depends on #1126 (models & core logic).

TAG=agy
CONV=2a820637-152b-46a6-9a45-e29918f1e322
