### PR TITLE
Feat/competition submissions limits

### DIFF
--- a/docs/competition_creation.md
+++ b/docs/competition_creation.md
@@ -331,8 +331,6 @@ Lists the hosts (users with host access) for a competition. Useful for
 confirming who can edit settings, upload data, or launch — especially after
 adding or removing collaborators via the web UI.
 
-Also invocable as `kaggle competitions hosts list`.
-
 **Usage:**
 
 ```bash

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -86,6 +86,8 @@ from kagglesdk.competitions.types.competition_api_service import (
     ApiCreateSubmissionRequest,
     ApiSubmission,
     ApiListSubmissionsRequest,
+    ApiGetSubmissionLimitsRequest,
+    ApiSubmissionLimits,
     ApiListTeamPublicSubmissionsRequest,
     ApiListDataFilesResponse,
     ApiListDataFilesRequest,
@@ -2020,6 +2022,14 @@ class KaggleApi:
                 return ""
             else:
                 raise e
+        if not quiet and competition:
+            # Bonus context: how many submissions are left today. Never fail
+            # the submit over a limits-endpoint blip.
+            try:
+                limits = self.competition_get_submission_limits(competition)
+                print(f"{limits.num_allowed_now} submissions remaining today.")
+            except Exception:
+                pass
         return submit_result.message
 
     def competition_submissions(
@@ -2098,6 +2108,46 @@ class KaggleApi:
                 )
             else:
                 print("No submissions found")
+
+    def competition_get_submission_limits(self, competition_name: str) -> ApiSubmissionLimits:
+        """Fetch the calling user's team's submission counts and remaining allowance.
+
+        Args:
+            competition_name (str): The competition name (slug).
+
+        Returns:
+            ApiSubmissionLimits: with num_today, num_total, num_allowed_now,
+            limited_by_total. All zero if the user is not on a team yet.
+        """
+        with self.build_kaggle_client() as kaggle:
+            request = ApiGetSubmissionLimitsRequest()
+            request.competition_name = competition_name
+            return kaggle.competitions.competition_api_client.get_submission_limits(request)
+
+    def competition_get_submission_limits_cli(
+        self,
+        competition=None,
+        competition_opt=None,
+        json_output=False,
+        quiet=False,
+    ):
+        """CLI wrapper for competition_get_submission_limits."""
+        competition_name = competition or competition_opt
+        if competition_name is None:
+            competition_name = self.get_config_value(self.CONFIG_NAME_COMPETITION)
+            if competition_name is not None and not quiet:
+                print("Using competition: " + competition_name)
+        if competition_name is None:
+            raise ValueError("No competition specified")
+
+        limits = self.competition_get_submission_limits(competition_name)
+        if json_output:
+            self.print_obj(limits)
+        else:
+            print(f"Submissions today: {limits.num_today}")
+            print(f"Lifetime submissions: {limits.num_total}")
+            suffix = " (limited by lifetime cap)" if limits.limited_by_total else ""
+            print(f"Remaining today: {limits.num_allowed_now}{suffix}")
 
     def competition_list_files(
         self, competition: str, page_token: Optional[str] = None, page_size: int = 20

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -903,6 +903,7 @@ class KaggleApi:
     MODEL_METADATA_FILE = "model-metadata.json"
     MODEL_INSTANCE_METADATA_FILE = "model-instance-metadata.json"
     COMPETITION_METADATA_FILE = "competition-metadata.json"
+    COMPETITION_SUBMIT_UPLOAD_FAILED_MESSAGE = "Could not submit to competition"
     MAX_NUM_INBOX_FILES_TO_UPLOAD = 1000
     MAX_UPLOAD_RESUME_ATTEMPTS = 10
 
@@ -1948,7 +1949,7 @@ class KaggleApi:
                     # Actual error is printed during upload_complete. Not
                     # ideal but changing would not be backwards compatible
                     resp = ApiCreateSubmissionResponse()
-                    resp.message = "Could not submit to competition"
+                    resp.message = self.COMPETITION_SUBMIT_UPLOAD_FAILED_MESSAGE
                     return resp
 
                 submit_request = ApiCreateSubmissionRequest()
@@ -2022,9 +2023,12 @@ class KaggleApi:
                 return ""
             else:
                 raise e
-        if not quiet and competition:
+        submit_succeeded = submit_result.message != self.COMPETITION_SUBMIT_UPLOAD_FAILED_MESSAGE
+        if submit_succeeded and not quiet and competition:
             # Bonus context: how many submissions are left today. Never fail
-            # the submit over a limits-endpoint blip.
+            # the submit over a limits-endpoint blip. Skipped on failed
+            # submissions so we don't imply the submission counted when it
+            # didn't.
             try:
                 limits = self.competition_get_submission_limits(competition)
                 print(f"{limits.num_allowed_now} submissions remaining today.")

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -589,11 +589,7 @@ def parse_competitions(subparsers) -> None:
     parser_competitions_pages_delete._action_groups.append(parser_competitions_pages_delete_optional)
     parser_competitions_pages_delete.set_defaults(func=api.competition_delete_page_cli)
 
-    # Competitions hosts (list hosts for a competition). Flat parser — an
-    # earlier version wrapped a `list` subcommand around this, but argparse
-    # can't disambiguate a parent positional (`<competition>`) from a
-    # subcommand token, so `kaggle competitions hosts my-comp` errored. Kept
-    # simple.
+    # Competitions hosts (list hosts for a competition)
     parser_competitions_hosts = subparsers_competitions.add_parser(
         "hosts",
         formatter_class=argparse.RawTextHelpFormatter,

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -332,6 +332,31 @@ def parse_competitions(subparsers) -> None:
     parser_competitions_team_submissions._action_groups.append(parser_competitions_team_submissions_optional)
     parser_competitions_team_submissions.set_defaults(func=api.competition_team_submissions_cli)
 
+    # Competitions submission limits (your team's submission counts and remaining daily allowance)
+    parser_competitions_submission_limits = subparsers_competitions.add_parser(
+        "submission-limits",
+        formatter_class=argparse.RawTextHelpFormatter,
+        help=Help.command_competitions_submission_limits,
+    )
+    parser_competitions_submission_limits_optional = parser_competitions_submission_limits._action_groups.pop()
+    parser_competitions_submission_limits_optional.add_argument(
+        "competition", nargs="?", default=None, help=Help.param_competition
+    )
+    parser_competitions_submission_limits_optional.add_argument(
+        "-c", "--competition", dest="competition_opt", required=False, help=argparse.SUPPRESS
+    )
+    parser_competitions_submission_limits_optional.add_argument(
+        "--json",
+        dest="json_output",
+        action="store_true",
+        help="Emit the limits as JSON instead of the human-readable view.",
+    )
+    parser_competitions_submission_limits_optional.add_argument(
+        "-q", "--quiet", dest="quiet", action="store_true", help=Help.param_quiet
+    )
+    parser_competitions_submission_limits._action_groups.append(parser_competitions_submission_limits_optional)
+    parser_competitions_submission_limits.set_defaults(func=api.competition_get_submission_limits_cli)
+
     # Competitions list episodes
     parser_competitions_episodes = subparsers_competitions.add_parser(
         "episodes", formatter_class=argparse.RawTextHelpFormatter, help=Help.command_competitions_episodes
@@ -564,37 +589,27 @@ def parse_competitions(subparsers) -> None:
     parser_competitions_pages_delete._action_groups.append(parser_competitions_pages_delete_optional)
     parser_competitions_pages_delete.set_defaults(func=api.competition_delete_page_cli)
 
-    # Competitions hosts (group: list)
-    shared_competition_hosts_list = argparse.ArgumentParser(add_help=False)
-    shared_competition_hosts_list.add_argument("competition", nargs="?", default=None, help=Help.param_competition)
-    shared_competition_hosts_list.add_argument(
-        "-c", "--competition", dest="competition_opt", required=False, help=argparse.SUPPRESS
-    )
-    _add_output_format_args(shared_competition_hosts_list)
-    shared_competition_hosts_list.add_argument(
-        "-q", "--quiet", dest="quiet", action="store_true", help=Help.param_quiet
-    )
-
+    # Competitions hosts (list hosts for a competition). Flat parser — an
+    # earlier version wrapped a `list` subcommand around this, but argparse
+    # can't disambiguate a parent positional (`<competition>`) from a
+    # subcommand token, so `kaggle competitions hosts my-comp` errored. Kept
+    # simple.
     parser_competitions_hosts = subparsers_competitions.add_parser(
         "hosts",
         formatter_class=argparse.RawTextHelpFormatter,
         help=Help.command_competitions_hosts,
-        parents=[shared_competition_hosts_list],
     )
-    subparsers_competitions_hosts = parser_competitions_hosts.add_subparsers(title="commands", dest="command")
-    subparsers_competitions_hosts.choices = Help.entity_hosts_choices
-
-    # Default action when no subcommand is given: list
+    parser_competitions_hosts_optional = parser_competitions_hosts._action_groups.pop()
+    parser_competitions_hosts_optional.add_argument("competition", nargs="?", default=None, help=Help.param_competition)
+    parser_competitions_hosts_optional.add_argument(
+        "-c", "--competition", dest="competition_opt", required=False, help=argparse.SUPPRESS
+    )
+    _add_output_format_args(parser_competitions_hosts_optional)
+    parser_competitions_hosts_optional.add_argument(
+        "-q", "--quiet", dest="quiet", action="store_true", help=Help.param_quiet
+    )
+    parser_competitions_hosts._action_groups.append(parser_competitions_hosts_optional)
     parser_competitions_hosts.set_defaults(func=api.competition_list_hosts_cli)
-
-    # Competitions hosts list (explicit)
-    parser_competitions_hosts_list = subparsers_competitions_hosts.add_parser(
-        "list",
-        formatter_class=argparse.RawTextHelpFormatter,
-        help=Help.command_competitions_hosts,
-        parents=[shared_competition_hosts_list],
-    )
-    parser_competitions_hosts_list.set_defaults(func=api.competition_list_hosts_cli)
 
     # Competitions data (group: update)
     parser_competitions_data = subparsers_competitions.add_parser(
@@ -2410,6 +2425,7 @@ class Help(object):
         "submissions",
         "leaderboard",
         "team-submissions",
+        "submission-limits",
         "episodes",
         "replay",
         "logs",
@@ -2483,7 +2499,6 @@ class Help(object):
     forums_topics_choices = ["list", "show"]
     entity_topics_choices = ["list", "show"]
     entity_pages_choices = ["list", "create", "update", "delete"]
-    entity_hosts_choices = ["list"]
     entity_data_choices = ["update"]
     entity_settings_choices = ["get", "update"]
     entity_solution_choices = ["create", "status"]
@@ -2555,6 +2570,9 @@ class Help(object):
     command_competitions_submissions = "Show your competition submissions"
     command_competitions_leaderboard = "Get competition leaderboard information"
     command_competitions_team_submissions = "List a team's public submissions (every active submission for simulation competitions, or the public leaderboard submission for regular competitions)"
+    command_competitions_submission_limits = (
+        "Show your team's submission counts and remaining daily allowance for a competition"
+    )
     command_competitions_episodes = "List episodes for a submission in a simulation competition"
     command_competitions_episode_replay = "Download the replay for a simulation episode"
     command_competitions_episode_logs = "Download agent logs for a simulation episode"

--- a/tests/unit/test_cli_competitions.py
+++ b/tests/unit/test_cli_competitions.py
@@ -200,6 +200,21 @@ def test_competitions_team_submissions_parser_succeeds(parser):
     assert kwargs["team_id"] == 12345
 
 
+def test_competitions_submission_limits_positional_succeeds(parser):
+    func, kwargs = parser.dispatch(["competitions", "submission-limits", "my-comp", "--json"])
+    assert func.__name__ == "competition_get_submission_limits_cli"
+    assert kwargs["competition"] == "my-comp"
+    assert kwargs["json_output"] is True
+
+
+def test_competitions_submission_limits_dash_c_succeeds(parser):
+    func, kwargs = parser.dispatch(["competitions", "submission-limits", "-c", "my-comp"])
+    assert func.__name__ == "competition_get_submission_limits_cli"
+    assert kwargs["competition"] is None
+    assert kwargs["competition_opt"] == "my-comp"
+    assert kwargs["json_output"] is False
+
+
 def test_competitions_episodes_parser_missing_sub_id_fails(parser):
     with pytest.raises(SystemExit):
         parser.dispatch(["competitions", "episodes"])
@@ -336,18 +351,19 @@ def test_competitions_pages_delete_succeeds(parser):
     assert kwargs["quiet"] is True
 
 
-def test_competitions_hosts_default_list_succeeds(parser):
+def test_competitions_hosts_dash_c_succeeds(parser):
     func, kwargs = parser.dispatch(["competitions", "hosts", "-c", "my-comp"])
     assert func.__name__ == "competition_list_hosts_cli"
     assert kwargs.get("competition") is None
     assert kwargs["competition_opt"] == "my-comp"
 
 
-def test_competitions_hosts_list_succeeds(parser):
-    func, kwargs = parser.dispatch(["competitions", "hosts", "list", "-c", "my-comp"])
+def test_competitions_hosts_positional_succeeds(parser):
+    # `hosts` is a flat parser (used to be a subcommand group, but argparse
+    # can't disambiguate a parent positional from a subcommand token).
+    func, kwargs = parser.dispatch(["competitions", "hosts", "my-comp"])
     assert func.__name__ == "competition_list_hosts_cli"
-    assert kwargs.get("competition") is None
-    assert kwargs["competition_opt"] == "my-comp"
+    assert kwargs["competition"] == "my-comp"
 
 
 def test_competitions_data_update_missing_args_fails(parser):

--- a/tests/unit/test_competition_submission_limits.py
+++ b/tests/unit/test_competition_submission_limits.py
@@ -1,0 +1,110 @@
+# coding=utf-8
+import io
+import json
+import sys
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, "../..")
+
+from kaggle.api.kaggle_api_extended import KaggleApi
+from kagglesdk.competitions.types.competition_api_service import ApiSubmissionLimits
+
+
+def _make_limits(**overrides) -> ApiSubmissionLimits:
+    limits = ApiSubmissionLimits()
+    for name, value in overrides.items():
+        setattr(limits, name, value)
+    return limits
+
+
+class TestCompetitionSubmissionLimits(unittest.TestCase):
+    """Tests for competition_get_submission_limits and its CLI wrapper."""
+
+    def setUp(self):
+        self.api = KaggleApi.__new__(KaggleApi)
+        self.api.config_values = {}
+
+    def _patch_client(self, mock_client, limits=None):
+        mock_kaggle = MagicMock()
+        mock_kaggle.competitions.competition_api_client.get_submission_limits.return_value = (
+            limits if limits is not None else _make_limits()
+        )
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+        return mock_kaggle
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_builds_request_with_competition_name(self, mock_client):
+        mock_kaggle = self._patch_client(mock_client, _make_limits(num_allowed_now=3))
+
+        result = self.api.competition_get_submission_limits("my-comp")
+
+        request = mock_kaggle.competitions.competition_api_client.get_submission_limits.call_args[0][0]
+        self.assertEqual(request.competition_name, "my-comp")
+        self.assertEqual(result.num_allowed_now, 3)
+
+    @patch.object(KaggleApi, "competition_get_submission_limits")
+    def test_cli_positional_competition(self, mock_get):
+        mock_get.return_value = _make_limits()
+        with redirect_stdout(io.StringIO()):
+            self.api.competition_get_submission_limits_cli(competition="my-comp")
+        mock_get.assert_called_once_with("my-comp")
+
+    @patch.object(KaggleApi, "competition_get_submission_limits")
+    def test_cli_dash_c_option(self, mock_get):
+        mock_get.return_value = _make_limits()
+        with redirect_stdout(io.StringIO()):
+            self.api.competition_get_submission_limits_cli(competition_opt="my-comp")
+        mock_get.assert_called_once_with("my-comp")
+
+    @patch.object(KaggleApi, "competition_get_submission_limits")
+    def test_cli_falls_back_to_config(self, mock_get):
+        mock_get.return_value = _make_limits()
+        self.api.config_values = {self.api.CONFIG_NAME_COMPETITION: "from-config"}
+        with redirect_stdout(io.StringIO()):
+            self.api.competition_get_submission_limits_cli()
+        mock_get.assert_called_once_with("from-config")
+
+    def test_cli_missing_competition_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.api.competition_get_submission_limits_cli()
+        self.assertIn("No competition specified", str(ctx.exception))
+
+    @patch.object(KaggleApi, "competition_get_submission_limits")
+    def test_cli_json_output_emits_valid_json(self, mock_get):
+        mock_get.return_value = _make_limits(num_today=3, num_total=47, num_allowed_now=2, limited_by_total=True)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            self.api.competition_get_submission_limits_cli(competition="my-comp", json_output=True)
+        payload = json.loads(buf.getvalue())
+        self.assertEqual(payload["numToday"], 3)
+        self.assertEqual(payload["numTotal"], 47)
+        self.assertEqual(payload["numAllowedNow"], 2)
+        self.assertTrue(payload["limitedByTotal"])
+
+    @patch.object(KaggleApi, "competition_get_submission_limits")
+    def test_cli_human_view_prints_all_labels(self, mock_get):
+        mock_get.return_value = _make_limits(num_today=3, num_total=47, num_allowed_now=2)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            self.api.competition_get_submission_limits_cli(competition="my-comp")
+        out = buf.getvalue()
+        self.assertIn("Submissions today: 3", out)
+        self.assertIn("Lifetime submissions: 47", out)
+        self.assertIn("Remaining today: 2", out)
+        self.assertNotIn("lifetime cap", out)
+
+    @patch.object(KaggleApi, "competition_get_submission_limits")
+    def test_cli_human_view_appends_lifetime_cap_suffix(self, mock_get):
+        mock_get.return_value = _make_limits(num_today=1, num_total=999, num_allowed_now=1, limited_by_total=True)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            self.api.competition_get_submission_limits_cli(competition="my-comp")
+        out = buf.getvalue()
+        self.assertIn("Remaining today: 1 (limited by lifetime cap)", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_competition_submit.py
+++ b/tests/unit/test_competition_submit.py
@@ -223,5 +223,67 @@ class TestCompetitionSubmit(unittest.TestCase):
         self.assertIn("Using competition: config-comp", f.getvalue())
 
 
+class TestCompetitionSubmitCliLimits(unittest.TestCase):
+    """After a successful submit, the CLI wrapper should print the remaining
+    submission allowance for the day. Limits errors must not fail the submit."""
+
+    def setUp(self):
+        self.api = KaggleApi.__new__(KaggleApi)
+        self.api.config_values = {"username": "testuser"}
+        self.api.already_printed_version_warning = True
+
+    @patch.object(KaggleApi, "competition_get_submission_limits")
+    @patch.object(KaggleApi, "competition_submit")
+    def test_cli_prints_remaining_after_success(self, mock_submit, mock_limits):
+        resp = ApiCreateSubmissionResponse()
+        resp.message = "submitted"
+        mock_submit.return_value = resp
+        mock_limits.return_value = MagicMock(num_allowed_now=4)
+
+        import io
+        from contextlib import redirect_stdout
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            result = self.api.competition_submit_cli(
+                file_name="sub.csv", message="msg", competition="my-comp", quiet=False
+            )
+
+        self.assertEqual(result, "submitted")
+        mock_limits.assert_called_once_with("my-comp")
+        self.assertIn("4 submissions remaining today.", buf.getvalue())
+
+    @patch.object(KaggleApi, "competition_get_submission_limits")
+    @patch.object(KaggleApi, "competition_submit")
+    def test_cli_swallows_limits_failure(self, mock_submit, mock_limits):
+        resp = ApiCreateSubmissionResponse()
+        resp.message = "submitted"
+        mock_submit.return_value = resp
+        mock_limits.side_effect = RuntimeError("limits endpoint blip")
+
+        import io
+        from contextlib import redirect_stdout
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            result = self.api.competition_submit_cli(
+                file_name="sub.csv", message="msg", competition="my-comp", quiet=False
+            )
+
+        self.assertEqual(result, "submitted")
+        self.assertNotIn("remaining today", buf.getvalue())
+
+    @patch.object(KaggleApi, "competition_get_submission_limits")
+    @patch.object(KaggleApi, "competition_submit")
+    def test_cli_skips_limits_when_quiet(self, mock_submit, mock_limits):
+        resp = ApiCreateSubmissionResponse()
+        resp.message = "submitted"
+        mock_submit.return_value = resp
+
+        self.api.competition_submit_cli(file_name="sub.csv", message="msg", competition="my-comp", quiet=True)
+
+        mock_limits.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_competition_submit.py
+++ b/tests/unit/test_competition_submit.py
@@ -284,6 +284,30 @@ class TestCompetitionSubmitCliLimits(unittest.TestCase):
 
         mock_limits.assert_not_called()
 
+    @patch.object(KaggleApi, "competition_get_submission_limits")
+    @patch.object(KaggleApi, "competition_submit")
+    def test_cli_skips_limits_on_upload_failure(self, mock_submit, mock_limits):
+        # competition_submit returns a synthetic response with this sentinel
+        # message when the file upload fails (no exception raised). We must
+        # NOT print the limits line in that case — it would imply the
+        # submission counted when it didn't.
+        resp = ApiCreateSubmissionResponse()
+        resp.message = KaggleApi.COMPETITION_SUBMIT_UPLOAD_FAILED_MESSAGE
+        mock_submit.return_value = resp
+
+        import io
+        from contextlib import redirect_stdout
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            result = self.api.competition_submit_cli(
+                file_name="sub.csv", message="msg", competition="my-comp", quiet=False
+            )
+
+        self.assertEqual(result, KaggleApi.COMPETITION_SUBMIT_UPLOAD_FAILED_MESSAGE)
+        mock_limits.assert_not_called()
+        self.assertNotIn("remaining today", buf.getvalue())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary

  Surfaces the GetSubmissionLimits endpoint added in kagglesdk 0.1.35 (GET /api/v1/competitions/{competition_name}/submissions/limits), and fixes a latent bug in competitions hosts while I was in the neighborhood.

  Changes

  New: kaggle competitions submission-limits <comp>

  Shows your team's submission counts and remaining daily allowance for a competition.

```
  $ kaggle competitions submission-limits titanic
  Submissions today: 3
  Lifetime submissions: 47
  Remaining today: 7
```

  With --json for scripting, and a (limited by lifetime cap) annotation when limited_by_total=True explains why remaining is smaller than the daily cap.

  Modeled as a top-level verb (like team-submissions) rather than a subcommand under submissions — the latter would have required either breaking the legacy submissions <comp> positional form or adding an argv-rewrite shim, both worse than a hyphenated verb.

  New: post-submit hint

  kaggle competitions submit now prints <N> submissions remaining today. on success. Wrapped in try/except so a limits-endpoint blip never fails an otherwise successful submit; skipped entirely under --quiet. Users get the info in the natural moment they care about it.

  Fix: competitions hosts <comp> (previously broken)

  competitions hosts was structured as a subcommand group with a decorative list subcommand. Argparse silently broke the positional form — kaggle competitions hosts my-comp errored with argument command: invalid choice: 'my-comp' (choose from list). Converted to a flat parser
  matching every other read-only competitions verb. Positional and -c/--competition both work now. The hosts list alias (used in one doc line, no known real users) is removed.
