### PR TITLE
Parse owner from owner/task format in _make_task_slug

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -9099,9 +9099,20 @@ class KaggleApi:
 
     @staticmethod
     def _make_task_slug(task: str) -> ApiBenchmarkTaskSlug:
-        """Build an ApiBenchmarkTaskSlug from a (pre-normalized) task string."""
+        """Build an ApiBenchmarkTaskSlug from a (pre-normalized) task string.
+
+        Supports the ``owner/task`` format: when the string contains a ``/``,
+        the part before it is used as ``owner_slug`` and the part after as
+        ``task_slug``. Without a ``/`` only ``task_slug`` is set and the owner
+        defaults to the current user on the server.
+        """
         slug = ApiBenchmarkTaskSlug()
-        slug.task_slug = task
+        if "/" in task:
+            owner, task_slug = task.split("/", 1)
+            slug.owner_slug = owner
+            slug.task_slug = task_slug
+        else:
+            slug.task_slug = task
         return slug
 
     @staticmethod

--- a/tests/unit/test_benchmarks_cli.py
+++ b/tests/unit/test_benchmarks_cli.py
@@ -1942,6 +1942,33 @@ class TestModelSlugNormalization:
 
 
 # ============================================================
+# Task Slug Parsing
+# ============================================================
+
+
+class TestMakeTaskSlug:
+    """Tests for ``KaggleApi._make_task_slug`` owner/task parsing."""
+
+    def test_plain_task_slug_no_owner(self):
+        """A plain task string sets only task_slug; owner is left unset."""
+        slug = KaggleApi._make_task_slug("my-task")
+        assert slug.task_slug == "my-task"
+        assert not slug.owner_slug
+
+    def test_owner_task_format_sets_both(self):
+        """``owner/task`` sets owner_slug and task_slug separately."""
+        slug = KaggleApi._make_task_slug("alice/my-task")
+        assert slug.owner_slug == "alice"
+        assert slug.task_slug == "my-task"
+
+    def test_owner_task_with_extra_slash(self):
+        """Only the first ``/`` splits owner from task; the rest stays in task_slug."""
+        slug = KaggleApi._make_task_slug("alice/my-task/v2")
+        assert slug.owner_slug == "alice"
+        assert slug.task_slug == "my-task/v2"
+
+
+# ============================================================
 # Models
 # ============================================================
 


### PR DESCRIPTION
The benchmark task slug builder ignored the owner when given an
owner/task string, so tasks owned by another user could not be
addressed. Split on the first slash to set owner_slug and task_slug
separately, falling back to the current-user default when no owner is
given.

BUG=b/538146551

Co-authored-by: kaggle-agent <kaggle-agent@users.noreply.github.com>

---

Task: [limagoog-20260723160622-76c6f8aa](https://agents.dev.kaggle.net/tasks/limagoog-20260723160622-76c6f8aa)

### Prompt

Fix bug http://b/538146551: The CLI's `_make_task_slug` method in `src/kaggle/api/kaggle_api_extended.py` doesn't parse the owner from `owner/task` format when building an `ApiBenchmarkTaskSlug`.

**What to fix:**

In `_make_task_slug` (around line 9101), split the `task` string on `/`:
- If it contains a `/`, set `slug.owner_slug` to the part before `/` and `slug.task_slug` to the part after.
- If no `/`, just set `slug.task_slug` as it does today (owner defaults to current user on the server).

**Tests:**
Add unit tests for `_make_task_slug` covering:
1. Plain task slug (no owner) — only `task_slug` is set
2. `owner/task` format — both `owner_slug` and `task_slug` are set
3. Edge case: slug with version like `owner/task` still works

Look at existing test files under `tests/unit/test_benchmarks_cli.py` for patterns.

Bug: http://b/538146551

