### PR TITLE
fix(cli): retry transient connection errors in with_retry

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -1064,37 +1064,36 @@ class KaggleApi:
                 try:
                     return func(*args)
                 except Exception as e:
-                    if type(e) is HTTPError:
-                        if self._is_retriable(e) and i < max_retries:
-                            # Use Retry-After header for 429 responses when available
-                            if self._is_rate_limited(e):
-                                retry_delay = self._get_retry_after_delay(e.response)
-                                if retry_delay is not None:
-                                    total_delay = retry_delay
-                                    self.logger.info(
-                                        "Rate limited (429). Retry-After: %.1f seconds (attempt %d/%d)",
-                                        total_delay,
-                                        i,
-                                        max_retries,
-                                    )
-                                else:
-                                    total_delay = self._calculate_backoff_delay(
-                                        i, initial_delay_millis, retry_multiplier, randomness_factor
-                                    )
-                                    self.logger.info(
-                                        "Rate limited (429). No valid Retry-After header; "
-                                        "backing off %.1f seconds (attempt %d/%d)",
-                                        total_delay,
-                                        i,
-                                        max_retries,
-                                    )
+                    if self._is_retriable(e) and i < max_retries:
+                        # Use Retry-After header for 429 responses when available
+                        if self._is_rate_limited(e):
+                            retry_delay = self._get_retry_after_delay(e.response)
+                            if retry_delay is not None:
+                                total_delay = retry_delay
+                                self.logger.info(
+                                    "Rate limited (429). Retry-After: %.1f seconds (attempt %d/%d)",
+                                    total_delay,
+                                    i,
+                                    max_retries,
+                                )
                             else:
                                 total_delay = self._calculate_backoff_delay(
                                     i, initial_delay_millis, retry_multiplier, randomness_factor
                                 )
-                            print("Request failed: %s. Will retry in %2.1f seconds" % (e, total_delay), file=sys.stderr)
-                            time.sleep(total_delay)
-                            continue
+                                self.logger.info(
+                                    "Rate limited (429). No valid Retry-After header; "
+                                    "backing off %.1f seconds (attempt %d/%d)",
+                                    total_delay,
+                                    i,
+                                    max_retries,
+                                )
+                        else:
+                            total_delay = self._calculate_backoff_delay(
+                                i, initial_delay_millis, retry_multiplier, randomness_factor
+                            )
+                        print("Request failed: %s. Will retry in %2.1f seconds" % (e, total_delay), file=sys.stderr)
+                        time.sleep(total_delay)
+                        continue
                     raise
 
         return retriable_func

--- a/tests/unit/test_retry_after.py
+++ b/tests/unit/test_retry_after.py
@@ -9,7 +9,8 @@ import unittest
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
-from requests.exceptions import HTTPError
+import urllib3.exceptions as urllib3_exceptions
+from requests.exceptions import ConnectionError, ConnectTimeout, HTTPError
 from requests.models import Response
 
 from kaggle.api.kaggle_api_extended import KaggleApi
@@ -102,6 +103,18 @@ class TestIsRetriable(unittest.TestCase):
         error = HTTPError(response=response)
         self.assertFalse(self.api._is_retriable(error))
 
+    def test_connection_error_is_retriable(self):
+        self.assertTrue(self.api._is_retriable(ConnectionError("boom")))
+
+    def test_connect_timeout_is_retriable(self):
+        self.assertTrue(self.api._is_retriable(ConnectTimeout("slow")))
+
+    def test_urllib3_protocol_error_is_retriable(self):
+        self.assertTrue(self.api._is_retriable(urllib3_exceptions.ProtocolError("broken")))
+
+    def test_value_error_is_not_retriable(self):
+        self.assertFalse(self.api._is_retriable(ValueError("nope")))
+
 
 class TestWithRetryRateLimiting(unittest.TestCase):
     """Tests for KaggleApi.with_retry() handling 429 responses."""
@@ -166,6 +179,82 @@ class TestWithRetryRateLimiting(unittest.TestCase):
         # Logger should mention missing Retry-After
         log_msg = self.api.logger.info.call_args[0][0]
         self.assertIn("No valid Retry-After", log_msg)
+
+    @patch("kaggle.api.kaggle_api_extended.time.sleep")
+    @patch("builtins.print")
+    def test_connection_error_is_retried(self, mock_print, mock_sleep):
+        call_count = 0
+
+        def failing_then_succeeding(*args):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise ConnectionError("connection dropped")
+            return "success"
+
+        wrapped = self.api.with_retry(failing_then_succeeding, max_retries=3)
+        result = wrapped()
+
+        self.assertEqual(result, "success")
+        self.assertEqual(call_count, 2)
+        mock_sleep.assert_called_once()
+
+    @patch("kaggle.api.kaggle_api_extended.time.sleep")
+    @patch("builtins.print")
+    def test_connect_timeout_is_retried(self, mock_print, mock_sleep):
+        call_count = 0
+
+        def failing_then_succeeding(*args):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise ConnectTimeout("timed out")
+            return "success"
+
+        wrapped = self.api.with_retry(failing_then_succeeding, max_retries=3)
+        result = wrapped()
+
+        self.assertEqual(result, "success")
+        self.assertEqual(call_count, 2)
+        mock_sleep.assert_called_once()
+
+    @patch("kaggle.api.kaggle_api_extended.time.sleep")
+    @patch("builtins.print")
+    def test_urllib3_protocol_error_is_retried(self, mock_print, mock_sleep):
+        call_count = 0
+
+        def failing_then_succeeding(*args):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise urllib3_exceptions.ProtocolError("connection aborted")
+            return "success"
+
+        wrapped = self.api.with_retry(failing_then_succeeding, max_retries=3)
+        result = wrapped()
+
+        self.assertEqual(result, "success")
+        self.assertEqual(call_count, 2)
+        mock_sleep.assert_called_once()
+
+    @patch("kaggle.api.kaggle_api_extended.time.sleep")
+    @patch("builtins.print")
+    def test_non_retriable_error_fails_immediately(self, mock_print, mock_sleep):
+        call_count = 0
+
+        def always_failing(*args):
+            nonlocal call_count
+            call_count += 1
+            raise ValueError("not retriable")
+
+        wrapped = self.api.with_retry(always_failing, max_retries=3)
+
+        with self.assertRaises(ValueError):
+            wrapped()
+
+        # Should not retry or sleep for a non-retriable exception.
+        self.assertEqual(call_count, 1)
+        mock_sleep.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`with_retry()` only retried exceptions when the error was an `HTTPError`. Because of that, transient network errors like `ConnectionError`, `ConnectTimeout`, and `urllib3` connection errors were raised immediately, even though `_is_retriable()` already marks them as retriable.

## Fix

Removed the extra `HTTPError` check and let `_is_retriable()` decide whether an exception should be retried. This keeps the existing 429 / `Retry-After` behavior the same while allowing transient connection errors to retry as intended.

## Tests

Added tests to verify that:

- `ConnectionError` retries and succeeds
- `ConnectTimeout` retries and succeeds
- `urllib3.ProtocolError` retries and succeeds
- non-retriable exceptions still fail immediately

Existing `Retry-After` tests continue to pass.

Ran:

```bash
pytest tests/unit/test_retry_after.py