### PR TITLE
feat(cli): add competitions solution create/status commands

### DIFF
--- a/docs/competition_creation.md
+++ b/docs/competition_creation.md
@@ -595,8 +595,8 @@ preprocessing / sampling; poll
 [`kaggle competitions solution status`](#kaggle-competitions-solution-status)
 until it's `ready` before opening submissions.
 
-The file is uploaded via the standard blob-upload pipeline (`ApiBlobType.INBOX`),
-and the resulting token is passed to `CreateCompetitionSolution`.
+The file is uploaded via the standard blob-upload pipeline, then the resulting
+token is passed to `CreateCompetitionSolution`.
 
 **Usage:**
 

--- a/docs/competition_creation.md
+++ b/docs/competition_creation.md
@@ -9,8 +9,10 @@ public competition-creation API endpoints (kagglesdk 0.1.31+):
 - [`kaggle competitions hosts`](#kaggle-competitions-hosts)
 - [`kaggle competitions settings get`](#kaggle-competitions-settings-get)
 - [`kaggle competitions settings update`](#kaggle-competitions-settings-update)
-- [`kaggle competitions launch`](#kaggle-competitions-launch)
 - [`kaggle competitions data update`](#kaggle-competitions-data-update)
+- [`kaggle competitions solution create`](#kaggle-competitions-solution-create)
+- [`kaggle competitions solution status`](#kaggle-competitions-solution-status)
+- [`kaggle competitions launch`](#kaggle-competitions-launch)
 
 All of these commands require an authenticated session
 (`kaggle config set username/password` or an API token).
@@ -34,12 +36,17 @@ kaggle competitions pages create my-comp-slug --name rules -f ./rules.md --publi
 # 5. Update the competition data (train.csv, test.csv, sample_submission.csv, ...).
 kaggle competitions data update my-comp-slug -p ./data -m "Initial release"
 
-# 6. Optionally tune host-only settings not covered by competition-metadata.json
+# 6. Upload the private solution CSV, then poll until scoring is ready.
+kaggle competitions solution create my-comp-slug -p ./solution.csv
+kaggle competitions solution status my-comp-slug
+# → Ready: true
+
+# 7. Optionally tune host-only settings not covered by competition-metadata.json
 #    (deadlines, runtime caps, leaderboard behavior, etc.).
 kaggle competitions settings get my-comp-slug
 kaggle competitions settings update my-comp-slug -f ./settings.json
 
-# 7. Launch the competition (now, or schedule a future UTC time).
+# 8. Launch the competition (now, or schedule a future UTC time).
 kaggle competitions launch my-comp-slug --at 2027-01-01T00:00:00Z
 ```
 
@@ -576,3 +583,103 @@ keep the format as an opaque single upload, pre-pack it into a `.zip` or
 
 The command prints the public URL plus the new `databundle_id` and
 `databundle_version_id` on success.
+
+---
+
+## `kaggle competitions solution create`
+
+Uploads the private solution CSV for a competition you host. The solution is
+what the backend scores submissions against — one row per row in the sample
+submission, with the same column shape. After uploading, the backend runs
+preprocessing / sampling; poll
+[`kaggle competitions solution status`](#kaggle-competitions-solution-status)
+until it's `ready` before opening submissions.
+
+The file is uploaded via the standard blob-upload pipeline (`ApiBlobType.INBOX`),
+and the resulting token is passed to `CreateCompetitionSolution`.
+
+**Usage:**
+
+```bash
+kaggle competitions solution create <competition> -p <path> [-q]
+```
+
+**Arguments:**
+
+- `<competition>`: The competition slug.
+
+**Options:**
+
+- `-p, --path <path>` (required): Path to a single CSV file. Must be a single
+  file — directories are rejected. The CSV shape must match a submission
+  file (same columns as `sample_submission.csv`).
+- `-q, --quiet` (optional): Suppress per-file upload progress lines.
+
+**Example:**
+
+```bash
+kaggle competitions solution create my-comp -p ./solution.csv
+# → Solution uploaded for "my-comp". Run 'kaggle competitions solution status my-comp' to check readiness.
+```
+
+Re-uploading a solution replaces the prior one. Note that this only works
+pre-launch; after launch the solution file is frozen.
+
+---
+
+## `kaggle competitions solution status`
+
+Shows the setup status for a competition's solution file — whether
+preprocessing/sampling has finished, any errors reported by the backend, and
+(for legacy C# metrics) the auto-inferred column mapping and required metric
+columns.
+
+Poll this after `solution create` (and after `data update` — some setup steps
+run against the databundle) until `Ready: true`. If `Setup error:` is set,
+stop polling and fix the underlying issue.
+
+**Usage:**
+
+```bash
+kaggle competitions solution status <competition> [--json]
+```
+
+**Arguments:**
+
+- `<competition>`: The competition slug.
+
+**Options:**
+
+- `--json` (optional): Emit the raw status as JSON instead of the
+  human-readable view.
+
+**Examples:**
+
+```bash
+# Human-readable summary.
+kaggle competitions solution status my-comp
+# → Ready: true
+#   Solution file: solution.csv — 12.3KB — uploaded 2027-01-01T00:00:00+00:00
+#     total=1000, public=300, private=700
+
+# Machine-readable — useful in a polling loop.
+kaggle competitions solution status my-comp --json
+```
+
+**Fields you might see (human view):**
+
+- `Ready: true|false` — whether scoring is unblocked.
+- `Setup error: <msg>` — populated if preprocessing failed. Surfaced
+  prominently; stop polling when it appears.
+- `Kernels metric: true` — the competition's scoring metric is a Kernels
+  metric. Kernels metrics auto-detect their column mapping; the host only
+  needs to wait for `Ready` to flip true.
+- `Row ID column: <name>` — for Kernels metrics, the auto-detected row-id
+  column.
+- `Solution file: <name> — <size> — uploaded <timestamp>` and
+  `total=..., public=..., private=...` — solution file metadata once the
+  upload is processed.
+- `Column mapping:` — for legacy C# metrics, the current mapping from metric
+  column name to CSV column name.
+- `Required columns:` — for legacy C# metrics, the metric column slots the
+  host needs to fill (name + expected data type).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ keywords = ["Kaggle", "API"]
 requires-python = ">= 3.11"
 dependencies = [
     "bleach",
-    "kagglesdk >= 0.1.34, < 1.0", # sync with kagglehub
+    "kagglesdk >= 0.1.35, < 1.0", # sync with kagglehub
     "python-slugify",
     "requests",
     "python-dateutil",

--- a/requirements.lock
+++ b/requirements.lock
@@ -26,7 +26,7 @@ jupyter-core==5.9.1
     # via nbformat
 jupytext==1.19.1
     # via kaggle (pyproject.toml)
-kagglesdk==0.1.34
+kagglesdk==0.1.35
     # via kaggle (pyproject.toml)
 markdown-it-py==4.0.0
     # via

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -3311,8 +3311,10 @@ class KaggleApi:
         """Upload the private solution CSV for a competition you host.
 
         The file is uploaded via the public blob-upload pipeline with
-        ApiBlobType.INBOX — the backend's CreateCompetitionSolutionHandler
-        pulls the blob out of the inbox bucket. After this call, poll
+        ApiBlobType.COMPETITION_SOLUTION — the backend routes this straight
+        to the CompetitionSolutions bucket instead of the general InboxFiles
+        bucket, so the source blob doesn't linger after CreateCompetitionSolution
+        moves it into the raw-solution slot. After this call, poll
         ``competition_get_solution_status`` until ``ready`` flips true (or
         ``setup_error`` is populated) before submissions can be scored.
 
@@ -3331,7 +3333,7 @@ class KaggleApi:
             upload_file = self._upload_file(
                 os.path.basename(path),
                 path,
-                ApiBlobType.INBOX,
+                ApiBlobType.COMPETITION_SOLUTION,
                 upload_context,
                 quiet,
                 resources=None,

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -111,6 +111,9 @@ from kagglesdk.competitions.types.competition_api_service import (
     ApiUpdateCompetitionSettingsRequest,
     ApiCreateCompetitionDataRequest,
     ApiCreateCompetitionDataResponse,
+    ApiCreateCompetitionSolutionRequest,
+    ApiGetCompetitionSolutionStatusRequest,
+    ApiCompetitionSolutionStatus,
     ApiCompetitionDataFile,
     ApiCompetitionPage,
     ApiCreateCompetitionRequest,
@@ -3303,6 +3306,146 @@ class KaggleApi:
             ignore_patterns=ignore_patterns,
         )
         print(f'New data version created for "{competition_name}": {response.url}')
+
+    def competition_create_solution(self, competition_name: str, path: str, quiet: bool = False) -> None:
+        """Upload the private solution CSV for a competition you host.
+
+        The file is uploaded via the public blob-upload pipeline with
+        ApiBlobType.INBOX — the backend's CreateCompetitionSolutionHandler
+        pulls the blob out of the inbox bucket. After this call, poll
+        ``competition_get_solution_status`` until ``ready`` flips true (or
+        ``setup_error`` is populated) before submissions can be scored.
+
+        Args:
+            competition_name (str): The competition name (slug).
+            path (str): Path to a single CSV file. The CSV must have the same
+                shape as a submission file.
+            quiet (bool): Suppress per-file upload progress lines.
+        """
+        if not path:
+            raise ValueError("-p/--path is required")
+        if not os.path.exists(path):
+            raise ValueError("Invalid path: " + path)
+        if not os.path.isfile(path):
+            raise ValueError("Solution must be a single CSV file, not a directory: " + path)
+
+        with ResumableUploadContext() as upload_context:
+            upload_file = self._upload_file(
+                os.path.basename(path),
+                path,
+                ApiBlobType.INBOX,
+                upload_context,
+                quiet,
+                resources=None,
+            )
+            if upload_file is None:
+                raise ValueError("Solution file upload failed")
+
+        with self.build_kaggle_client() as kaggle:
+            request = ApiCreateCompetitionSolutionRequest()
+            request.competition_name = competition_name
+            request.blob_token = upload_file.token
+            kaggle.competitions.competition_api_client.create_competition_solution(request)
+
+    def competition_create_solution_cli(
+        self,
+        competition=None,
+        competition_opt=None,
+        path=None,
+        quiet=False,
+    ):
+        """CLI wrapper for competition_create_solution."""
+        competition_name = competition or competition_opt
+        if competition_name is None:
+            competition_name = self.get_config_value(self.CONFIG_NAME_COMPETITION)
+            if competition_name is not None and not quiet:
+                print("Using competition: " + competition_name)
+        if competition_name is None:
+            raise ValueError("No competition specified")
+        if not path:
+            raise ValueError("-p/--path is required")
+
+        self.competition_create_solution(competition_name=competition_name, path=path, quiet=quiet)
+        print(
+            f'Solution uploaded for "{competition_name}". '
+            f"Run 'kaggle competitions solution status {competition_name}' to check readiness."
+        )
+
+    def competition_get_solution_status(self, competition_name: str) -> ApiCompetitionSolutionStatus:
+        """Fetch the solution-setup status for a competition you host.
+
+        Args:
+            competition_name (str): The competition name (slug).
+
+        Returns:
+            ApiCompetitionSolutionStatus: current setup state, including a
+            ``ready`` flag and any ``setup_error`` reported by preprocessing.
+        """
+        with self.build_kaggle_client() as kaggle:
+            request = ApiGetCompetitionSolutionStatusRequest()
+            request.competition_name = competition_name
+            return kaggle.competitions.competition_api_client.get_competition_solution_status(request)
+
+    def competition_get_solution_status_cli(
+        self,
+        competition=None,
+        competition_opt=None,
+        json_output=False,
+        quiet=False,
+    ):
+        """CLI wrapper for competition_get_solution_status."""
+        competition_name = competition or competition_opt
+        if competition_name is None:
+            competition_name = self.get_config_value(self.CONFIG_NAME_COMPETITION)
+            if competition_name is not None and not quiet:
+                print("Using competition: " + competition_name)
+        if competition_name is None:
+            raise ValueError("No competition specified")
+
+        status = self.competition_get_solution_status(competition_name)
+        if json_output:
+            self.print_obj(status)
+        else:
+            self._print_competition_solution_status(status)
+
+    def _print_competition_solution_status(self, status: ApiCompetitionSolutionStatus) -> None:
+        """Print a compact human view of a solution status."""
+        print(f"Ready: {'true' if status.ready else 'false'}")
+        if status.setup_error:
+            print(f"Setup error: {status.setup_error}")
+        if status.kernels_metric:
+            print("Kernels metric: true")
+        if status.row_id_column_name:
+            print(f"Row ID column: {status.row_id_column_name}")
+        info = status.solution_info
+        if info is not None and (info.file_name or info.file_size_bytes or info.total_rows):
+            parts = []
+            if info.file_name:
+                parts.append(info.file_name)
+            if info.file_size_bytes:
+                parts.append(File.get_size(info.file_size_bytes))
+            if info.upload_date:
+                parts.append(f"uploaded {info.upload_date.isoformat()}")
+            print("Solution file: " + " — ".join(parts) if parts else "Solution file:")
+            row_bits = []
+            if info.total_rows:
+                row_bits.append(f"total={info.total_rows}")
+            if info.public_rows:
+                row_bits.append(f"public={info.public_rows}")
+            if info.private_rows:
+                row_bits.append(f"private={info.private_rows}")
+            if row_bits:
+                print("  " + ", ".join(row_bits))
+        if status.column_mapping:
+            print("Column mapping:")
+            for metric_col, csv_col in status.column_mapping.items():
+                print(f"  {metric_col} -> {csv_col}")
+        if status.required_metric_columns:
+            print("Required columns:")
+            for col in status.required_metric_columns:
+                if col is None:
+                    continue
+                print(f"  {col.name} ({col.data_type})")
 
     def competition_launch(self, competition_name: str, future_time: Optional[datetime] = None) -> None:
         """Launch a competition you host, optionally at a future UTC time.

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -3322,8 +3322,6 @@ class KaggleApi:
                 shape as a submission file.
             quiet (bool): Suppress per-file upload progress lines.
         """
-        if not path:
-            raise ValueError("-p/--path is required")
         if not os.path.exists(path):
             raise ValueError("Invalid path: " + path)
         if not os.path.isfile(path):
@@ -3410,15 +3408,17 @@ class KaggleApi:
 
     def _print_competition_solution_status(self, status: ApiCompetitionSolutionStatus) -> None:
         """Print a compact human view of a solution status."""
-        print(f"Ready: {'true' if status.ready else 'false'}")
         if status.setup_error:
+            print("Ready: false (setup failed)")
             print(f"Setup error: {status.setup_error}")
+        else:
+            print(f"Ready: {'true' if status.ready else 'false'}")
         if status.kernels_metric:
             print("Kernels metric: true")
         if status.row_id_column_name:
             print(f"Row ID column: {status.row_id_column_name}")
         info = status.solution_info
-        if info is not None and (info.file_name or info.file_size_bytes or info.total_rows):
+        if info is not None and (info.file_name or info.file_size_bytes or info.upload_date):
             parts = []
             if info.file_name:
                 parts.append(info.file_name)
@@ -3426,7 +3426,7 @@ class KaggleApi:
                 parts.append(File.get_size(info.file_size_bytes))
             if info.upload_date:
                 parts.append(f"uploaded {info.upload_date.isoformat()}")
-            print("Solution file: " + " — ".join(parts) if parts else "Solution file:")
+            print("Solution file: " + " — ".join(parts))
             row_bits = []
             if info.total_rows:
                 row_bits.append(f"total={info.total_rows}")

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -734,6 +734,67 @@ def parse_competitions(subparsers) -> None:
     parser_competitions_settings_update._action_groups.append(parser_competitions_settings_update_optional)
     parser_competitions_settings_update.set_defaults(func=api.competition_update_settings_cli)
 
+    # Competitions solution (group: create, status)
+    parser_competitions_solution = subparsers_competitions.add_parser(
+        "solution",
+        formatter_class=argparse.RawTextHelpFormatter,
+        help=Help.command_competitions_solution,
+    )
+    subparsers_competitions_solution = parser_competitions_solution.add_subparsers(title="commands", dest="command")
+    subparsers_competitions_solution.required = True
+    subparsers_competitions_solution.choices = Help.entity_solution_choices
+
+    # Competitions solution create
+    parser_competitions_solution_create = subparsers_competitions_solution.add_parser(
+        "create",
+        formatter_class=argparse.RawTextHelpFormatter,
+        help=Help.command_competitions_solution_create,
+    )
+    parser_competitions_solution_create_optional = parser_competitions_solution_create._action_groups.pop()
+    parser_competitions_solution_create_optional.add_argument(
+        "competition", nargs="?", default=None, help=Help.param_competition
+    )
+    parser_competitions_solution_create_optional.add_argument(
+        "-c", "--competition", dest="competition_opt", required=False, help=argparse.SUPPRESS
+    )
+    parser_competitions_solution_create_optional.add_argument(
+        "-p",
+        "--path",
+        dest="path",
+        required=True,
+        help="Path to the private solution CSV. Must be a single file in the same shape as a submission.",
+    )
+    parser_competitions_solution_create_optional.add_argument(
+        "-q", "--quiet", dest="quiet", action="store_true", help=Help.param_quiet
+    )
+    parser_competitions_solution_create._action_groups.append(parser_competitions_solution_create_optional)
+    parser_competitions_solution_create.set_defaults(func=api.competition_create_solution_cli)
+
+    # Competitions solution status
+    parser_competitions_solution_status = subparsers_competitions_solution.add_parser(
+        "status",
+        formatter_class=argparse.RawTextHelpFormatter,
+        help=Help.command_competitions_solution_status,
+    )
+    parser_competitions_solution_status_optional = parser_competitions_solution_status._action_groups.pop()
+    parser_competitions_solution_status_optional.add_argument(
+        "competition", nargs="?", default=None, help=Help.param_competition
+    )
+    parser_competitions_solution_status_optional.add_argument(
+        "-c", "--competition", dest="competition_opt", required=False, help=argparse.SUPPRESS
+    )
+    parser_competitions_solution_status_optional.add_argument(
+        "--json",
+        dest="json_output",
+        action="store_true",
+        help="Emit the status as JSON instead of the human-readable view.",
+    )
+    parser_competitions_solution_status_optional.add_argument(
+        "-q", "--quiet", dest="quiet", action="store_true", help=Help.param_quiet
+    )
+    parser_competitions_solution_status._action_groups.append(parser_competitions_solution_status_optional)
+    parser_competitions_solution_status.set_defaults(func=api.competition_get_solution_status_cli)
+
     # Competitions launch (publish now, or schedule for a future UTC time)
     parser_competitions_launch = subparsers_competitions.add_parser(
         "launch", formatter_class=argparse.RawTextHelpFormatter, help=Help.command_competitions_launch
@@ -2356,6 +2417,7 @@ class Help(object):
         "hosts",
         "data",
         "settings",
+        "solution",
         "launch",
         "init",
         "create",
@@ -2424,6 +2486,7 @@ class Help(object):
     entity_hosts_choices = ["list"]
     entity_data_choices = ["update"]
     entity_settings_choices = ["get", "update"]
+    entity_solution_choices = ["create", "status"]
     config_choices = ["view", "set", "unset"]
     auth_choices = ["login", "print-access-token", "revoke"]
 
@@ -2505,6 +2568,9 @@ class Help(object):
     command_competitions_settings = "Manage settings for a competition you host"
     command_competitions_settings_get = "Show the current settings for a competition you host"
     command_competitions_settings_update = "Update settings for a competition you host from a JSON or YAML file"
+    command_competitions_solution = "Manage the private solution file for a competition you host"
+    command_competitions_solution_create = "Upload the private solution CSV for a competition you host"
+    command_competitions_solution_status = "Show the setup status for a competition's solution file"
     command_competitions_launch = "Launch a competition you host, optionally at a future UTC time"
     command_competitions_init = "Initialize folder with a competition-metadata.json template"
     command_competitions_create = "Create a new competition from competition-metadata.json"

--- a/tests/unit/test_cli_competitions.py
+++ b/tests/unit/test_cli_competitions.py
@@ -424,6 +424,41 @@ def test_competitions_settings_update_succeeds(parser):
     assert kwargs["json_output"] is True
 
 
+def test_competitions_solution_create_missing_path_fails(parser):
+    with pytest.raises(SystemExit):
+        parser.dispatch(["competitions", "solution", "create", "my-comp"])
+
+
+def test_competitions_solution_create_succeeds(parser):
+    func, kwargs = parser.dispatch(["competitions", "solution", "create", "my-comp", "-p", "/tmp/sol.csv", "-q"])
+    assert func.__name__ == "competition_create_solution_cli"
+    assert kwargs["competition"] == "my-comp"
+    assert kwargs["path"] == "/tmp/sol.csv"
+    assert kwargs["quiet"] is True
+
+
+def test_competitions_solution_create_with_dash_c_succeeds(parser):
+    func, kwargs = parser.dispatch(["competitions", "solution", "create", "-c", "my-comp", "-p", "/tmp/sol.csv"])
+    assert func.__name__ == "competition_create_solution_cli"
+    assert kwargs["competition"] is None
+    assert kwargs["competition_opt"] == "my-comp"
+    assert kwargs["path"] == "/tmp/sol.csv"
+
+
+def test_competitions_solution_status_succeeds(parser):
+    func, kwargs = parser.dispatch(["competitions", "solution", "status", "my-comp", "--json"])
+    assert func.__name__ == "competition_get_solution_status_cli"
+    assert kwargs["competition"] == "my-comp"
+    assert kwargs["json_output"] is True
+
+
+def test_competitions_solution_status_default_no_json_succeeds(parser):
+    func, kwargs = parser.dispatch(["competitions", "solution", "status", "my-comp"])
+    assert func.__name__ == "competition_get_solution_status_cli"
+    assert kwargs["competition"] == "my-comp"
+    assert kwargs["json_output"] is False
+
+
 def test_competitions_launch_parser_default_succeeds(parser):
     func, kwargs = parser.dispatch(["competitions", "launch", "my-comp"])
     assert func.__name__ == "competition_launch_cli"

--- a/tests/unit/test_competition_create_solution.py
+++ b/tests/unit/test_competition_create_solution.py
@@ -72,8 +72,12 @@ class TestCompetitionCreateSolution(unittest.TestCase):
         self.assertIn("upload failed", str(ctx.exception))
 
     def test_missing_path_raises(self):
-        with self.assertRaises(ValueError):
+        # Empty string flows into os.path.exists("") -> False, so we surface the
+        # Invalid-path error. (Argparse's required=True catches this at the CLI
+        # boundary; the guard here is for direct Python callers.)
+        with self.assertRaises(ValueError) as ctx:
             self.api.competition_create_solution(competition_name="my-comp", path="")
+        self.assertIn("Invalid path", str(ctx.exception))
 
     def test_directory_path_raises(self):
         with self.assertRaises(ValueError) as ctx:

--- a/tests/unit/test_competition_create_solution.py
+++ b/tests/unit/test_competition_create_solution.py
@@ -44,17 +44,18 @@ class TestCompetitionCreateSolution(unittest.TestCase):
 
     @patch.object(KaggleApi, "_upload_file")
     @patch.object(KaggleApi, "build_kaggle_client")
-    def test_uploads_file_via_inbox_and_sends_token(self, mock_client, mock_upload):
+    def test_uploads_file_via_competition_solution_bucket_and_sends_token(self, mock_client, mock_upload):
         mock_upload.return_value = _mock_upload_file("blob-tok-1")
         mock_kaggle = self._patch_client(mock_client)
 
         self.api.competition_create_solution(competition_name="my-comp", path=self.solution_path)
 
-        # _upload_file called with basename, full path, ApiBlobType.INBOX
+        # _upload_file called with basename, full path, ApiBlobType.COMPETITION_SOLUTION
+        # (avoids the generic InboxFiles bucket so the source blob doesn't linger).
         args, _ = mock_upload.call_args
         self.assertEqual(args[0], "solution.csv")
         self.assertEqual(args[1], self.solution_path)
-        self.assertEqual(args[2], ApiBlobType.INBOX)
+        self.assertEqual(args[2], ApiBlobType.COMPETITION_SOLUTION)
 
         # The blob token flows through to CreateCompetitionSolution
         request = mock_kaggle.competitions.competition_api_client.create_competition_solution.call_args[0][0]

--- a/tests/unit/test_competition_create_solution.py
+++ b/tests/unit/test_competition_create_solution.py
@@ -1,0 +1,120 @@
+# coding=utf-8
+import io
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, "../..")
+
+from kaggle.api.kaggle_api_extended import KaggleApi
+from kagglesdk.blobs.types.blob_api_service import ApiBlobType
+
+
+def _mock_upload_file(token):
+    uf = MagicMock()
+    uf.token = token
+    return uf
+
+
+class TestCompetitionCreateSolution(unittest.TestCase):
+    """Tests for competition_create_solution and its CLI wrapper."""
+
+    def setUp(self):
+        self.api = KaggleApi.__new__(KaggleApi)
+        self.api.config_values = {}
+        self.tmp = tempfile.mkdtemp()
+        self.solution_path = os.path.join(self.tmp, "solution.csv")
+        with open(self.solution_path, "w") as f:
+            f.write("id,target\n1,0\n2,1\n")
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _patch_client(self, mock_client):
+        mock_kaggle = MagicMock()
+        mock_kaggle.competitions.competition_api_client.create_competition_solution.return_value = None
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+        return mock_kaggle
+
+    @patch.object(KaggleApi, "_upload_file")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_uploads_file_via_inbox_and_sends_token(self, mock_client, mock_upload):
+        mock_upload.return_value = _mock_upload_file("blob-tok-1")
+        mock_kaggle = self._patch_client(mock_client)
+
+        self.api.competition_create_solution(competition_name="my-comp", path=self.solution_path)
+
+        # _upload_file called with basename, full path, ApiBlobType.INBOX
+        args, _ = mock_upload.call_args
+        self.assertEqual(args[0], "solution.csv")
+        self.assertEqual(args[1], self.solution_path)
+        self.assertEqual(args[2], ApiBlobType.INBOX)
+
+        # The blob token flows through to CreateCompetitionSolution
+        request = mock_kaggle.competitions.competition_api_client.create_competition_solution.call_args[0][0]
+        self.assertEqual(request.competition_name, "my-comp")
+        self.assertEqual(request.blob_token, "blob-tok-1")
+
+    @patch.object(KaggleApi, "_upload_file")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_upload_failure_raises(self, mock_client, mock_upload):
+        mock_upload.return_value = None
+        self._patch_client(mock_client)
+
+        with self.assertRaises(ValueError) as ctx:
+            self.api.competition_create_solution(competition_name="my-comp", path=self.solution_path)
+        self.assertIn("upload failed", str(ctx.exception))
+
+    def test_missing_path_raises(self):
+        with self.assertRaises(ValueError):
+            self.api.competition_create_solution(competition_name="my-comp", path="")
+
+    def test_directory_path_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.api.competition_create_solution(competition_name="my-comp", path=self.tmp)
+        self.assertIn("single CSV file", str(ctx.exception))
+
+    def test_nonexistent_path_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.api.competition_create_solution(
+                competition_name="my-comp", path=os.path.join(self.tmp, "does-not-exist.csv")
+            )
+        self.assertIn("Invalid path", str(ctx.exception))
+
+    @patch.object(KaggleApi, "competition_create_solution")
+    def test_cli_positional_competition(self, mock_create):
+        with redirect_stdout(io.StringIO()):
+            self.api.competition_create_solution_cli(competition="my-comp", path=self.solution_path)
+        mock_create.assert_called_once_with(competition_name="my-comp", path=self.solution_path, quiet=False)
+
+    @patch.object(KaggleApi, "competition_create_solution")
+    def test_cli_dash_c_option(self, mock_create):
+        with redirect_stdout(io.StringIO()):
+            self.api.competition_create_solution_cli(competition_opt="my-comp", path=self.solution_path)
+        mock_create.assert_called_once_with(competition_name="my-comp", path=self.solution_path, quiet=False)
+
+    @patch.object(KaggleApi, "competition_create_solution")
+    def test_cli_falls_back_to_config(self, mock_create):
+        self.api.config_values = {self.api.CONFIG_NAME_COMPETITION: "from-config"}
+        with redirect_stdout(io.StringIO()):
+            self.api.competition_create_solution_cli(path=self.solution_path)
+        mock_create.assert_called_once_with(competition_name="from-config", path=self.solution_path, quiet=False)
+
+    def test_cli_missing_competition_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.api.competition_create_solution_cli(path=self.solution_path)
+        self.assertIn("No competition specified", str(ctx.exception))
+
+    def test_cli_missing_path_raises(self):
+        with self.assertRaises(ValueError):
+            self.api.competition_create_solution_cli(competition="my-comp")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_competition_solution_status.py
+++ b/tests/unit/test_competition_solution_status.py
@@ -1,0 +1,164 @@
+# coding=utf-8
+import io
+import json
+import sys
+import unittest
+from contextlib import redirect_stdout
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, "../..")
+
+from kaggle.api.kaggle_api_extended import KaggleApi
+from kagglesdk.competitions.types.competition_api_service import (
+    ApiCompetitionSolutionStatus,
+    ApiMetricColumn,
+    ApiSolutionFileInfo,
+)
+
+
+def _make_status(**overrides) -> ApiCompetitionSolutionStatus:
+    status = ApiCompetitionSolutionStatus()
+    for name, value in overrides.items():
+        setattr(status, name, value)
+    return status
+
+
+class TestCompetitionSolutionStatus(unittest.TestCase):
+    """Tests for competition_get_solution_status and its CLI wrapper."""
+
+    def setUp(self):
+        self.api = KaggleApi.__new__(KaggleApi)
+        self.api.config_values = {}
+
+    def _patch_client(self, mock_client, status=None):
+        mock_kaggle = MagicMock()
+        mock_kaggle.competitions.competition_api_client.get_competition_solution_status.return_value = (
+            status if status is not None else _make_status()
+        )
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+        return mock_kaggle
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_get_status_builds_request_with_competition_name(self, mock_client):
+        mock_kaggle = self._patch_client(mock_client, _make_status(ready=True))
+
+        result = self.api.competition_get_solution_status("my-comp")
+
+        request = mock_kaggle.competitions.competition_api_client.get_competition_solution_status.call_args[0][0]
+        self.assertEqual(request.competition_name, "my-comp")
+        self.assertTrue(result.ready)
+
+    @patch.object(KaggleApi, "competition_get_solution_status")
+    def test_cli_positional_competition(self, mock_get):
+        mock_get.return_value = _make_status(ready=True)
+        with redirect_stdout(io.StringIO()):
+            self.api.competition_get_solution_status_cli(competition="my-comp")
+        mock_get.assert_called_once_with("my-comp")
+
+    @patch.object(KaggleApi, "competition_get_solution_status")
+    def test_cli_dash_c_option(self, mock_get):
+        mock_get.return_value = _make_status()
+        with redirect_stdout(io.StringIO()):
+            self.api.competition_get_solution_status_cli(competition_opt="my-comp")
+        mock_get.assert_called_once_with("my-comp")
+
+    @patch.object(KaggleApi, "competition_get_solution_status")
+    def test_cli_falls_back_to_config(self, mock_get):
+        mock_get.return_value = _make_status()
+        self.api.config_values = {self.api.CONFIG_NAME_COMPETITION: "from-config"}
+        with redirect_stdout(io.StringIO()):
+            self.api.competition_get_solution_status_cli()
+        mock_get.assert_called_once_with("from-config")
+
+    def test_cli_missing_competition_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.api.competition_get_solution_status_cli()
+        self.assertIn("No competition specified", str(ctx.exception))
+
+    @patch.object(KaggleApi, "competition_get_solution_status")
+    def test_cli_json_output_emits_valid_json(self, mock_get):
+        mock_get.return_value = _make_status(ready=True, setup_error="bad column")
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            self.api.competition_get_solution_status_cli(competition="my-comp", json_output=True)
+        payload = json.loads(buf.getvalue())
+        self.assertTrue(payload["ready"])
+        self.assertEqual(payload["setupError"], "bad column")
+
+    @patch.object(KaggleApi, "competition_get_solution_status")
+    def test_cli_human_view_shows_ready_false_by_default(self, mock_get):
+        mock_get.return_value = _make_status()
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            self.api.competition_get_solution_status_cli(competition="my-comp")
+        self.assertIn("Ready: false", buf.getvalue())
+
+    @patch.object(KaggleApi, "competition_get_solution_status")
+    def test_cli_human_view_surfaces_setup_error(self, mock_get):
+        mock_get.return_value = _make_status(setup_error="missing header row")
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            self.api.competition_get_solution_status_cli(competition="my-comp")
+        out = buf.getvalue()
+        self.assertIn("Setup error: missing header row", out)
+
+    @patch.object(KaggleApi, "competition_get_solution_status")
+    def test_cli_human_view_prints_kernels_and_row_id(self, mock_get):
+        mock_get.return_value = _make_status(
+            ready=True,
+            kernels_metric=True,
+            row_id_column_name="row_id",
+        )
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            self.api.competition_get_solution_status_cli(competition="my-comp")
+        out = buf.getvalue()
+        self.assertIn("Ready: true", out)
+        self.assertIn("Kernels metric: true", out)
+        self.assertIn("Row ID column: row_id", out)
+
+    @patch.object(KaggleApi, "competition_get_solution_status")
+    def test_cli_human_view_prints_column_mapping_and_required_columns(self, mock_get):
+        col = ApiMetricColumn()
+        col.name = "target"
+        col.data_type = "Double"
+        status = _make_status(required_metric_columns=[col])
+        # column_mapping setter in the SDK has a validation bug; assign the
+        # private attribute directly to sidestep it.
+        object.__setattr__(status, "_column_mapping", {"target": "y"})
+        mock_get.return_value = status
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            self.api.competition_get_solution_status_cli(competition="my-comp")
+        out = buf.getvalue()
+        self.assertIn("Column mapping:", out)
+        self.assertIn("target -> y", out)
+        self.assertIn("Required columns:", out)
+        self.assertIn("target (Double)", out)
+
+    @patch.object(KaggleApi, "competition_get_solution_status")
+    def test_cli_human_view_prints_solution_info(self, mock_get):
+        info = ApiSolutionFileInfo()
+        info.file_name = "solution.csv"
+        info.file_size_bytes = 1234
+        info.upload_date = datetime(2026, 7, 21, 12, 0, tzinfo=timezone.utc)
+        info.total_rows = 100
+        info.public_rows = 30
+        info.private_rows = 70
+        mock_get.return_value = _make_status(ready=True, solution_info=info)
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            self.api.competition_get_solution_status_cli(competition="my-comp")
+        out = buf.getvalue()
+        self.assertIn("solution.csv", out)
+        self.assertIn("uploaded 2026-07-21T12:00:00+00:00", out)
+        self.assertIn("total=100", out)
+        self.assertIn("public=30", out)
+        self.assertIn("private=70", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_competition_solution_status.py
+++ b/tests/unit/test_competition_solution_status.py
@@ -97,11 +97,15 @@ class TestCompetitionSolutionStatus(unittest.TestCase):
 
     @patch.object(KaggleApi, "competition_get_solution_status")
     def test_cli_human_view_surfaces_setup_error(self, mock_get):
-        mock_get.return_value = _make_status(setup_error="missing header row")
+        # Even if the server also reports ready=True, a setup_error must flip
+        # the Ready line so polling scripts eyeballing the first line stop.
+        mock_get.return_value = _make_status(ready=True, setup_error="missing header row")
         buf = io.StringIO()
         with redirect_stdout(buf):
             self.api.competition_get_solution_status_cli(competition="my-comp")
         out = buf.getvalue()
+        self.assertIn("Ready: false (setup failed)", out)
+        self.assertNotIn("Ready: true", out)
         self.assertIn("Setup error: missing header row", out)
 
     @patch.object(KaggleApi, "competition_get_solution_status")
@@ -158,6 +162,23 @@ class TestCompetitionSolutionStatus(unittest.TestCase):
         self.assertIn("total=100", out)
         self.assertIn("public=30", out)
         self.assertIn("private=70", out)
+
+    @patch.object(KaggleApi, "competition_get_solution_status")
+    def test_cli_human_view_skips_bare_solution_file_label(self, mock_get):
+        # If the server ever returns solution_info populated only with
+        # row-count fields (partial preprocessing state), we should suppress
+        # the "Solution file:" header entirely rather than print a bare label.
+        info = ApiSolutionFileInfo()
+        info.total_rows = 100
+        info.public_rows = 30
+        info.private_rows = 70
+        mock_get.return_value = _make_status(ready=True, solution_info=info)
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            self.api.competition_get_solution_status_cli(competition="my-comp")
+        out = buf.getvalue()
+        self.assertNotIn("Solution file:", out)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -14,7 +14,6 @@ class TestHttpClient(unittest.TestCase):
             creds = _get_apikey_creds()
             self.assertIsNone(creds)
 
-    @unittest.expectedFailure  # needs kagglesdk >= 0.1.35
     @patch("os.path.exists")
     def test_get_apikey_creds_invalid_json(self, mock_exists):
         mock_exists.return_value = True


### PR DESCRIPTION
Wire the recently-added CreateCompetitionSolution and GetCompetitionSolutionStatus endpoints (kaggle-sdk-python 0.1.34) so hosts can finish standing up a competition from the CLI: upload the private solution CSV and poll preprocessing/scoring status.

Solution uploads go through the public blob-upload pipeline with ApiBlobType.INBOX -- CreateCompetitionSolutionHandler reads the token via GetBlobFromInboxTokenAsync (verified against kaggle-azure).