### PR TITLE
fix(benchmarks): support owner/task separator in benchmark commands

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -143,6 +143,21 @@ Displays or downloads the evaluation results for all models that have run tasks 
 
 All tasks commands live under `kaggle benchmarks tasks` (alias: `kaggle b t`).
 
+### Task Name Format
+
+Task arguments (`<TASK>`) support two formats:
+
+*   **Bare slug** (`my-task`): Refers to a task owned by the current user.
+*   **Owner prefix** (`owner/my-task`): Refers to a specific owner's task (e.g., another user's public task, or `your-username/my-task`).
+
+| Command Group | Supported Formats | Description |
+|---|---|---|
+| **View & Run** (`run`, `status`, `download`, `log`) | `my-task`, `owner/my-task` | Interact with your own tasks or public tasks from other users |
+| **Publish** (`publish`) | `my-task`, `your-username/my-task` | Make your own task public (must be task owner) |
+| **Create** (`push`) | `my-task` only | Must match the `@task(name="...")` decorator in your Python source file |
+
+> **Slug Normalization:** Task names are automatically converted to URL-safe slugs (`My Task` → `my-task`). For `owner/task` arguments, each segment is slugified independently (`Owner/My Task` → `owner/my-task`) so the `/` separator is preserved.
+
 ### `kaggle benchmarks tasks push`
 
 Creates or updates a benchmark task from a local Python source file. The file must contain at least one function decorated with `@task`.
@@ -218,7 +233,7 @@ kaggle benchmarks tasks run <TASK> [options]
 
 **Arguments:**
 
-*   `<TASK>`: Task name (slug, e.g. `my-task`).
+*   `<TASK>`: Task name (slug, e.g. `my-task` or `owner/my-task`).
 
 **Options:**
 
@@ -300,7 +315,7 @@ kaggle benchmarks tasks status <TASK> [options]
 
 **Arguments:**
 
-*   `<TASK>`: Task name (slug, e.g. `my-task`).
+*   `<TASK>`: Task name (slug, e.g. `my-task` or `owner/my-task`).
 
 **Options:**
 
@@ -314,7 +329,13 @@ kaggle benchmarks tasks status <TASK> [options]
     kaggle b t status my-task
     ```
 
-2.  Show status for specific models only:
+2.  Show status for another user's task:
+
+    ```bash
+    kaggle b t status someuser/their-task
+    ```
+
+3.  Show status for specific models only:
 
     ```bash
     kaggle b t status my-task -m gemini-2.5-pro
@@ -340,7 +361,7 @@ kaggle benchmarks tasks download <TASK> [options]
 
 **Arguments:**
 
-*   `<TASK>`: Task name (slug, e.g. `my-task`).
+*   `<TASK>`: Task name (slug, e.g. `my-task` or `owner/my-task`).
 
 **Options:**
 
@@ -357,19 +378,25 @@ kaggle benchmarks tasks download <TASK> [options]
     kaggle b t download my-task
     ```
 
-2.  Download outputs for a specific model into a custom directory:
+2.  Download outputs from another user's public task:
+
+    ```bash
+    kaggle b t download someuser/their-task
+    ```
+
+3.  Download outputs for a specific model into a custom directory:
 
     ```bash
     kaggle b t download my-task -m gemini-2.5-pro -o ./results
     ```
 
-3.  Download outputs with source notebooks included:
+4.  Download outputs with source notebooks included:
 
     ```bash
     kaggle b t download my-task --include-source
     ```
 
-4.  Force re-download of previously downloaded runs:
+5.  Force re-download of previously downloaded runs:
 
     ```bash
     kaggle b t download my-task --force
@@ -421,7 +448,7 @@ kaggle benchmarks tasks log <TASK> [options]
 
 **Arguments:**
 
-*   `<TASK>`: Task name (slug, e.g. `my-task`).
+*   `<TASK>`: Task name (slug, e.g. `my-task` or `owner/my-task`).
 
 **Options:**
 
@@ -437,13 +464,19 @@ kaggle benchmarks tasks log <TASK> [options]
     kaggle b t log my-task
     ```
 
-2.  Show logs for a specific model's run(s):
+2.  Show logs for another user's task:
+
+    ```bash
+    kaggle b t log someuser/their-task
+    ```
+
+3.  Show logs for a specific model's run(s):
 
     ```bash
     kaggle b t log my-task -m gemini-2.5-pro
     ```
 
-3.  Show logs for multiple models:
+4.  Show logs for multiple models:
 
     ```bash
     kaggle b t logs my-task -m gemini-2.5-pro -m claude-sonnet-4
