### PR TITLE
Document --ignore-patterns option

### DIFF
--- a/docs/competition_creation.md
+++ b/docs/competition_creation.md
@@ -520,7 +520,7 @@ file you want in the new version.
 
 ```bash
 kaggle competitions data update <competition> -p <path> -m "<version notes>" \
-    [--rerun] [--include-hidden]
+    [--rerun] [--include-hidden] [--ignore-patterns <patterns>]
 ```
 
 **Arguments:**
@@ -545,6 +545,7 @@ kaggle competitions data update <competition> -p <path> -m "<version notes>" \
   sub-directories (names starting with `.` — e.g. `.DS_Store`, `.git/`,
   `.gitignore`). Skipped by default so you don't accidentally publish OS
   metadata or version-control detritus.
+- `--ignore-patterns <patterns>` (optional): Patterns to ignore when uploading files/dirs. Can be specified multiple times. Note that default ignore patterns (like `.git/`, `.cache/`, `.huggingface/`) are bypassed when `--include-hidden` is True.
 
 **Examples:**
 

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -173,6 +173,8 @@ kaggle datasets create -p <FOLDER_PATH> [options]
 *   `-q, --quiet`: Suppress verbose output.
 *   `-t, --keep-tabular`: Do not convert tabular files to CSV (default is to convert).
 *   `-r, --dir-mode <MODE>`: How to handle directories: `skip` (ignore), `zip` (compressed upload), `tar` (uncompressed upload) (default: `skip`).
+*   `--ignore-patterns <PATTERNS>`: Patterns of files/dirs to ignore. Can be specified multiple times.
+
 
 **Example:**
 
@@ -208,6 +210,8 @@ kaggle datasets version -p <FOLDER_PATH> -m <VERSION_NOTES> [options]
 *   `-t, --keep-tabular`: Do not convert tabular files to CSV.
 *   `-r, --dir-mode <MODE>`: Directory handling mode (`skip`, `zip`, `tar`).
 *   `-d, --delete-old-versions`: Delete old versions of this dataset.
+*   `--ignore-patterns <PATTERNS>`: Patterns of files/dirs to ignore. Can be specified multiple times.
+
 
 **Example:**
 

--- a/docs/model_variations.md
+++ b/docs/model_variations.md
@@ -44,6 +44,8 @@ kaggle models variations create -p <FOLDER_PATH> [options]
 *   `-p, --path <FOLDER_PATH>`: Path to the folder containing the model variation files and the `model-instance-metadata.json` file (defaults to the current directory).
 *   `-q, --quiet`: Suppress verbose output.
 *   `-r, --dir-mode <MODE>`: How to handle directories within the upload: `skip` (ignore), `zip` (compressed upload), `tar` (uncompressed upload) (default: `skip`).
+*   `--ignore-patterns <PATTERNS>`: Patterns of files/dirs to ignore. Can be specified multiple times.
+
 
 **Example:**
 

--- a/docs/model_variations_versions.md
+++ b/docs/model_variations_versions.md
@@ -22,6 +22,8 @@ kaggle models variations versions create <MODEL_VARIATION> -p <FOLDER_PATH> [opt
 *   `-n, --version-notes <NOTES>`: Notes describing this version.
 *   `-q, --quiet`: Suppress verbose output.
 *   `-r, --dir-mode <MODE>`: How to handle directories within the upload: `skip` (ignore), `zip` (compressed upload), `tar` (uncompressed upload) (default: `skip`).
+*   `--ignore-patterns <PATTERNS>`: Patterns of files/dirs to ignore. Can be specified multiple times.
+
 
 **Example:**
 


### PR DESCRIPTION
This PR documents the new `--ignore-patterns` option in the markdown documentation for models, datasets, and competitions.

Depends on #1128 (competitions), #1127 (datasets).

TAG=agy
CONV=2a820637-152b-46a6-9a45-e29918f1e322
