### PR TITLE
Add Kaggle Secrets documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -55,7 +55,7 @@ The Kaggle CLI is organized into several command groups:
 *   [Competitions](./competitions.md): Manage and participate in Kaggle competitions.
 *   [Datasets](./datasets.md): Search, download, and manage Kaggle datasets.
 *   [Forums](./forums.md): Browse and read Kaggle discussion forums.
-*   [Kernels](./kernels.md): Interact with Kaggle Kernels (notebooks and scripts).
+*   [Kernels](./kernels.md): Interact with Kaggle Kernels (notebooks and scripts). Includes information on using [Kaggle Secrets](./kernels.md#using-secrets-in-kernels).
 *   [Models](./models.md): Manage your Kaggle Models.
 *   [Model Variations](./model_variations.md): Manage variations of your Kaggle Models.
 *   [Model Variation Versions](./model_variations_versions.md): Manage versions of your Kaggle Model Variations.

--- a/docs/kernels.md
+++ b/docs/kernels.md
@@ -399,12 +399,12 @@ This command displays a full discussion topic along with all of its comments ren
 
 If your kernel needs to access sensitive information (like API keys or passwords) without exposing them in your code, you should use **Kaggle Secrets**.
 
-### 1. Add Secrets on Kaggle.com
+### 1. Define Secrets on Kaggle.com (no CLI support)
 1.  Open your notebook in the Kaggle Notebook Editor.
 2.  In the menu, select **Add-ons** -> **Secrets**.
 3.  Add your secrets as key-value pairs (e.g., Label: `MY_API_KEY`, Value: `your-actual-key-value`).
 
-### 2. Access Secrets in your Code
+### 2. Use Secrets in your Code Running on Kaggle.com
 Use the `UserSecretsClient` from the `kaggle_secrets` package to retrieve your secrets at runtime:
 
 ```python

--- a/docs/kernels.md
+++ b/docs/kernels.md
@@ -394,3 +394,24 @@ kaggle kernels topics show owner/kernel-slug/12345
 **Purpose:**
 
 This command displays a full discussion topic along with all of its comments rendered in an indented tree structure.
+
+## Using Secrets in Kernels
+
+If your kernel needs to access sensitive information (like API keys or passwords) without exposing them in your code, you should use **Kaggle Secrets**.
+
+### 1. Add Secrets on Kaggle.com
+1.  Open your notebook in the Kaggle Notebook Editor.
+2.  In the menu, select **Add-ons** -> **Secrets**.
+3.  Add your secrets as key-value pairs (e.g., Label: `MY_API_KEY`, Value: `your-actual-key-value`).
+
+### 2. Access Secrets in your Code
+Use the `UserSecretsClient` from the `kaggle_secrets` package to retrieve your secrets at runtime:
+
+```python
+from kaggle_secrets import UserSecretsClient
+
+# Retrieve the secret value using the label you defined
+secret_value = UserSecretsClient().get_secret("MY_API_KEY")
+```
+
+**Note:** The `kaggle_secrets` package is pre-installed and only functional within the Kaggle notebook execution environment. It will not work when running scripts locally.


### PR DESCRIPTION
Expose Kaggle Secrets usage in the CLI documentation to help users avoid hardcoding sensitive credentials in their notebooks.

Added a new section "Using Secrets in Kernels" to docs/kernels.md and linked to it from docs/README.md.

TAG=agy
CONV=2a820637-152b-46a6-9a45-e29918f1e322

Fixes #https://github.com/Kaggle/kaggle-cli/issues/408