@@ -531,7 +564,7 @@ kaggle benchmarks tasks delete <TASK> [options]
 
 **Arguments:**
 
-*   `<TASK>`: Task name (slug, e.g. `my-task`).
+*   `<TASK>`: Task name (slug, e.g. `my-task` or `owner/my-task`).
 
 **Options:**
 
@@ -561,7 +594,7 @@ kaggle benchmarks tasks publish <TASK> [options]
  
 **Arguments:**
  
-*   `<TASK>`: Task name (slug, e.g. `my-task`).
+*   `<TASK>`: Task name (slug, e.g. `my-task` or `owner/my-task`).
  
 **Options:**
  

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -9099,10 +9099,41 @@ class KaggleApi:
 
     @staticmethod
     def _make_task_slug(task: str) -> ApiBenchmarkTaskSlug:
-        """Build an ApiBenchmarkTaskSlug from a (pre-normalized) task string."""
+        """Build an ApiBenchmarkTaskSlug from a (pre-normalized) task string.
+
+        Supports the ``owner/task`` format: when the string contains a ``/``,
+        the part before it is used as ``owner_slug`` and the part after as
+        ``task_slug``. Without a ``/`` only ``task_slug`` is set and the owner
+        defaults to the current user on the server.
+        """
         slug = ApiBenchmarkTaskSlug()
-        slug.task_slug = task
+        if "/" in task:
+            owner, task_slug = task.split("/", 1)
+            slug.owner_slug = owner
+            slug.task_slug = task_slug
+        else:
+            slug.task_slug = task
         return slug
+
+    @staticmethod
+    def _slugify_task(task: str) -> str:
+        """Slugify a task name while preserving the ``owner/task`` separator.
+
+        The generic ``slugify()`` replaces ``/`` with ``-``, which destroys
+        the owner/task structure that ``_make_task_slug`` relies on.  This
+        helper slugifies each segment independently so that
+        ``owner/my-task`` becomes ``owner/my-task``
+        instead of ``owner-my-task``.
+
+        Raises:
+            ValueError: If either the owner or task segment is empty
+                (e.g. ``/task``, ``owner/``, ``/``).
+        """
+        parts = task.split("/", 1)
+        slugified = [slugify(p) for p in parts]
+        if len(slugified) == 2 and not all(slugified):
+            raise ValueError(f"Invalid task format '{task}'. Use 'task-name' or 'owner/task-name'.")
+        return "/".join(slugified)
 
     @staticmethod
     def _normalize_model_slug(slug: str) -> str:
@@ -9827,7 +9858,7 @@ class KaggleApi:
         if poll_interval is not None and poll_interval <= 0:
             raise ValueError("--poll-interval must be a positive integer")
         models = self._normalize_model_list(model)
-        task = slugify(task)
+        task = self._slugify_task(task)
 
         with self.build_kaggle_client() as kaggle:
             # Verify the task exists and is ready to run
@@ -9943,7 +9974,7 @@ class KaggleApi:
                 page -= 1
 
     def benchmarks_tasks_status_cli(self, task, model=None):
-        task = slugify(task)
+        task = self._slugify_task(task)
         with self.build_kaggle_client() as kaggle:
             task_info = self._get_benchmark_task(task, kaggle)
             print(f"Task:     {task_info.slug.task_slug}")
@@ -9982,7 +10013,7 @@ class KaggleApi:
 
     def benchmarks_tasks_download_cli(self, task, model=None, output=None, include_source=False, force=False):
         """Download output files for completed/errored benchmark task runs."""
-        task = slugify(task)
+        task = self._slugify_task(task)
         output = output or "."
 
         with self.build_kaggle_client() as kaggle:
@@ -10061,6 +10092,7 @@ class KaggleApi:
                     # Note: extractall() is safe here because the zip originates from
                     # the trusted Kaggle server, not user-supplied input (zip-slip).
                     with zipfile.ZipFile(zipfile_path, "r") as zf:
+                        os.makedirs(tmp_outdir, exist_ok=True)
                         zf.extractall(tmp_outdir)
                 except zipfile.BadZipFile:
                     print(f"{row_prefix} {size_str:<{size_col}} {'Bad zip':<{prog_col}}")
@@ -10144,7 +10176,7 @@ class KaggleApi:
 
     def benchmarks_tasks_log_cli(self, task, model=None):
         """Print execution logs for benchmark task run(s)."""
-        task = slugify(task)
+        task = self._slugify_task(task)
 
         with self.build_kaggle_client() as kaggle:
             self._get_benchmark_task(task, kaggle)
