### PR TITLE
fix(cli): prevent stale file corruption when resuming downloads

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -5469,10 +5469,75 @@ class KaggleApi:
         else:
             print("Dataset creation error: " + result.error)
 
+    def _resume_marker_path(self, outfile):
+        """Path of the sidecar file that records the identity of an in-progress download."""
+        return outfile + ".kaggle-partial"
+
+    def _read_resume_marker(self, outfile):
+        """Return the persisted resume marker dict for ``outfile``, or None if absent/invalid."""
+        try:
+            with open(self._resume_marker_path(outfile), "r") as marker:
+                data = json.load(marker)
+            return data if isinstance(data, dict) else None
+        except (OSError, ValueError):
+            return None
+
+    def _write_resume_marker(self, outfile, validator, size):
+        """Persist the current object's identity next to a partially-downloaded file.
+
+        Without an identity token (``validator``) a future run cannot prove the
+        partial belongs to the current object, so no marker is written (and any
+        stale one is removed) to keep cross-invocation resume disabled.
+        """
+        if validator is None:
+            self._clear_resume_marker(outfile)
+            return
+        try:
+            with open(self._resume_marker_path(outfile), "w") as marker:
+                json.dump({"validator": validator, "size": size}, marker)
+        except OSError:
+            pass  # Best effort: at worst we simply cannot resume this file later.
+
+    def _clear_resume_marker(self, outfile):
+        """Remove the resume marker for ``outfile`` if present."""
+        try:
+            os.remove(self._resume_marker_path(outfile))
+        except OSError:
+            pass
+
+    def _can_resume_partial(self, outfile, resume, resumable, validator, size):
+        """Whether an existing local file is a verified partial of the current object.
+
+        Returns True only when appending to ``outfile`` is provably safe: resume
+        was requested, the server supports ranges, we have an identity token, and
+        a persisted marker matches that token (and the expected total size) while
+        the local file is strictly shorter than the remote object.
+        """
+        if not (resume and resumable) or validator is None:
+            return False
+        if not os.path.isfile(outfile):
+            return False
+        marker = self._read_resume_marker(outfile)
+        if not marker or marker.get("validator") != validator:
+            return False
+        if size is not None and marker.get("size") != size:
+            return False
+        part_size = os.path.getsize(outfile)
+        if size is not None:
+            return 0 < part_size < size
+        return part_size > 0
+
     def download_file(
         self, response, outfile, http_client, quiet=True, resume=False, chunk_size=1048576, max_retries=5, timeout=300
     ):
         """Downloads a file to an output file, streaming in chunks with automatic retry on failure.
+
+        A resume (HTTP Range request appended to the existing file) is only performed
+        when the local bytes are proven to belong to the current remote object: either
+        because it is an in-process retry of the same download, or because a persisted
+        ``.kaggle-partial`` marker records a matching identity token (ETag/Last-Modified)
+        and total size. This prevents silently corrupting or keeping a stale file when
+        the remote object has changed between runs.
 
         Args:
             response: The response object to download.
@@ -5502,6 +5567,12 @@ class KaggleApi:
         # Check if file is resumable
         resumable = "Accept-Ranges" in response.headers and response.headers["Accept-Ranges"] == "bytes"
 
+        # Identity token used to prove a local partial belongs to the *current*
+        # remote object before we resume (append) onto it. Prefer the strong
+        # ETag; fall back to Last-Modified. May be None if the server sends
+        # neither, in which case cross-invocation resume is disabled.
+        resume_validator = response.headers.get("ETag") or last_modified
+
         # Retry loop for handling network errors
         retry_count = 0
         download_url = response.url
@@ -5517,12 +5588,28 @@ class KaggleApi:
                 # Check file existence inside loop (may be created during retry)
                 file_exists = os.path.isfile(outfile)
 
-                # Determine starting position
-                if retry_count > 0 or (resume and resumable and file_exists):
+                # Decide whether to resume an existing file or start fresh.
+                #
+                # Appending only makes sense when the bytes already on disk belong
+                # to the *same* remote object we are fetching now. We allow that
+                # only for an in-process retry (same download session) or when a
+                # persisted resume marker proves the local partial was written for
+                # the current object. Otherwise a stale file from an older/newer
+                # version would be silently corrupted (remote grew) or kept as-is
+                # (remote shrank). See the method docstring.
+                resume_from_partial = retry_count == 0 and self._can_resume_partial(
+                    outfile, resume, resumable, resume_validator, size
+                )
+
+                if retry_count > 0 or resume_from_partial:
                     size_read = os.path.getsize(outfile) if file_exists else 0
                     open_mode = "ab"
 
-                    if size is not None and size_read >= size:
+                    if size is not None and size_read == size:
+                        # Every byte is already present (e.g. a retry that had in
+                        # fact completed). Finalize instead of re-downloading.
+                        os.utime(outfile, times=(remote_date_timestamp, remote_date_timestamp))
+                        self._clear_resume_marker(outfile)
                         if not quiet:
                             print("File already downloaded completely.")
                         return
@@ -5537,9 +5624,14 @@ class KaggleApi:
                         else:
                             print(f"Resuming from {size_read} bytes{remaining}...")
 
-                    # Request with Range header for resume, preserving authentication
+                    # Request with Range header for resume, preserving authentication.
+                    # If-Range asks the server to return the full object (200) instead
+                    # of a partial (206) if it changed underneath us, so we never
+                    # append across a version boundary.
                     retry_headers = original_headers.copy()
                     retry_headers["Range"] = f"bytes={size_read}-"
+                    if resume_validator is not None:
+                        retry_headers["If-Range"] = resume_validator
                     response = requests.request(
                         original_method,
                         download_url,
@@ -5547,9 +5639,35 @@ class KaggleApi:
                         stream=True,
                         timeout=timeout,
                     )
+
+                    if response.status_code == 206:
+                        pass  # Partial content: safe to append from size_read.
+                    elif response.status_code == 200:
+                        # Range ignored or object changed (If-Range miss): the body
+                        # is the whole current object, so overwrite from scratch.
+                        size_read = 0
+                        open_mode = "wb"
+                        self._write_resume_marker(outfile, resume_validator, size)
+                    else:
+                        # e.g. 416 Range Not Satisfiable (local file >= remote size).
+                        # Discard the stale bytes and re-request the full object.
+                        response.close()
+                        response = requests.request(
+                            original_method,
+                            download_url,
+                            headers=original_headers,
+                            stream=True,
+                            timeout=timeout,
+                        )
+                        size_read = 0
+                        open_mode = "wb"
+                        self._write_resume_marker(outfile, resume_validator, size)
                 else:
                     size_read = 0
                     open_mode = "wb"
+                    # Persist object identity up front so a later invocation can
+                    # safely resume this file if the download is interrupted.
+                    self._write_resume_marker(outfile, resume_validator, size)
 
                     if not quiet:
                         print("Downloading " + os.path.basename(outfile) + " to " + outpath)
@@ -5592,6 +5710,10 @@ class KaggleApi:
                         if not quiet:
                             print(f"\n{error_msg}")
                         raise ValueError(error_msg)
+
+                # Completed and verified: drop the resume marker so this file is
+                # never treated as a resumable partial on a future run.
+                self._clear_resume_marker(outfile)
 
                 # Success - exit retry loop
                 break

--- a/tests/unit/test_benchmarks_cli.py
+++ b/tests/unit/test_benchmarks_cli.py
@@ -1794,6 +1794,7 @@ class TestDownloadFile:
                 "Content-Range": f"bytes={len(content1)}-{total_size-1}/{total_size}",
             },
         )
+        retry_resp.status_code = 206  # real range responses return 206 Partial Content
 
         outfile = str(tmp_path / "retry_out.bin")
 
@@ -1824,6 +1825,9 @@ class TestDownloadFile:
         os.makedirs(os.path.dirname(outfile), exist_ok=True)
         with open(outfile, "wb") as f:
             f.write(content_existing)
+        # Cross-invocation resume now requires a marker proving the local partial
+        # belongs to the current object (validator = Last-Modified here, no ETag).
+        api._write_resume_marker(outfile, "Mon, 01 Jan 2024 00:00:00 GMT", total_size)
 
         resp = self._make_response(headers={"Content-Length": str(total_size), "Accept-Ranges": "bytes"})
         resp.request.headers = {"Authorization": "Bearer token"}
@@ -1835,6 +1839,7 @@ class TestDownloadFile:
                 "Content-Range": f"bytes={len(content_existing)}-{total_size-1}/{total_size}",
             },
         )
+        resume_resp.status_code = 206  # real range responses return 206 Partial Content
 
         with patch("requests.request", return_value=resume_resp) as mock_request:
             api.download_file(resp, outfile, MagicMock(), resume=True, quiet=True)

--- a/tests/unit/test_download_resume.py
+++ b/tests/unit/test_download_resume.py
@@ -1,0 +1,313 @@
+# coding=utf-8
+"""Regression tests for safe download resume in ``KaggleApi.download_file``.
+
+These guard against the object-identity resume bug where a stale local file
+from a *different* version of a remote object was blindly appended to (remote
+grew -> silent corruption) or kept as-is (remote shrank -> silent staleness),
+because resume was gated only on file size with no identity check.
+
+The tests drive ``download_file`` against a real in-process HTTP server that
+behaves like GCS-backed Kaggle downloads: it advertises ``Accept-Ranges: bytes``
+and honours both ``Range`` and ``If-Range``.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from unittest.mock import patch
+
+sys.path.insert(0, "../..")
+
+import requests
+
+from kaggle.api.kaggle_api_extended import KaggleApi
+
+
+class _Origin:
+    """Mutable remote-object state shared with the request handler."""
+
+    def __init__(self, blob=b"", etag=None, last_modified="Wed, 01 Jan 2025 00:00:00 GMT"):
+        self.blob = blob
+        self.etag = etag
+        self.last_modified = last_modified
+        self.range_requests = 0  # how many GETs carried a Range header
+        self.if_range_seen = []  # If-Range values observed
+
+
+def _make_handler(origin):
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *a):
+            pass
+
+        def _common_headers(self):
+            self.send_header("Accept-Ranges", "bytes")
+            if origin.etag is not None:
+                self.send_header("ETag", origin.etag)
+            self.send_header("Last-Modified", origin.last_modified)
+
+        def do_GET(self):
+            blob = origin.blob
+            total = len(blob)
+            rng = self.headers.get("Range")
+            if_range = self.headers.get("If-Range")
+
+            if rng and rng.startswith("bytes="):
+                origin.range_requests += 1
+                origin.if_range_seen.append(if_range)
+                start = int(rng[len("bytes=") :].split("-")[0])
+
+                # If-Range miss (object changed): serve the whole current object.
+                validators = {v for v in (origin.etag, origin.last_modified) if v}
+                if if_range is not None and if_range not in validators:
+                    self._send_full(blob)
+                    return
+
+                if start >= total:
+                    self.send_response(416)
+                    self.send_header("Content-Range", f"bytes */{total}")
+                    self.end_headers()
+                    return
+
+                body = blob[start:]
+                self.send_response(206)
+                self._common_headers()
+                self.send_header("Content-Range", f"bytes {start}-{total - 1}/{total}")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+            else:
+                self._send_full(blob)
+
+        def _send_full(self, blob):
+            self.send_response(200)
+            self._common_headers()
+            self.send_header("Content-Length", str(len(blob)))
+            self.end_headers()
+            self.wfile.write(blob)
+
+    return Handler
+
+
+class _FailingResponse:
+    """A stand-in initial response whose body dies mid-stream (network error)."""
+
+    def __init__(self, url, headers, fail_after):
+        self.url = url
+        self.headers = headers
+        self.status_code = 200
+        self._fail_after = fail_after
+        self.request = type("R", (), {"method": "GET", "headers": {}})()
+
+    def iter_content(self, chunk_size):
+        blob = self.headers["_blob"]
+        yield blob[: self._fail_after]
+        raise requests.exceptions.ConnectionError("simulated mid-stream failure")
+
+
+class DownloadResumeTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.origin = _Origin()
+        cls.server = ThreadingHTTPServer(("127.0.0.1", 0), _make_handler(cls.origin))
+        cls.port = cls.server.server_address[1]
+        cls.thread = threading.Thread(target=cls.server.serve_forever, daemon=True)
+        cls.thread.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+        cls.server.server_close()
+
+    def setUp(self):
+        self.api = KaggleApi.__new__(KaggleApi)
+        self.tmpdir = tempfile.mkdtemp()
+        self.outfile = os.path.join(self.tmpdir, "data.bin")
+        # reset shared origin counters
+        self.origin.range_requests = 0
+        self.origin.if_range_seen = []
+
+    @property
+    def url(self):
+        return f"http://127.0.0.1:{self.port}/data.bin"
+
+    def _set_remote(self, blob, etag='"v1"'):
+        self.origin.blob = blob
+        self.origin.etag = etag
+
+    def _seed_file(self, data):
+        with open(self.outfile, "wb") as f:
+            f.write(data)
+
+    def _seed_marker(self, validator, size):
+        with open(self.api._resume_marker_path(self.outfile), "w") as f:
+            json.dump({"validator": validator, "size": size}, f)
+
+    def _run(self, resume=True):
+        resp = requests.get(self.url, stream=True)
+        self.api.download_file(resp, self.outfile, http_client=None, quiet=True, resume=resume)
+        with open(self.outfile, "rb") as f:
+            return f.read()
+
+    def _marker_exists(self):
+        return os.path.isfile(self.api._resume_marker_path(self.outfile))
+
+    # --- The two reported scenarios ------------------------------------------
+
+    def test_remote_grew_does_not_corrupt_stale_complete_file(self):
+        """Remote grew 100->150; a stale complete file with no marker must be
+        fully re-downloaded, never appended to."""
+        self._set_remote(b"B" * 150)
+        self._seed_file(b"A" * 100)  # stale, no marker
+        result = self._run()
+        self.assertEqual(result, b"B" * 150)
+        self.assertEqual(self.origin.range_requests, 0)  # no resume attempted
+        self.assertFalse(self._marker_exists())
+
+    def test_remote_shrank_does_not_keep_stale_file(self):
+        """Remote shrank 100->80; a stale larger file with no marker must be
+        replaced by the new content, not kept."""
+        self._set_remote(b"B" * 80)
+        self._seed_file(b"A" * 100)  # stale, no marker
+        result = self._run()
+        self.assertEqual(result, b"B" * 80)
+        self.assertFalse(self._marker_exists())
+
+    # --- Legitimate resume is preserved --------------------------------------
+
+    def test_genuine_resume_appends_with_matching_marker(self):
+        """A real interrupted partial (with a matching marker) is resumed via a
+        Range request, appending only the missing tail."""
+        blob = b"B" * 150
+        self._set_remote(blob, etag='"v1"')
+        self._seed_file(blob[:60])
+        self._seed_marker('"v1"', 150)
+        result = self._run()
+        self.assertEqual(result, blob)
+        self.assertEqual(self.origin.range_requests, 1)  # resume happened
+        self.assertEqual(self.origin.if_range_seen, ['"v1"'])
+        self.assertFalse(self._marker_exists())  # cleared on success
+
+    def test_partial_with_mismatched_marker_restarts(self):
+        """A partial whose marker identifies a *different* object is discarded
+        and restarted rather than appended to."""
+        self._set_remote(b"B" * 150, etag='"v2"')
+        self._seed_file(b"A" * 60)  # bytes from an old object
+        self._seed_marker('"v1"', 150)  # marker for the OLD object
+        result = self._run()
+        self.assertEqual(result, b"B" * 150)
+        self.assertEqual(self.origin.range_requests, 0)  # no unsafe append
+        self.assertFalse(self._marker_exists())
+
+    def test_if_range_miss_falls_back_to_overwrite(self):
+        """Marker matches the initial response, but the object changes before the
+        Range request; If-Range triggers a 200 and we overwrite instead of append."""
+        self._set_remote(b"B" * 150, etag='"v1"')
+        self._seed_file(b"B" * 60)
+        self._seed_marker('"v1"', 150)
+        resp = requests.get(self.url, stream=True)  # captures etag "v1", size 150
+        # Object changes (same size, new content + etag) before the resume request.
+        self._set_remote(b"C" * 150, etag='"v2"')
+        self.api.download_file(resp, self.outfile, http_client=None, quiet=True, resume=True)
+        with open(self.outfile, "rb") as f:
+            result = f.read()
+        self.assertEqual(result, b"C" * 150)  # overwritten, not "BBB...CCC"
+        self.assertFalse(self._marker_exists())
+
+    def test_fresh_download_writes_and_clears_marker(self):
+        self._set_remote(b"B" * 120)
+        result = self._run()
+        self.assertEqual(result, b"B" * 120)
+        self.assertFalse(self._marker_exists())
+
+    def test_no_resume_when_resume_false(self):
+        """resume=False (i.e. --force) always downloads fresh, ignoring markers."""
+        self._set_remote(b"B" * 150, etag='"v1"')
+        self._seed_file(b"B" * 60)
+        self._seed_marker('"v1"', 150)
+        result = self._run(resume=False)
+        self.assertEqual(result, b"B" * 150)
+        self.assertEqual(self.origin.range_requests, 0)
+
+    def test_in_process_retry_resumes(self):
+        """A mid-stream network failure resumes from the bytes already written,
+        within the same call, using If-Range."""
+        blob = b"B" * 150
+        self._set_remote(blob, etag='"v1"')
+        headers = {
+            "Accept-Ranges": "bytes",
+            "Content-Length": "150",
+            "ETag": '"v1"',
+            "Last-Modified": "Wed, 01 Jan 2025 00:00:00 GMT",
+            "_blob": blob,
+        }
+        failing = _FailingResponse(self.url, headers, fail_after=60)
+        with patch("kaggle.api.kaggle_api_extended.time.sleep"):
+            self.api.download_file(failing, self.outfile, http_client=None, quiet=True, resume=True)
+        with open(self.outfile, "rb") as f:
+            result = f.read()
+        self.assertEqual(result, blob)
+        self.assertEqual(self.origin.range_requests, 1)  # resumed after failure
+        self.assertFalse(self._marker_exists())
+
+
+class CanResumePartialUnitTest(unittest.TestCase):
+    """Fast, server-free unit tests for the resume-eligibility predicate."""
+
+    def setUp(self):
+        self.api = KaggleApi.__new__(KaggleApi)
+        self.tmpdir = tempfile.mkdtemp()
+        self.outfile = os.path.join(self.tmpdir, "data.bin")
+
+    def _seed(self, data, marker=None):
+        with open(self.outfile, "wb") as f:
+            f.write(data)
+        if marker is not None:
+            with open(self.api._resume_marker_path(self.outfile), "w") as f:
+                json.dump(marker, f)
+
+    def test_true_when_marker_matches_and_partial_shorter(self):
+        self._seed(b"x" * 60, {"validator": '"v1"', "size": 150})
+        self.assertTrue(self.api._can_resume_partial(self.outfile, True, True, '"v1"', 150))
+
+    def test_false_without_resume(self):
+        self._seed(b"x" * 60, {"validator": '"v1"', "size": 150})
+        self.assertFalse(self.api._can_resume_partial(self.outfile, False, True, '"v1"', 150))
+
+    def test_false_without_range_support(self):
+        self._seed(b"x" * 60, {"validator": '"v1"', "size": 150})
+        self.assertFalse(self.api._can_resume_partial(self.outfile, True, False, '"v1"', 150))
+
+    def test_false_without_validator(self):
+        self._seed(b"x" * 60, {"validator": '"v1"', "size": 150})
+        self.assertFalse(self.api._can_resume_partial(self.outfile, True, True, None, 150))
+
+    def test_false_when_no_marker(self):
+        self._seed(b"x" * 60)  # no marker
+        self.assertFalse(self.api._can_resume_partial(self.outfile, True, True, '"v1"', 150))
+
+    def test_false_on_validator_mismatch(self):
+        self._seed(b"x" * 60, {"validator": '"v1"', "size": 150})
+        self.assertFalse(self.api._can_resume_partial(self.outfile, True, True, '"v2"', 150))
+
+    def test_false_on_size_mismatch(self):
+        self._seed(b"x" * 60, {"validator": '"v1"', "size": 150})
+        self.assertFalse(self.api._can_resume_partial(self.outfile, True, True, '"v1"', 200))
+
+    def test_false_when_partial_not_shorter(self):
+        self._seed(b"x" * 150, {"validator": '"v1"', "size": 150})
+        self.assertFalse(self.api._can_resume_partial(self.outfile, True, True, '"v1"', 150))
+
+    def test_false_when_file_missing(self):
+        self.assertFalse(self.api._can_resume_partial(self.outfile, True, True, '"v1"', 150))
+
+    def test_write_skips_marker_without_validator(self):
+        self.api._write_resume_marker(self.outfile, None, 150)
+        self.assertFalse(os.path.isfile(self.api._resume_marker_path(self.outfile)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary

Fixes a bug where downloading a dataset or competition file without `--force` could silently corrupt or keep stale files when the remote file had changed.

If the remote file grew, the CLI resumed the download by appending the new bytes to the existing local file, resulting in a file containing the old version's prefix and the new version's suffix. Since the final file size still matched the expected `Content-Length`, the corruption went undetected.

If the remote file became smaller, the CLI incorrectly treated the existing larger file as already complete and skipped downloading the new version.

### Root Cause

The resume logic only checked three things before resuming a download:

* `resume=True` (the default when `--force` isn't used)
* the server supports byte ranges (`Accept-Ranges: bytes`)
* the destination file already exists

It never verified whether the existing local file actually belonged to the current remote object. There was no validation using `ETag`, `If-Range`, checksums, or any other object identity mechanism.

As a result, a previously downloaded file from an older version could be treated as a valid partial download of a newer version.

### Solution

This change makes resume safe by validating the remote object's identity before appending to an existing file.

* Added a small `.kaggle-partial` marker that stores the remote object's identity (`ETag`, or `Last-Modified` as a fallback) along with the expected file size.
* Resume is now only allowed when the marker matches the current remote object and the local file is genuinely incomplete.
* Added `If-Range` to resume requests and handled server responses appropriately:

  * `206 Partial Content` → continue appending.
  * `200 OK` → restart the download since the object changed or the range was ignored.
  * `416` (or other unexpected responses) → discard the stale partial and download the file again.
* Completed downloads remove the marker so fully downloaded files are never resumed accidentally.

This preserves legitimate interrupted-download resume while preventing silent corruption and stale downloads.

### Testing

Added a new regression test suite in `tests/unit/test_download_resume.py` covering:

* Remote file grows
* Remote file shrinks
* Normal interrupted download resume
* Fresh downloads
* `--force` downloads
* Marker mismatch handling
* `If-Range` fallback behavior
* Additional edge cases around the resume logic

Also updated the existing `download_file` tests to reflect the new resume behavior.

Ran:

* New regression tests
* Existing `download_file` tests
* Full unit test suite

The new tests pass successfully. The only remaining failures are three unrelated, pre-existing Windows path separator tests in `test_kernels_pull.py`.

### Backward Compatibility

Interrupted downloads can still be resumed normally.

Older partial downloads created before this change (without a marker) are downloaded again once instead of being resumed, avoiding potential corruption.

`--force` behavior remains unchanged, and the normal download path does not introduce any additional API requests.