### PR TITLE
Fix model and owner slug validation

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -6877,6 +6877,8 @@ class KaggleApi:
             raise ValueError("Default title detected, please change values before uploading")
         if slug == "INSERT_SLUG_HERE":
             raise ValueError("Default slug detected, please change values before uploading")
+        self._validate_slug_syntax(owner_slug, allow_underscore=True)
+        self._validate_slug_syntax(slug, allow_underscore=False)
         if not isinstance(is_private, bool):
             raise ValueError("model.isPrivate must be a boolean")
 
@@ -6981,6 +6983,8 @@ class KaggleApi:
             raise ValueError("Default ownerSlug detected, please change values before uploading")
         if slug == "INSERT_SLUG_HERE":
             raise ValueError("Default slug detected, please change values before uploading")
+        self._validate_slug_syntax(owner_slug, allow_underscore=True)
+        self._validate_slug_syntax(slug, allow_underscore=False)
         if is_private != None and not isinstance(is_private, bool):
             raise ValueError("model.isPrivate must be a boolean")
         if publish_time:
@@ -8473,6 +8477,25 @@ class KaggleApi:
             split = model.split("/")
             if not split[0] or not split[1]:
                 raise ValueError("Invalid model specification " + model)
+
+    def _validate_slug_syntax(self, slug: str, allow_underscore: bool = False) -> None:
+        if allow_underscore:
+            pattern = r"^[a-z0-9]+(?:[_-][a-z0-9]+)*$"
+            error_msg = (
+                f"Invalid owner slug: {slug}. Owner slugs must be lowercase, "
+                "alphanumeric, and may contain hyphens and underscores, but "
+                "not start or end with them, nor contain consecutive ones."
+            )
+        else:
+            pattern = r"^[a-z0-9]+(?:-[a-z0-9]+)*$"
+            error_msg = (
+                f"Invalid slug: {slug}. Slugs must be lowercase, alphanumeric, "
+                "and may contain hyphens, but not start or end with them, nor "
+                "contain consecutive ones."
+            )
+
+        if not re.match(pattern, slug):
+            raise ValueError(error_msg)
 
     def split_model_string(self, model: str) -> Tuple[Union[str, None], str]:
         """Splits a model string into owner_slug and model_slug.

--- a/tests/unit/test_model_create.py
+++ b/tests/unit/test_model_create.py
@@ -366,6 +366,126 @@ class TestModelCreate(unittest.TestCase):
                 self.api.model_create_new(tmpdir)
             self.assertIn("Default slug detected", str(context.exception))
 
+    def test_model_create_new_invalid_slug_uppercase_fails(self):
+        metadata = self._get_valid_model_metadata()
+        metadata["slug"] = "Invalid-Slug"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata, "model-metadata.json")
+            with self.assertRaises(ValueError) as context:
+                self.api.model_create_new(tmpdir)
+            self.assertIn("Invalid slug", str(context.exception))
+
+    def test_model_create_new_invalid_slug_special_char_fails(self):
+        metadata = self._get_valid_model_metadata()
+        metadata["slug"] = "invalid_slug"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata, "model-metadata.json")
+            with self.assertRaises(ValueError) as context:
+                self.api.model_create_new(tmpdir)
+            self.assertIn("Invalid slug", str(context.exception))
+
+    def test_model_create_new_invalid_slug_leading_hyphen_fails(self):
+        metadata = self._get_valid_model_metadata()
+        metadata["slug"] = "-invalid-slug"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata, "model-metadata.json")
+            with self.assertRaises(ValueError) as context:
+                self.api.model_create_new(tmpdir)
+            self.assertIn("Invalid slug", str(context.exception))
+
+    def test_model_create_new_invalid_slug_trailing_hyphen_fails(self):
+        metadata = self._get_valid_model_metadata()
+        metadata["slug"] = "invalid-slug-"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata, "model-metadata.json")
+            with self.assertRaises(ValueError) as context:
+                self.api.model_create_new(tmpdir)
+            self.assertIn("Invalid slug", str(context.exception))
+
+    def test_model_create_new_invalid_slug_consecutive_hyphens_fails(self):
+        metadata = self._get_valid_model_metadata()
+        metadata["slug"] = "invalid--slug"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata, "model-metadata.json")
+            with self.assertRaises(ValueError) as context:
+                self.api.model_create_new(tmpdir)
+            self.assertIn("Invalid slug", str(context.exception))
+
+    def test_model_create_new_invalid_owner_slug_uppercase_fails(self):
+        metadata = self._get_valid_model_metadata()
+        metadata["ownerSlug"] = "Invalid-Owner"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata, "model-metadata.json")
+            with self.assertRaises(ValueError) as context:
+                self.api.model_create_new(tmpdir)
+            self.assertIn("Invalid owner slug", str(context.exception))
+
+    def test_model_create_new_invalid_owner_slug_special_char_fails(self):
+        metadata = self._get_valid_model_metadata()
+        metadata["ownerSlug"] = "invalid@owner"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata, "model-metadata.json")
+            with self.assertRaises(ValueError) as context:
+                self.api.model_create_new(tmpdir)
+            self.assertIn("Invalid owner slug", str(context.exception))
+
+    def test_model_create_new_invalid_owner_slug_leading_hyphen_fails(self):
+        metadata = self._get_valid_model_metadata()
+        metadata["ownerSlug"] = "-invalid-owner"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata, "model-metadata.json")
+            with self.assertRaises(ValueError) as context:
+                self.api.model_create_new(tmpdir)
+            self.assertIn("Invalid owner slug", str(context.exception))
+
+    def test_model_create_new_invalid_owner_slug_trailing_underscore_fails(self):
+        metadata = self._get_valid_model_metadata()
+        metadata["ownerSlug"] = "invalid-owner_"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata, "model-metadata.json")
+            with self.assertRaises(ValueError) as context:
+                self.api.model_create_new(tmpdir)
+            self.assertIn("Invalid owner slug", str(context.exception))
+
+    def test_model_create_new_invalid_owner_slug_consecutive_underscores_fails(self):
+        metadata = self._get_valid_model_metadata()
+        metadata["ownerSlug"] = "invalid__owner"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata, "model-metadata.json")
+            with self.assertRaises(ValueError) as context:
+                self.api.model_create_new(tmpdir)
+            self.assertIn("Invalid owner slug", str(context.exception))
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_model_create_new_valid_owner_slug_with_underscore_succeeds(self, mock_client):
+        mock_kaggle = MagicMock()
+        mock_response = ApiCreateModelResponse()
+        mock_kaggle.models.model_api_client.create_model.return_value = mock_response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        metadata = self._get_valid_model_metadata()
+        metadata["ownerSlug"] = "test_user"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata, "model-metadata.json")
+            response = self.api.model_create_new(tmpdir)
+            self.assertEqual(response, mock_response)
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_model_create_new_valid_owner_slug_with_hyphen_succeeds(self, mock_client):
+        mock_kaggle = MagicMock()
+        mock_response = ApiCreateModelResponse()
+        mock_kaggle.models.model_api_client.create_model.return_value = mock_response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        metadata = self._get_valid_model_metadata()
+        metadata["ownerSlug"] = "test-user"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata, "model-metadata.json")
+            response = self.api.model_create_new(tmpdir)
+            self.assertEqual(response, mock_response)
+
     def test_model_create_new_invalid_is_private_fails(self):
         metadata = self._get_valid_model_metadata()
         metadata["isPrivate"] = "not-a-bool"
@@ -435,6 +555,39 @@ class TestModelCreate(unittest.TestCase):
             with self.assertRaises(ValueError) as context:
                 self.api.model_update(tmpdir)
             self.assertIn("Default slug detected", str(context.exception))
+
+    def test_model_update_invalid_slug_uppercase_fails(self):
+        metadata = self._get_valid_model_metadata()
+        metadata["slug"] = "Invalid-Slug"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata, "model-metadata.json")
+            with self.assertRaises(ValueError) as context:
+                self.api.model_update(tmpdir)
+            self.assertIn("Invalid slug", str(context.exception))
+
+    def test_model_update_invalid_owner_slug_uppercase_fails(self):
+        metadata = self._get_valid_model_metadata()
+        metadata["ownerSlug"] = "Invalid-Owner"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata, "model-metadata.json")
+            with self.assertRaises(ValueError) as context:
+                self.api.model_update(tmpdir)
+            self.assertIn("Invalid owner slug", str(context.exception))
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_model_update_valid_owner_slug_with_underscore_succeeds(self, mock_client):
+        mock_kaggle = MagicMock()
+        mock_response = MagicMock()
+        mock_kaggle.models.model_api_client.update_model.return_value = mock_response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        metadata = self._get_valid_model_metadata()
+        metadata["ownerSlug"] = "test_user"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, metadata, "model-metadata.json")
+            response = self.api.model_update(tmpdir)
+            self.assertEqual(response, mock_response)
 
     def test_model_update_invalid_is_private_fails(self):
         metadata = self._get_valid_model_metadata()


### PR DESCRIPTION
Validate model slug and owner slug in model-metadata.json before sending to API.
Model slugs must be lowercase, alphanumeric, and contain only hyphens.
Owner slugs may also contain underscores.

Fixes: #1133

TAG=agy
CONV=7b917f8b-ff11-48c4-a39a-aaf134a39ca6