@@ -10246,7 +10278,7 @@ class KaggleApi:
 
     def benchmarks_tasks_publish_cli(self, task, publish_backing_notebook=True):
         """Publish a benchmark task, making it public."""
-        task = slugify(task)
+        task = self._slugify_task(task)
 
         with self.build_kaggle_client() as kaggle:
             # Verify the task exists first

--- a/tests/unit/test_benchmarks_cli.py
+++ b/tests/unit/test_benchmarks_cli.py
@@ -1942,6 +1942,97 @@ class TestModelSlugNormalization:
 
 
 # ============================================================
+# Task Slug Normalization
+# ============================================================
+
+
+class TestTaskSlugNormalization:
+    """Tests for ``_slugify_task`` and ``_make_task_slug``."""
+
+    # -- _slugify_task --
+
+    @pytest.mark.parametrize(
+        "input_task, expected",
+        [
+            # Bare task name — no owner
+            ("my-task", "my-task"),
+            # Owner/task format preserved
+            ("owner/my-task", "owner/my-task"),
+            # Normalization: uppercase, underscores, spaces
+            ("My Task", "my-task"),
+            ("Owner/My Task", "owner/my-task"),
+            ("my_task", "my-task"),
+            ("OWNER/TASK_NAME", "owner/task-name"),
+            # Extra slashes after the first are merged by slugify
+            ("owner/task/extra", "owner/task-extra"),
+            # Unicode transliteration
+            ("café/naïve-task", "cafe/naive-task"),
+        ],
+        ids=[
+            "bare_task",
+            "owner_task",
+            "uppercase_bare",
+            "uppercase_owner_task",
+            "underscore_bare",
+            "uppercase_underscore_owner",
+            "extra_slashes",
+            "unicode",
+        ],
+    )
+    def test_slugify_task(self, input_task, expected):
+        assert KaggleApi._slugify_task(input_task) == expected
+
+    @pytest.mark.parametrize(
+        "invalid_input",
+        [
+            "/task",
+            "owner/",
+            "/",
+        ],
+        ids=[
+            "missing_owner",
+            "missing_task",
+            "bare_slash",
+        ],
+    )
+    def test_slugify_task_rejects_empty_segments(self, invalid_input):
+        with pytest.raises(ValueError, match="Invalid task format"):
+            KaggleApi._slugify_task(invalid_input)
+
+    # -- _make_task_slug --
+
+    def test_make_task_slug_bare(self):
+        slug = KaggleApi._make_task_slug("my-task")
+        assert slug.task_slug == "my-task"
+        assert not slug.owner_slug
+
+    def test_make_task_slug_with_owner(self):
+        slug = KaggleApi._make_task_slug("owner/my-task")
+        assert slug.owner_slug == "owner"
+        assert slug.task_slug == "my-task"
+
+    # -- End-to-end: owner/task propagates to API requests --
+
+    def test_status_sends_owner_slug(self, api, capsys):
+        """``status owner/task`` should set owner_slug on the API request."""
+        _setup_completed_task(api)
+        api._mock_benchmarks.list_benchmark_task_runs.return_value = MagicMock(runs=[], next_page_token="")
+        api.benchmarks_tasks_status_cli("someuser/my-task")
+        request = api._mock_benchmarks.get_benchmark_task.call_args[0][0]
+        assert request.slug.owner_slug == "someuser"
+        assert request.slug.task_slug == "my-task"
+
+    def test_status_bare_task_omits_owner_slug(self, api, capsys):
+        """``status my-task`` should not set owner_slug."""
+        _setup_completed_task(api)
+        api._mock_benchmarks.list_benchmark_task_runs.return_value = MagicMock(runs=[], next_page_token="")
+        api.benchmarks_tasks_status_cli("my-task")
+        request = api._mock_benchmarks.get_benchmark_task.call_args[0][0]
+        assert not request.slug.owner_slug
+        assert request.slug.task_slug == "my-task"
+
+
+# ============================================================
 # Models
 # ============================================================
 


### PR DESCRIPTION
Before the fix `kaggle benchmarks tasks download truedolaameng/hello-kaggle` fails even when the task is public. Changes:

- slugify() replaces '/' with '-', turning 'owner/task' into 'owner-task' so _make_task_slug never splits the owner. Add _slugify_task() that slugifies each segment independently while preserving the separator.

- Also fix os.rename crash when a benchmark run zip is empty (0 entries): extractall() does not create the target directory in that case, so ensure it exists with os.makedirs before extracting.

TESTED=`kaggle benchmarks tasks download truedolaameng/hello-kaggle`