### PR TITLE
feat(competitions): add submission status command and --wait support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 ### Next
 
+* Add `--wait`/`--poll-interval` to `kaggle competitions submit` to wait for scoring, and add `kaggle competitions submission <ref>` to look up a single submission's status and score
+
 ### 2.2.3
 
 * Update --format help text to reference output_format.md (#1074)

--- a/docs/competitions.md
+++ b/docs/competitions.md
@@ -145,6 +145,10 @@ kaggle competitions submit <COMPETITION> -f <FILE_NAME> -m <MESSAGE> [options]
 *   `-v, --version <VERSION>`: Version of the kernel to submit (e.g. `2`).
 *   `-q, --quiet`: Suppress verbose output.
 *   `--sandbox`: Mark submission as a sandbox submission (competition hosts/admins only).
+*   `--wait [SECONDS]`: Wait for the submission to finish scoring, printing the public score when done. Optionally pass a timeout in seconds (`0` or no value = wait indefinitely). Exits non-zero if scoring fails or the timeout is reached.
+*   `--poll-interval <SECONDS>`: Maximum seconds between status polls while waiting (default: `60`). Polling starts at 5s and increases automatically.
+
+On a successful submission the command prints the numeric submission ref, e.g. `Submission ref: 12345678`. You can look that submission up later with [`kaggle competitions submission`](#kaggle-competitions-submission).
 
 **Example: Standard (not code) competition:**
 
@@ -162,9 +166,54 @@ Submit the `submission.csv` produced by version `3` of your `<YOUR_USERNAME>/rsn
 kaggle competitions submit rsna-2024-lumbar-spine-degenerative-classification -f submission.csv -k <YOUR_USERNAME>/rsna-submission -v 3 -m "Test message"
 ```
 
+**Example: Submit and wait for the score (useful in CI):**
+
+Submit and block until scoring finishes (up to a 10-minute timeout), then print the public score:
+
+```bash
+kaggle competitions submit house-prices-advanced-regression-techniques -f sample_submission.csv -m "CI run" --wait 600
+```
+
+The command exits `0` once the submission is scored and non-zero if scoring fails or the timeout is reached, so it can gate a pipeline.
+
 **Purpose:**
 
 Use this command to upload your predictions or code to a competition for scoring.
+
+## `kaggle competitions submission`
+
+Shows the status and score of a single submission by its numeric ref (as printed by `kaggle competitions submit`).
+
+**Usage:**
+
+```bash
+kaggle competitions submission <SUBMISSION_REF>
+```
+
+**Arguments:**
+
+*   `<SUBMISSION_REF>`: The numeric submission ref printed by `kaggle competitions submit`.
+
+**Example:**
+
+```bash
+kaggle competitions submission 12345678
+```
+
+Output:
+
+```
+Submission Ref:  12345678
+Status:          COMPLETE
+Public Score:    0.98765
+Private Score:
+Description:     Test message
+Submission Date: 2026-07-19 12:00:00
+```
+
+**Purpose:**
+
+Use this command to check whether a submission has finished scoring and to read its public score — for example, after submitting without `--wait`, or from a script polling for results.
 
 ## `kaggle competitions submissions`
 

--- a/docs/competitions.md
+++ b/docs/competitions.md
@@ -145,8 +145,8 @@ kaggle competitions submit <COMPETITION> -f <FILE_NAME> -m <MESSAGE> [options]
 *   `-v, --version <VERSION>`: Version of the kernel to submit (e.g. `2`).
 *   `-q, --quiet`: Suppress verbose output.
 *   `--sandbox`: Mark submission as a sandbox submission (competition hosts/admins only).
-*   `--wait [SECONDS]`: Wait for the submission to finish scoring, printing the public score when done. Optionally pass a timeout in seconds (`0` or no value = wait indefinitely). Exits non-zero if scoring fails or the timeout is reached.
-*   `--poll-interval <SECONDS>`: Maximum seconds between status polls while waiting (default: `60`). Polling starts at 5s and increases automatically.
+*   `--wait [SECONDS]`: Wait for the submission to finish scoring, printing the public score when done. Optionally pass a timeout in seconds (`0` or no value = wait up to 12 hours, the maximum notebook runtime). Exits non-zero if scoring fails or the timeout is reached.
+*   `--poll-interval <SECONDS>`: Maximum seconds between status polls while waiting (default: `60`, minimum: `5`). Polling starts at 5s and increases automatically.
 
 On a successful submission the command prints the numeric submission ref, e.g. `Submission ref: 12345678`. You can look that submission up later with [`kaggle competitions submission`](#kaggle-competitions-submission).
 

--- a/skills/references/competitions.md
+++ b/skills/references/competitions.md
@@ -24,6 +24,7 @@ kaggle competitions (alias: kaggle c)
 ├── download
 ├── submit
 ├── submissions
+├── submission
 ├── leaderboard
 ├── team-submissions
 ├── episodes
@@ -148,6 +149,8 @@ kaggle competitions submit [COMPETITION] -m <MESSAGE> [options]
 - `-m, --message <MESSAGE>`: Required submission description.
 - `-v, --version <VERSION>`: Kernel version for code competitions.
 - `--sandbox`: Mark as sandbox submission for competition hosts/admins.
+- `--wait [SECONDS]`: Wait for the submission to finish scoring and print the public score. `0` or no value waits indefinitely; a positive value is a timeout in seconds. Exits non-zero on scoring failure or timeout.
+- `--poll-interval <SECONDS>`: Max seconds between status polls while waiting (default 60; starts at 5s, backs off).
 - `-q, --quiet`: Suppress progress output.
 
 **Examples:**
@@ -155,12 +158,33 @@ kaggle competitions submit [COMPETITION] -m <MESSAGE> [options]
 ```bash
 kaggle competitions submit titanic -f submission.csv -m "baseline"
 kaggle c submit lux-ai -k user/agent -f submission.tar.gz -m "agent run" -v 3
+kaggle competitions submit titanic -f submission.csv -m "CI run" --wait 600
 ```
 
 **Purpose:** Submit predictions or code-kernel output to a competition.
 
-**Notes:** `--sandbox` is intended for competition hosts/admins. Code competition
-submission uses `-k`, `-f`, and optional `-v`.
+**Notes:** On success the command prints `Submission ref: <ref>`; use it with
+`kaggle competitions submission <ref>`. `--sandbox` is intended for competition
+hosts/admins. Code competition submission uses `-k`, `-f`, and optional `-v`.
+
+## `kaggle competitions submission`
+
+Shows the status and score of a single submission by its numeric ref.
+
+**Usage:**
+
+```bash
+kaggle competitions submission <SUBMISSION_REF>
+```
+
+**Examples:**
+
+```bash
+kaggle competitions submission 12345678
+```
+
+**Purpose:** Check whether a submission has finished scoring and read its public
+score (e.g. after submitting without `--wait`, or when polling from a script).
 
 ## `kaggle competitions submissions`
 

--- a/skills/references/competitions.md
+++ b/skills/references/competitions.md
@@ -149,8 +149,8 @@ kaggle competitions submit [COMPETITION] -m <MESSAGE> [options]
 - `-m, --message <MESSAGE>`: Required submission description.
 - `-v, --version <VERSION>`: Kernel version for code competitions.
 - `--sandbox`: Mark as sandbox submission for competition hosts/admins.
-- `--wait [SECONDS]`: Wait for the submission to finish scoring and print the public score. `0` or no value waits indefinitely; a positive value is a timeout in seconds. Exits non-zero on scoring failure or timeout.
-- `--poll-interval <SECONDS>`: Max seconds between status polls while waiting (default 60; starts at 5s, backs off).
+- `--wait [SECONDS]`: Wait for the submission to finish scoring and print the public score. `0` or no value waits up to 12 hours (the maximum notebook runtime); a positive value is a timeout in seconds. Exits non-zero on scoring failure or timeout.
+- `--poll-interval <SECONDS>`: Max seconds between status polls while waiting (default 60, minimum 5; starts at 5s, backs off).
 - `-q, --quiet`: Suppress progress output.
 
 **Examples:**

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -1990,7 +1990,8 @@ class KaggleApi:
             quiet (bool): Suppress verbose output (default is False).
             sandbox (bool): Mark as a sandbox submission (default is False).
             wait (Optional[int]): If not None, wait for the submission to finish scoring.
-                A value of 0 waits indefinitely; a positive value is a timeout in seconds.
+                A value of 0 (or a bare --wait) waits up to 12 hours, the maximum Kaggle
+                notebook runtime; a positive value is a timeout in seconds.
             poll_interval (int): Maximum seconds between status polls while waiting (default 60).
 
         Returns:
@@ -1998,8 +1999,15 @@ class KaggleApi:
         """
         if kernel and not version or version and not kernel:
             raise ValueError("Code competition submissions require both the output file name and the version number")
-        if wait is not None and poll_interval <= 0:
-            raise ValueError("--poll-interval must be a positive integer")
+        if wait is not None:
+            if poll_interval < self._MIN_POLL_INTERVAL:
+                raise ValueError(
+                    "--poll-interval must be at least %ss to avoid overloading Kaggle's servers."
+                    % self._MIN_POLL_INTERVAL
+                )
+            # "Wait indefinitely" (0) is capped at the 12h maximum notebook runtime.
+            if wait == 0:
+                wait = self._DEFAULT_WAIT_TIMEOUT
         competition = competition or competition_opt
         try:
             if kernel:
@@ -9348,6 +9356,13 @@ class KaggleApi:
         return f"{'-'.join(in_names) or 'Unknown'}-to-{'-'.join(out_names) or 'Unknown'}"
 
     _ADAPTIVE_POLL_START = 5  # Initial adaptive polling interval in seconds
+    # Lower bound for --poll-interval. Tied to the adaptive start: polling more
+    # frequently than the backoff's own starting interval would just hammer
+    # Kaggle's servers with no benefit, so 5s is the sane minimum.
+    _MIN_POLL_INTERVAL = _ADAPTIVE_POLL_START  # 5s
+    # Default --wait timeout. A Kaggle notebook runs for at most 12 hours, so an
+    # unbounded wait can never outlast the submission; cap it at that maximum.
+    _DEFAULT_WAIT_TIMEOUT = 12 * 60 * 60  # 12 hours, in seconds
 
     @staticmethod
     def _adaptive_sleep(current_interval, poll_interval, verbose=False):

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -84,6 +84,7 @@ from kagglesdk.competitions.types.competition_api_service import (
     ApiCreateSubmissionResponse,
     ApiStartSubmissionUploadRequest,
     ApiCreateSubmissionRequest,
+    ApiGetSubmissionRequest,
     ApiSubmission,
     ApiListSubmissionsRequest,
     ApiListTeamPublicSubmissionsRequest,
@@ -153,6 +154,7 @@ from kagglesdk.competitions.types.competition_enums import (
     SubmissionGroup,
     SubmissionSortBy,
 )
+from kagglesdk.competitions.types.submission_status import SubmissionStatus
 
 from kagglesdk.competitions.types.competition import PubliclyCloneable, Reward, RewardTypeId
 from kagglesdk.competitions.types.host_service import CompetitionSettings
@@ -1973,6 +1975,8 @@ class KaggleApi:
         competition_opt: Optional[str] = None,
         quiet: bool = False,
         sandbox: bool = False,
+        wait: Optional[int] = None,
+        poll_interval: int = 60,
     ) -> str:
         """Submits a competition using the client.
 
@@ -1985,12 +1989,17 @@ class KaggleApi:
             competition_opt (Optional[str]): An alternative competition option provided by cli.
             quiet (bool): Suppress verbose output (default is False).
             sandbox (bool): Mark as a sandbox submission (default is False).
+            wait (Optional[int]): If not None, wait for the submission to finish scoring.
+                A value of 0 waits indefinitely; a positive value is a timeout in seconds.
+            poll_interval (int): Maximum seconds between status polls while waiting (default 60).
 
         Returns:
             str:
         """
         if kernel and not version or version and not kernel:
             raise ValueError("Code competition submissions require both the output file name and the version number")
+        if wait is not None and poll_interval <= 0:
+            raise ValueError("--poll-interval must be a positive integer")
         competition = competition or competition_opt
         try:
             if kernel:
@@ -2016,7 +2025,126 @@ class KaggleApi:
                 return ""
             else:
                 raise e
+
+        # The backend returns the new submission's ref; surface it so users can
+        # look the submission up later (e.g. `kaggle competitions submission <ref>`).
+        submission_ref = getattr(submit_result, "ref", None)
+        if submission_ref:
+            print("Submission ref: %s" % submission_ref)
+            if wait is not None:
+                self._poll_submission(submission_ref, wait, poll_interval, quiet=quiet)
+
         return submit_result.message
+
+    def get_submission(self, submission_ref: int) -> ApiSubmission:
+        """Fetches a single competition submission by its numeric ref.
+
+        Args:
+            submission_ref (int): The numeric submission ref (printed by
+                ``kaggle competitions submit``).
+
+        Returns:
+            ApiSubmission: The submission, including its scoring status and scores.
+        """
+        with self.build_kaggle_client() as kaggle:
+            request = ApiGetSubmissionRequest()
+            request.ref = int(submission_ref)
+            return self.with_retry(kaggle.competitions.competition_api_client.get_submission)(request)
+
+    def _poll_submission(self, submission_ref, wait, poll_interval, quiet=False):
+        """Polls a submission until it finishes scoring or the wait times out.
+
+        Reuses the shared adaptive-backoff (``_adaptive_sleep``) and retry
+        (``with_retry``) infrastructure. A transient 404 immediately after
+        submission (eventual consistency) is treated as PENDING while still
+        inside the wait window rather than being surfaced as an error.
+
+        Args:
+            submission_ref: The numeric submission ref to poll.
+            wait: 0 waits indefinitely; a positive value is a timeout in seconds.
+            poll_interval: Maximum seconds between polls (adaptive up to this cap).
+            quiet: Suppress per-poll status output (default is False).
+
+        Returns:
+            ApiSubmission: The submission once it reaches COMPLETE.
+
+        Raises:
+            ValueError: If the submission finishes in ERROR or the wait times out.
+        """
+        start_time = time.time()
+        current_interval = min(self._ADAPTIVE_POLL_START, poll_interval)
+        try:
+            while True:
+                try:
+                    submission = self.get_submission(submission_ref)
+                except HTTPError as e:
+                    # A freshly created submission may not be immediately
+                    # readable; keep waiting rather than failing.
+                    if e.response is not None and e.response.status_code == 404:
+                        submission = None
+                    else:
+                        raise
+
+                status = submission.status if submission is not None else SubmissionStatus.PENDING
+
+                if status == SubmissionStatus.COMPLETE:
+                    if not quiet:
+                        score = submission.public_score or "(not published)"
+                        print("Submission scored. Public score: %s" % score)
+                    return submission
+
+                if status == SubmissionStatus.ERROR:
+                    error = (submission.error_description or "").strip() or "No error message provided."
+                    raise ValueError("Submission %s failed to score.\n  Error: %s" % (submission_ref, error))
+
+                if not quiet:
+                    print("Submission status: %s..." % status.name)
+
+                if wait > 0 and (time.time() - start_time) > wait:
+                    raise ValueError(
+                        "Timed out after %ss waiting for submission %s to finish scoring.\n"
+                        "Submission ref: %s\n"
+                        "Check status with: kaggle competitions submission %s"
+                        % (wait, submission_ref, submission_ref, submission_ref)
+                    )
+
+                current_interval = self._adaptive_sleep(current_interval, poll_interval)
+        except KeyboardInterrupt:
+            print(
+                "\nStopped waiting for submission %s.\n"
+                "Check status with: kaggle competitions submission %s" % (submission_ref, submission_ref)
+            )
+            raise
+
+    def competition_submission_cli(self, submission_ref, submission_ref_opt=None):
+        """Shows status and score for a single competition submission.
+
+        Args:
+            submission_ref: The numeric submission ref (printed by
+                ``kaggle competitions submit``).
+            submission_ref_opt: An alternative ref provided by the client.
+        """
+        submission_ref = submission_ref if submission_ref is not None else submission_ref_opt
+        if submission_ref is None:
+            raise ValueError("A submission ref must be specified")
+        submission = self.get_submission(submission_ref)
+        self._print_submission(submission)
+
+    def _print_submission(self, submission: ApiSubmission) -> None:
+        """Prints a single submission as an aligned, human-readable block."""
+        status = submission.status.name if submission.status is not None else ""
+        rows = [
+            ("Submission Ref", submission.ref),
+            ("Status", status),
+            ("Public Score", submission.public_score),
+            ("Private Score", submission.private_score),
+            ("Description", submission.description),
+            ("Submission Date", submission.date),
+        ]
+        width = max(len(label) for label, _ in rows)
+        for label, value in rows:
+            display = "" if value is None else self.string(value)
+            print("%-*s %s" % (width + 1, label + ":", display))
 
     def competition_submissions(
         self,

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -255,6 +255,24 @@ def parse_competitions(subparsers) -> None:
     parser_competitions_submit_optional.add_argument(
         "--sandbox", dest="sandbox", action="store_true", help=Help.param_sandbox
     )
+    parser_competitions_submit_optional.add_argument(
+        "--wait",
+        dest="wait",
+        type=int,
+        nargs="?",
+        const=0,
+        default=None,
+        required=False,
+        help=Help.param_submit_wait,
+    )
+    parser_competitions_submit_optional.add_argument(
+        "--poll-interval",
+        dest="poll_interval",
+        type=int,
+        default=60,
+        required=False,
+        help=Help.param_submit_poll_interval,
+    )
     parser_competitions_submit._action_groups.append(parser_competitions_submit_optional)
     parser_competitions_submit.set_defaults(func=api.competition_submit_cli)
 
@@ -281,6 +299,20 @@ def parse_competitions(subparsers) -> None:
     )
     parser_competitions_submissions._action_groups.append(parser_competitions_submissions_optional)
     parser_competitions_submissions.set_defaults(func=api.competition_submissions_cli)
+
+    # Competitions get single submission
+    parser_competitions_submission = subparsers_competitions.add_parser(
+        "submission", formatter_class=argparse.RawTextHelpFormatter, help=Help.command_competitions_submission
+    )
+    parser_competitions_submission_optional = parser_competitions_submission._action_groups.pop()
+    parser_competitions_submission_optional.add_argument(
+        "submission_ref", nargs="?", default=None, help=Help.param_submission_ref
+    )
+    parser_competitions_submission_optional.add_argument(
+        "-r", "--ref", dest="submission_ref_opt", required=False, help=argparse.SUPPRESS
+    )
+    parser_competitions_submission._action_groups.append(parser_competitions_submission_optional)
+    parser_competitions_submission.set_defaults(func=api.competition_submission_cli)
 
     # Competitions leaderboard
     parser_competitions_leaderboard = subparsers_competitions.add_parser(
@@ -2347,6 +2379,7 @@ class Help(object):
         "download",
         "submit",
         "submissions",
+        "submission",
         "leaderboard",
         "team-submissions",
         "episodes",
@@ -2490,6 +2523,7 @@ class Help(object):
     command_competitions_download = "Download competition files"
     command_competitions_submit = "Make a new competition submission"
     command_competitions_submissions = "Show your competition submissions"
+    command_competitions_submission = "Show status and score for a single submission by its ref"
     command_competitions_leaderboard = "Get competition leaderboard information"
     command_competitions_team_submissions = "List a team's public submissions (every active submission for simulation competitions, or the public leaderboard submission for regular competitions)"
     command_competitions_episodes = "List episodes for a submission in a simulation competition"
@@ -2605,6 +2639,15 @@ class Help(object):
     )
     param_code_kernel = "Name of kernel (notebook) to submit to a code competition"
     param_code_version = 'Version of kernel to submit to a code competition, e.g. "3"'
+    param_submit_wait = (
+        "Wait for the submission to finish scoring. Optionally specify a timeout in seconds "
+        "(0 or omit value = wait indefinitely)"
+    )
+    param_submit_poll_interval = (
+        "Maximum seconds between status polls while waiting (default: 60). Polling starts at 5s "
+        "and increases automatically"
+    )
+    param_submission_ref = "The numeric submission ref (printed by 'kaggle competitions submit')"
     param_csv = "Print results in CSV format (if not set print in table format)"
     param_format = (
         "Print results in selected format (csv, table, json). For details on "

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -2641,11 +2641,11 @@ class Help(object):
     param_code_version = 'Version of kernel to submit to a code competition, e.g. "3"'
     param_submit_wait = (
         "Wait for the submission to finish scoring. Optionally specify a timeout in seconds "
-        "(0 or omit value = wait indefinitely)"
+        "(0 or omit value = wait up to 12 hours, the maximum notebook runtime)"
     )
     param_submit_poll_interval = (
-        "Maximum seconds between status polls while waiting (default: 60). Polling starts at 5s "
-        "and increases automatically"
+        "Maximum seconds between status polls while waiting (default: 60, minimum: 5). "
+        "Polling starts at 5s and increases automatically"
     )
     param_submission_ref = "The numeric submission ref (printed by 'kaggle competitions submit')"
     param_csv = "Print results in CSV format (if not set print in table format)"

--- a/tests/unit/test_competition_submit_wait.py
+++ b/tests/unit/test_competition_submit_wait.py
@@ -1,0 +1,328 @@
+# coding=utf-8
+"""Tests for `competitions submit --wait` and `competitions submission <ref>`.
+
+Covers the parser wiring, the submission polling helper (_poll_submission),
+the submit-with-wait flow, the single-submission display command, and the
+end-to-end CLI exit codes (0 on success, 1 on scoring failure).
+"""
+
+import io
+import sys
+from contextlib import redirect_stdout
+from unittest.mock import MagicMock, patch
+
+import pytest
+from requests.exceptions import HTTPError
+
+from kaggle.api.kaggle_api_extended import KaggleApi
+from kagglesdk.competitions.types.competition_api_service import ApiSubmission
+from kagglesdk.competitions.types.submission_status import SubmissionStatus
+
+
+def _api():
+    """A bare KaggleApi instance without running __init__/authenticate."""
+    api = KaggleApi.__new__(KaggleApi)
+    api.config_values = {"username": "testuser"}
+    api.already_printed_version_warning = True
+    return api
+
+
+def _submission(status, ref=12345, public="0.987", private="0.812", desc="my run", error=None):
+    s = ApiSubmission()
+    s.ref = ref
+    s.status = status
+    if public is not None:
+        s.public_score = public
+    if private is not None:
+        s.private_score = private
+    if desc is not None:
+        s.description = desc
+    if error is not None:
+        s.error_description = error
+    return s
+
+
+def _http_404():
+    return HTTPError(response=MagicMock(status_code=404))
+
+
+# --------------------------------------------------------------------------
+# Parser tests
+# --------------------------------------------------------------------------
+def test_submit_parser_wait_flag_bare(parser):
+    func, kwargs = parser.dispatch(["competitions", "submit", "my-comp", "-f", "sub.csv", "-m", "msg", "--wait"])
+    assert func.__name__ == "competition_submit_cli"
+    assert kwargs["wait"] == 0  # const: bare --wait means wait indefinitely
+    assert kwargs["poll_interval"] == 60
+
+
+def test_submit_parser_wait_with_timeout(parser):
+    func, kwargs = parser.dispatch(["competitions", "submit", "my-comp", "-f", "sub.csv", "-m", "msg", "--wait", "300"])
+    assert func.__name__ == "competition_submit_cli"
+    assert kwargs["wait"] == 300
+    assert kwargs["poll_interval"] == 60
+
+
+def test_submit_parser_poll_interval(parser):
+    func, kwargs = parser.dispatch(
+        ["competitions", "submit", "my-comp", "-f", "sub.csv", "-m", "msg", "--wait", "--poll-interval", "5"]
+    )
+    assert func.__name__ == "competition_submit_cli"
+    assert kwargs["wait"] == 0
+    assert kwargs["poll_interval"] == 5
+
+
+def test_submit_parser_no_wait_default(parser):
+    func, kwargs = parser.dispatch(["competitions", "submit", "my-comp", "-f", "sub.csv", "-m", "msg"])
+    assert func.__name__ == "competition_submit_cli"
+    assert kwargs["wait"] is None  # absent → do not wait (backward compatible)
+    assert kwargs["poll_interval"] == 60
+
+
+def test_submission_parser_succeeds(parser):
+    func, kwargs = parser.dispatch(["competitions", "submission", "12345"])
+    assert func.__name__ == "competition_submission_cli"
+    assert kwargs["submission_ref"] == "12345"
+
+
+# --------------------------------------------------------------------------
+# _poll_submission behavior
+# --------------------------------------------------------------------------
+def test_poll_submission_completes_and_prints_score():
+    api = _api()
+    api._adaptive_sleep = MagicMock(return_value=60)  # no real sleeping
+    api.get_submission = MagicMock(
+        side_effect=[
+            _submission(SubmissionStatus.PENDING),
+            _submission(SubmissionStatus.PENDING),
+            _submission(SubmissionStatus.COMPLETE, public="0.987"),
+        ]
+    )
+
+    out = io.StringIO()
+    with redirect_stdout(out):
+        result = api._poll_submission(12345, wait=0, poll_interval=60)
+
+    assert result.status == SubmissionStatus.COMPLETE
+    assert api.get_submission.call_count == 3  # polled until terminal
+    assert api._adaptive_sleep.call_count == 2  # slept between the two PENDING polls
+    printed = out.getvalue()
+    assert "Public score: 0.987" in printed
+    assert printed.count("Submission status: PENDING...") == 2
+
+
+def test_poll_submission_error_raises_with_description():
+    api = _api()
+    api._adaptive_sleep = MagicMock(return_value=60)
+    api.get_submission = MagicMock(
+        side_effect=[
+            _submission(SubmissionStatus.PENDING),
+            _submission(SubmissionStatus.ERROR, error="Evaluation Exception: wrong number of rows"),
+        ]
+    )
+
+    with pytest.raises(ValueError) as ctx:
+        api._poll_submission(12345, wait=0, poll_interval=60, quiet=True)
+
+    msg = str(ctx.value)
+    assert "failed to score" in msg
+    assert "wrong number of rows" in msg
+
+
+def test_poll_submission_timeout_raises_with_resume_hint():
+    api = _api()
+    api._adaptive_sleep = MagicMock(return_value=60)
+    api.get_submission = MagicMock(return_value=_submission(SubmissionStatus.PENDING))
+
+    # start_time=1000, then elapsed check sees 2000 → exceeds wait=10 → timeout.
+    with patch("kaggle.api.kaggle_api_extended.time.time", side_effect=[1000.0, 2000.0]):
+        with pytest.raises(ValueError) as ctx:
+            api._poll_submission(12345, wait=10, poll_interval=60, quiet=True)
+
+    msg = str(ctx.value)
+    assert "Timed out after 10s" in msg
+    assert "Submission ref: 12345" in msg
+    assert "kaggle competitions submission 12345" in msg
+
+
+def test_poll_submission_transient_404_treated_as_pending():
+    api = _api()
+    api._adaptive_sleep = MagicMock(return_value=60)
+    api.get_submission = MagicMock(
+        side_effect=[
+            _http_404(),  # eventual consistency: not visible yet
+            _http_404(),
+            _submission(SubmissionStatus.PENDING),
+            _submission(SubmissionStatus.COMPLETE),
+        ]
+    )
+
+    result = api._poll_submission(12345, wait=0, poll_interval=60, quiet=True)
+
+    assert result.status == SubmissionStatus.COMPLETE
+    assert api.get_submission.call_count == 4  # kept polling through the 404s
+
+
+def test_poll_submission_non_404_http_error_propagates():
+    api = _api()
+    api._adaptive_sleep = MagicMock(return_value=60)
+    api.get_submission = MagicMock(side_effect=HTTPError(response=MagicMock(status_code=500)))
+
+    with pytest.raises(HTTPError):
+        api._poll_submission(12345, wait=0, poll_interval=60, quiet=True)
+
+
+def test_poll_submission_keyboard_interrupt_prints_hint_and_reraises():
+    api = _api()
+    api.get_submission = MagicMock(return_value=_submission(SubmissionStatus.PENDING))
+    api._adaptive_sleep = MagicMock(side_effect=KeyboardInterrupt())
+
+    out = io.StringIO()
+    with redirect_stdout(out):
+        with pytest.raises(KeyboardInterrupt):
+            api._poll_submission(12345, wait=0, poll_interval=60, quiet=True)
+
+    printed = out.getvalue()
+    assert "Stopped waiting for submission 12345" in printed
+    assert "kaggle competitions submission 12345" in printed
+
+
+# --------------------------------------------------------------------------
+# competition_submit_cli integration with --wait
+# --------------------------------------------------------------------------
+def test_submit_cli_prints_ref_without_wait():
+    api = _api()
+    api.competition_submit = MagicMock(return_value=MagicMock(ref=999, message="Successfully submitted"))
+    api._poll_submission = MagicMock()
+
+    out = io.StringIO()
+    with redirect_stdout(out):
+        result = api.competition_submit_cli(file_name="sub.csv", message="m", competition="comp", quiet=True)
+
+    assert "Submission ref: 999" in out.getvalue()
+    api._poll_submission.assert_not_called()  # no --wait → do not poll
+    assert result == "Successfully submitted"
+
+
+def test_submit_cli_wait_polls_submission():
+    api = _api()
+    api.competition_submit = MagicMock(return_value=MagicMock(ref=12345, message="Successfully submitted"))
+    api._poll_submission = MagicMock()
+
+    out = io.StringIO()
+    with redirect_stdout(out):
+        result = api.competition_submit_cli(
+            file_name="sub.csv", message="m", competition="comp", quiet=False, wait=0, poll_interval=60
+        )
+
+    assert "Submission ref: 12345" in out.getvalue()
+    api._poll_submission.assert_called_once_with(12345, 0, 60, quiet=False)
+    assert result == "Successfully submitted"
+
+
+def test_submit_cli_invalid_poll_interval_fails_fast():
+    api = _api()
+    api.competition_submit = MagicMock()
+
+    with pytest.raises(ValueError) as ctx:
+        api.competition_submit_cli(file_name="sub.csv", message="m", competition="comp", wait=0, poll_interval=0)
+
+    assert "--poll-interval must be a positive integer" in str(ctx.value)
+    api.competition_submit.assert_not_called()  # validated before submitting
+
+
+def test_submit_cli_wait_propagates_scoring_error():
+    api = _api()
+    api.competition_submit = MagicMock(return_value=MagicMock(ref=12345, message="Successfully submitted"))
+    api._poll_submission = MagicMock(side_effect=ValueError("Submission 12345 failed to score."))
+
+    with pytest.raises(ValueError):
+        api.competition_submit_cli(file_name="sub.csv", message="m", competition="comp", wait=0, poll_interval=60)
+
+
+# --------------------------------------------------------------------------
+# competition_submission_cli display command
+# --------------------------------------------------------------------------
+def test_submission_cli_displays_fields():
+    api = _api()
+    api.get_submission = MagicMock(
+        return_value=_submission(SubmissionStatus.COMPLETE, ref=12345, public="0.987", private="0.812", desc="my run")
+    )
+
+    out = io.StringIO()
+    with redirect_stdout(out):
+        api.competition_submission_cli("12345")
+
+    printed = out.getvalue()
+    for label in ("Submission Ref", "Status", "Public Score", "Private Score", "Description", "Submission Date"):
+        assert label in printed
+    assert "COMPLETE" in printed
+    assert "12345" in printed
+    assert "0.987" in printed
+    assert "0.812" in printed
+    assert "my run" in printed
+    api.get_submission.assert_called_once_with("12345")
+
+
+def test_submission_cli_missing_ref_fails():
+    api = _api()
+    with pytest.raises(ValueError) as ctx:
+        api.competition_submission_cli(None)
+    assert "A submission ref must be specified" in str(ctx.value)
+
+
+# --------------------------------------------------------------------------
+# End-to-end CLI exit codes via main()
+# --------------------------------------------------------------------------
+def _run_main(monkeypatch, api, argv):
+    """Run kaggle.cli.main() with the given argv; return the process exit code."""
+    import kaggle.cli as cli
+
+    monkeypatch.setattr(cli, "api", api)
+    monkeypatch.setattr(api, "authenticate", MagicMock())
+    monkeypatch.setattr(api, "_authenticated", True, raising=False)
+    monkeypatch.setattr(sys, "argv", ["kaggle", *argv])
+    try:
+        cli.main()
+        return 0
+    except SystemExit as e:
+        return e.code if isinstance(e.code, int) else 1
+
+
+def test_cli_submit_wait_success_exits_zero(monkeypatch, api):
+    api.competition_submit = MagicMock(return_value=MagicMock(ref=12345, message="Successfully submitted"))
+    api.get_submission = MagicMock(return_value=_submission(SubmissionStatus.COMPLETE, public="0.987"))
+    api._adaptive_sleep = MagicMock(return_value=60)
+
+    out = io.StringIO()
+    with redirect_stdout(out):
+        code = _run_main(
+            monkeypatch,
+            api,
+            ["competitions", "submit", "comp", "-f", "sub.csv", "-m", "msg", "--wait"],
+        )
+
+    assert code == 0
+    assert "Public score: 0.987" in out.getvalue()
+
+
+def test_cli_submit_wait_scoring_error_exits_one(monkeypatch, api):
+    api.competition_submit = MagicMock(return_value=MagicMock(ref=12345, message="Successfully submitted"))
+    api.get_submission = MagicMock(return_value=_submission(SubmissionStatus.ERROR, error="Evaluation failed"))
+    api._adaptive_sleep = MagicMock(return_value=60)
+
+    err = io.StringIO()
+    with redirect_stdout(io.StringIO()):
+        with patch("sys.stderr", err):
+            code = _run_main(
+                monkeypatch,
+                api,
+                ["competitions", "submit", "comp", "-f", "sub.csv", "-m", "msg", "--wait"],
+            )
+
+    assert code == 1
+    assert "failed to score" in err.getvalue()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/unit/test_competition_submit_wait.py
+++ b/tests/unit/test_competition_submit_wait.py
@@ -52,7 +52,8 @@ def _http_404():
 def test_submit_parser_wait_flag_bare(parser):
     func, kwargs = parser.dispatch(["competitions", "submit", "my-comp", "-f", "sub.csv", "-m", "msg", "--wait"])
     assert func.__name__ == "competition_submit_cli"
-    assert kwargs["wait"] == 0  # const: bare --wait means wait indefinitely
+    # const: bare --wait parses to 0; competition_submit_cli resolves 0 to the 12h default.
+    assert kwargs["wait"] == 0
     assert kwargs["poll_interval"] == 60
 
 
@@ -204,7 +205,8 @@ def test_submit_cli_prints_ref_without_wait():
     assert result == "Successfully submitted"
 
 
-def test_submit_cli_wait_polls_submission():
+def test_submit_cli_wait_default_timeout_is_12h():
+    # A bare --wait (wait=0) is resolved to the 12h maximum notebook runtime, not infinite.
     api = _api()
     api.competition_submit = MagicMock(return_value=MagicMock(ref=12345, message="Successfully submitted"))
     api._poll_submission = MagicMock()
@@ -216,19 +218,49 @@ def test_submit_cli_wait_polls_submission():
         )
 
     assert "Submission ref: 12345" in out.getvalue()
-    api._poll_submission.assert_called_once_with(12345, 0, 60, quiet=False)
+    # 0 → 12h (43200s); poll_interval passed through unchanged.
+    api._poll_submission.assert_called_once_with(12345, 43200, 60, quiet=False)
     assert result == "Successfully submitted"
 
 
-def test_submit_cli_invalid_poll_interval_fails_fast():
+def test_submit_cli_wait_explicit_timeout_passed_through():
+    # An explicit positive timeout is forwarded verbatim (no 12h substitution).
+    api = _api()
+    api.competition_submit = MagicMock(return_value=MagicMock(ref=12345, message="Successfully submitted"))
+    api._poll_submission = MagicMock()
+
+    with redirect_stdout(io.StringIO()):
+        api.competition_submit_cli(
+            file_name="sub.csv", message="m", competition="comp", quiet=False, wait=300, poll_interval=60
+        )
+
+    api._poll_submission.assert_called_once_with(12345, 300, 60, quiet=False)
+
+
+def test_submit_cli_poll_interval_below_minimum_fails_fast():
     api = _api()
     api.competition_submit = MagicMock()
 
+    # 3s is below the 5s minimum poll interval.
     with pytest.raises(ValueError) as ctx:
-        api.competition_submit_cli(file_name="sub.csv", message="m", competition="comp", wait=0, poll_interval=0)
+        api.competition_submit_cli(file_name="sub.csv", message="m", competition="comp", wait=0, poll_interval=3)
 
-    assert "--poll-interval must be a positive integer" in str(ctx.value)
+    assert "--poll-interval must be at least 5s" in str(ctx.value)
     api.competition_submit.assert_not_called()  # validated before submitting
+
+
+def test_submit_cli_poll_interval_at_minimum_is_accepted():
+    # The 5s boundary is valid and reaches polling.
+    api = _api()
+    api.competition_submit = MagicMock(return_value=MagicMock(ref=12345, message="Successfully submitted"))
+    api._poll_submission = MagicMock()
+
+    with redirect_stdout(io.StringIO()):
+        api.competition_submit_cli(
+            file_name="sub.csv", message="m", competition="comp", quiet=False, wait=600, poll_interval=5
+        )
+
+    api._poll_submission.assert_called_once_with(12345, 600, 5, quiet=False)
 
 
 def test_submit_cli_wait_propagates_scoring_error():


### PR DESCRIPTION
## Summary

This PR improves the competition submission workflow by adding support for waiting on a submission to finish scoring and by exposing submission details through a new CLI command.

### What's changed

* `kaggle competitions submit` now prints the submission reference after a successful submission.
* Added `--wait [SECONDS]` to wait until a submission finishes scoring and print the public score.
* Added `--poll-interval` to control the maximum polling interval while waiting.
* Added a new command:

```bash
kaggle competitions submission <ref>
```

to view the status and details of a single submission.

### Why?

Currently, after submitting to a competition, the CLI exits immediately and doesn't expose the submission reference returned by the backend. Although the SDK already provides a `get_submission()` API, there isn't a CLI command that uses it.

This makes it difficult to automate competition workflows or use the CLI in CI pipelines since users have to repeatedly check `kaggle competitions submissions` and identify the correct submission manually.

This PR exposes the existing SDK functionality through the CLI without requiring any backend changes.

### Example

```bash
$ kaggle competitions submit -c titanic -f submission.csv -m "CI run" --wait

Submission ref: 12345678
Submission status: PENDING...
Submission status: PENDING...
Submission scored. Public score: 0.78468
```

```bash
$ kaggle competitions submission 12345678

Submission Ref: 12345678
Status: COMPLETE
Public Score: 0.78468
Description: CI run
```

### Implementation

* Added a dedicated submission polling helper.
* Reused the existing retry and adaptive polling utilities.
* Added handling for scoring errors, timeouts, retries, and temporary `404` responses immediately after submission.
* Added documentation and CLI help for the new options and command.

### Testing

* Added unit tests covering parser behavior, polling, timeout handling, scoring failures, retries, and the new command.
* Ran the full test suite.
* Verified the feature against the live Kaggle API by:

  * submitting a competition entry,
  * retrieving it using the returned submission reference,
  * waiting until scoring completed,
  * and confirming the public score was displayed correctly.

### Backward compatibility

Without `--wait`, the existing submission workflow behaves as before. The only visible change is that the submission reference is now printed after a successful submission.
