### PR TITLE
fix(cli): prevent silent partial uploads on upload failure

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -716,6 +716,18 @@ class ResumableFileUpload(object):
         with io.open(self._upload_info_file_path, "w") as f:
             json.dump(self.to_dict(), f, indent=True)
 
+    def upload_expired(self) -> None:
+        """Discards an upload session that can no longer be resumed.
+
+        The upload has to be restarted from scratch, which means initiating a new
+        upload session to get a fresh create url and token.
+
+        Returns:
+            None:
+        """
+        self.start_blob_upload_response = None
+        self.can_resume = False
+
     def upload_completed(self):
         """Marks the upload as complete.
 
@@ -5457,6 +5469,12 @@ class KaggleApi:
             if upload_result == ResumableUploadResult.INCOMPLETE:
                 continue  # Continue (i.e., retry/resume) only if the upload is incomplete.
 
+            if upload_result == ResumableUploadResult.EXPIRED:
+                # The session can no longer be resumed, so drop it and initiate a
+                # new one on the next attempt to restart the upload from scratch.
+                file_upload.upload_expired()
+                continue
+
             if upload_result == ResumableUploadResult.COMPLETE:
                 file_upload.upload_completed()
             break
@@ -8913,6 +8931,11 @@ class KaggleApi:
 
         Returns:
             None:
+
+        Raises:
+            ValueError: If any file could not be uploaded. The request is left
+                incomplete, so callers must not go on to create the dataset/model
+                version.
         """
         patterns = DEFAULT_IGNORE_PATTERNS + (ignore_patterns or [])
         for file_name in os.listdir(folder):
@@ -8941,6 +8964,8 @@ class KaggleApi:
                 resources,
                 patterns,
             )
+            # None means the entry was intentionally skipped (e.g., a folder without
+            # --dir-mode); a failed upload raises instead of being skipped.
             if upload_file is not None:
                 files = request.files
                 if files is not None:
@@ -9003,7 +9028,7 @@ class KaggleApi:
         quiet: bool,
         resources: Optional[List[Dict[str, Union[str, Dict[str, List[Dict[str, str]]]]]]],
         content_type: Optional[str] = None,
-    ) -> Union[UploadFile, None]:
+    ) -> UploadFile:
         """A helper function to upload a single file.
 
         Args:
@@ -9016,7 +9041,11 @@ class KaggleApi:
             content_type (str): Optional MIME content type, e.g. "text/plain", "image/png"
 
         Returns:
-            Union[UploadFile, None]: An UploadFile object if the upload was successful, otherwise None.
+            UploadFile: An UploadFile object for the uploaded file.
+
+        Raises:
+            ValueError: If the file could not be uploaded. Callers must not create
+                the dataset/model version in that case, or it would be missing a file.
         """
 
         if not quiet:
@@ -9025,9 +9054,10 @@ class KaggleApi:
         content_length = os.path.getsize(full_path)
         token = self._upload_blob(full_path, quiet, blob_type, upload_context, content_type)
         if token is None:
-            if not quiet:
-                print("Upload unsuccessful: " + file_name)
-            return None
+            # Never swallowed, even when quiet: silently dropping the file here would
+            # produce a dataset/model version that is missing it. The underlying error
+            # was already printed by upload_complete.
+            raise ValueError("Upload unsuccessful: " + file_name)
         if not quiet:
             print("Upload successful: " + file_name + " (" + File.get_size(content_length) + ")")
         upload_file = UploadFile()
@@ -9155,13 +9185,13 @@ class KaggleApi:
         if response.status_code == 404:
             # Upload expired so need to start from scratch.
             if not quiet:
-                print("Upload of %s expired. Please try again." % path)
-            return ResumableUploadResult.Failed()
+                print("Upload of %s expired. Restarting the upload." % path)
+            return ResumableUploadResult.Expired()
         if response.status_code == 308:  # Resume Incomplete
             bytes_uploaded = self._get_bytes_already_uploaded(response, quiet)
             if bytes_uploaded is None:
                 # There is an error with the Range header so need to start from scratch.
-                return ResumableUploadResult.Failed()
+                return ResumableUploadResult.Expired()
             result = ResumableUploadResult.Incomplete(bytes_uploaded)
             if not quiet:
                 print("Already uploaded %d bytes. Will resume upload at %d." % (result.bytes_uploaded, result.start_at))

--- a/src/kaggle/models/kaggle_models_extended.py
+++ b/src/kaggle/models/kaggle_models_extended.py
@@ -288,15 +288,20 @@ class ResumableUploadResult(object):
     # Upload was complete, i.e., all bytes were received by the server.
     COMPLETE = 1
 
-    # There was a non-transient error during the upload or the upload expired.
-    # The upload cannot be resumed so it should be restarted from scratch
-    # (i.e., call /api/v1/files/upload to initiate the upload and get the
-    # create/upload url and token).
+    # The server rejected the upload with a non-transient error. The upload
+    # cannot be resumed and restarting it would only hit the same error, so it
+    # should be abandoned.
     FAILED = 2
 
     # Upload was interrupted due to some (transient) failure but it can be
     # safely resumed.
     INCOMPLETE = 3
+
+    # The upload session is gone (e.g., it expired) but the file itself was
+    # never rejected. The upload cannot be resumed so it should be restarted
+    # from scratch (i.e., call /api/v1/files/upload to initiate the upload and
+    # get the create/upload url and token).
+    EXPIRED = 4
 
     def __init__(self, result, bytes_uploaded=None):
         self.result = result
@@ -318,3 +323,7 @@ class ResumableUploadResult(object):
     @staticmethod
     def Incomplete(bytes_uploaded=None):
         return ResumableUploadResult(ResumableUploadResult.INCOMPLETE, bytes_uploaded)
+
+    @staticmethod
+    def Expired():
+        return ResumableUploadResult(ResumableUploadResult.EXPIRED)

--- a/tests/unit/test_dataset_create.py
+++ b/tests/unit/test_dataset_create.py
@@ -10,7 +10,8 @@ from requests.exceptions import HTTPError
 sys.path.insert(0, "../..")
 
 from kaggle.api.kaggle_api_extended import KaggleApi
-from kagglesdk.blobs.types.blob_api_service import ApiBlobType
+from kaggle.models.kaggle_models_extended import ResumableUploadResult
+from kagglesdk.blobs.types.blob_api_service import ApiBlobType, ApiStartBlobUploadResponse
 
 
 class TestDatasetCreate(unittest.TestCase):
@@ -32,6 +33,39 @@ class TestDatasetCreate(unittest.TestCase):
         meta_file_path = os.path.join(folder, "dataset-metadata.json")
         with open(meta_file_path, "w", encoding="utf-8") as f:
             json.dump(metadata, f)
+
+    def _mock_kaggle_client(self, mock_client):
+        """Wires build_kaggle_client so that blob uploads can be driven end to end."""
+        mock_kaggle = MagicMock()
+        started = []
+
+        def start_blob_upload(request):
+            started.append(request)
+            response = ApiStartBlobUploadResponse()
+            response.create_url = "http://upload-url/%d" % len(started)
+            response.token = "token-%d" % len(started)
+            return response
+
+        mock_kaggle.blobs.blob_api_client.start_blob_upload.side_effect = start_blob_upload
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+        return mock_kaggle
+
+    def _write_data_files(self, folder, *file_names):
+        for file_name in file_names:
+            with open(os.path.join(folder, file_name), "w", encoding="utf-8") as f:
+                f.write("col\n1\n")
+
+    @staticmethod
+    def _fail_upload_of(failing_file_name):
+        """Returns an upload_complete stand-in that only fails one specific file."""
+
+        def upload_complete(path, url, quiet, resume=False):
+            if os.path.basename(path) == failing_file_name:
+                return ResumableUploadResult.FAILED
+            return ResumableUploadResult.COMPLETE
+
+        return upload_complete
 
     def test_dataset_create_new_invalid_folder_fails(self):
         with self.assertRaises(ValueError) as context:
@@ -377,6 +411,59 @@ class TestDatasetCreate(unittest.TestCase):
             self.assertEqual(call_args[2], tmpdir)
             self.assertEqual(call_args[3], ApiBlobType.DATASET)
             self.assertEqual(call_args[7], ignore_patterns)
+
+    @patch.object(KaggleApi, "upload_complete")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_dataset_create_version_upload_failure_aborts(self, mock_client, mock_upload_complete):
+        mock_kaggle = self._mock_kaggle_client(mock_client)
+        mock_upload_complete.side_effect = self._fail_upload_of("two.csv")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, self._get_valid_metadata())
+            self._write_data_files(tmpdir, "one.csv", "two.csv", "three.csv")
+
+            with patch("kaggle.api.kaggle_api_extended.tempfile.gettempdir", return_value=tmpdir):
+                with self.assertRaises(ValueError) as context:
+                    self.api.dataset_create_version(tmpdir, "version notes here", quiet=True)
+
+        # A version missing one of its files must never be created.
+        self.assertIn("Upload unsuccessful: two.csv", str(context.exception))
+        mock_kaggle.datasets.dataset_api_client.create_dataset_version.assert_not_called()
+
+    @patch.object(KaggleApi, "dataset_status")
+    @patch.object(KaggleApi, "upload_complete")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_dataset_create_new_upload_failure_aborts(self, mock_client, mock_upload_complete, mock_status):
+        mock_kaggle = self._mock_kaggle_client(mock_client)
+        mock_upload_complete.side_effect = self._fail_upload_of("two.csv")
+        mock_status.side_effect = HTTPError("not found")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, self._get_valid_metadata())
+            self._write_data_files(tmpdir, "one.csv", "two.csv", "three.csv")
+
+            with patch("kaggle.api.kaggle_api_extended.tempfile.gettempdir", return_value=tmpdir):
+                with self.assertRaises(ValueError) as context:
+                    self.api.dataset_create_new(tmpdir, quiet=True)
+
+        self.assertIn("Upload unsuccessful: two.csv", str(context.exception))
+        mock_kaggle.datasets.dataset_api_client.create_dataset.assert_not_called()
+
+    @patch.object(KaggleApi, "upload_complete", return_value=ResumableUploadResult.COMPLETE)
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_dataset_create_version_uploads_every_file_succeeds(self, mock_client, mock_upload_complete):
+        mock_kaggle = self._mock_kaggle_client(mock_client)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_metadata(tmpdir, self._get_valid_metadata())
+            self._write_data_files(tmpdir, "one.csv", "two.csv", "three.csv")
+
+            with patch("kaggle.api.kaggle_api_extended.tempfile.gettempdir", return_value=tmpdir):
+                self.api.dataset_create_version(tmpdir, "version notes here", quiet=True)
+
+        mock_kaggle.datasets.dataset_api_client.create_dataset_version.assert_called_once()
+        request = mock_kaggle.datasets.dataset_api_client.create_dataset_version.call_args[0][0]
+        self.assertEqual(sorted(f.token for f in request.body.files), ["token-1", "token-2", "token-3"])
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_model_create.py
+++ b/tests/unit/test_model_create.py
@@ -9,13 +9,14 @@ import sys
 sys.path.insert(0, "../..")
 
 from kaggle.api.kaggle_api_extended import KaggleApi
+from kaggle.models.kaggle_models_extended import ResumableUploadResult
 from kagglesdk.models.types.model_enums import ModelFramework, ModelInstanceType
 from kagglesdk.models.types.model_api_service import (
     ApiCreateModelResponse,
     ApiCreateModelRequest,
     ApiUpdateModelRequest,
 )
-from kagglesdk.blobs.types.blob_api_service import ApiBlobType
+from kagglesdk.blobs.types.blob_api_service import ApiBlobType, ApiStartBlobUploadResponse
 
 
 class TestModelCreate(unittest.TestCase):
@@ -747,6 +748,53 @@ class TestModelInstanceVersionCreate(unittest.TestCase):
             self.assertTrue(call_args[5])
             self.assertEqual(call_args[6], "zip")
             self.assertEqual(call_args[7], ignore_patterns)
+
+    def _mock_kaggle_client(self, mock_client):
+        """Wires build_kaggle_client so that blob uploads can be driven end to end."""
+        mock_kaggle = MagicMock()
+        started = []
+
+        def start_blob_upload(request):
+            started.append(request)
+            response = ApiStartBlobUploadResponse()
+            response.create_url = "http://upload-url/%d" % len(started)
+            response.token = "token-%d" % len(started)
+            return response
+
+        mock_kaggle.blobs.blob_api_client.start_blob_upload.side_effect = start_blob_upload
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+        return mock_kaggle
+
+    @patch.object(KaggleApi, "upload_complete")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_model_instance_version_create_upload_failure_aborts(self, mock_client, mock_upload_complete):
+        mock_kaggle = self._mock_kaggle_client(mock_client)
+
+        def upload_complete(path, url, quiet, resume=False):
+            if os.path.basename(path) == "weights.bin":
+                return ResumableUploadResult.FAILED
+            return ResumableUploadResult.COMPLETE
+
+        mock_upload_complete.side_effect = upload_complete
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for file_name in ("config.json", "weights.bin"):
+                with open(os.path.join(tmpdir, file_name), "w", encoding="utf-8") as f:
+                    f.write("data")
+
+            with patch("kaggle.api.kaggle_api_extended.tempfile.gettempdir", return_value=tmpdir):
+                with self.assertRaises(ValueError) as context:
+                    self.api.model_instance_version_create(
+                        "testuser/test-model/keras/test-instance",
+                        tmpdir,
+                        version_notes="test version",
+                        quiet=True,
+                    )
+
+        # A version missing one of its files must never be created.
+        self.assertIn("Upload unsuccessful: weights.bin", str(context.exception))
+        mock_kaggle.models.model_api_client.create_model_instance_version.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_upload_helpers.py
+++ b/tests/unit/test_upload_helpers.py
@@ -17,7 +17,7 @@ sys.path.insert(0, "../..")
 from kaggle.api.kaggle_api_extended import KaggleApi
 from kaggle.models.kaggle_models_extended import ResumableUploadResult
 from kagglesdk.blobs.types.blob_api_service import ApiBlobType, ApiStartBlobUploadResponse
-from kagglesdk.datasets.types.dataset_api_service import ApiDatasetColumn
+from kagglesdk.datasets.types.dataset_api_service import ApiCreateDatasetVersionRequestBody, ApiDatasetColumn
 from kaggle.models.upload_file import UploadFile
 
 
@@ -38,6 +38,24 @@ class TestUploadHelpers(unittest.TestCase):
         with open(path, "wb") as f:
             f.write(b"\0" * size)
         return path
+
+    def _mock_blob_client(self, mock_client):
+        """Wires a build_kaggle_client mock whose start_blob_upload returns a fresh
+        url/token per call, so tests can count how often a session was initiated."""
+        mock_kaggle = MagicMock()
+        started = []
+
+        def start_blob_upload(request):
+            started.append(request)
+            response = ApiStartBlobUploadResponse()
+            response.create_url = "http://upload-url/%d" % len(started)
+            response.token = "token-%d" % len(started)
+            return response
+
+        mock_kaggle.blobs.blob_api_client.start_blob_upload.side_effect = start_blob_upload
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+        return mock_kaggle.blobs.blob_api_client.start_blob_upload
 
     # _get_bytes_already_uploaded tests
     def test_get_bytes_no_header_returns_minus_one(self):
@@ -102,8 +120,10 @@ class TestUploadHelpers(unittest.TestCase):
         mock_session.put.return_value = mock_response
         mock_session_cls.return_value = mock_session
 
+        # An expired session cannot be resumed but the file was never rejected, so the
+        # upload has to be restarted from scratch rather than abandoned.
         res = self.api._resume_upload("path", "url", 1000, quiet=True)
-        self.assertEqual(res.result, ResumableUploadResult.FAILED)
+        self.assertEqual(res.result, ResumableUploadResult.EXPIRED)
 
     @patch.object(KaggleApi, "_get_bytes_already_uploaded", return_value=500)
     @patch("requests.Session")
@@ -122,15 +142,16 @@ class TestUploadHelpers(unittest.TestCase):
 
     @patch.object(KaggleApi, "_get_bytes_already_uploaded", return_value=None)
     @patch("requests.Session")
-    def test_resume_upload_incomplete_308_error_returns_failed(self, mock_session_cls, mock_get_bytes):
+    def test_resume_upload_incomplete_308_error_returns_expired(self, mock_session_cls, mock_get_bytes):
         mock_session = MagicMock()
         mock_response = MagicMock()
         mock_response.status_code = 308
         mock_session.put.return_value = mock_response
         mock_session_cls.return_value = mock_session
 
+        # A broken Range header means the offset is unknown, so start from scratch.
         res = self.api._resume_upload("path", "url", 1000, quiet=True)
-        self.assertEqual(res.result, ResumableUploadResult.FAILED)
+        self.assertEqual(res.result, ResumableUploadResult.EXPIRED)
 
     @patch("requests.Session")
     def test_resume_upload_other_error_returns_failed(self, mock_session_cls):
@@ -228,6 +249,18 @@ class TestUploadHelpers(unittest.TestCase):
     @patch.object(KaggleApi, "_resume_upload")
     @patch("requests.Session")
     @patch("kaggle.api.kaggle_api_extended.tqdm")
+    def test_upload_complete_resume_expired_returns_expired(self, mock_tqdm, mock_session_cls, mock_resume):
+        mock_resume.return_value = ResumableUploadResult.Expired()
+
+        path = self._create_dummy_file(100)
+        res = self.api.upload_complete(path, "http://url", quiet=True, resume=True)
+        self.assertEqual(res, ResumableUploadResult.EXPIRED)
+        mock_resume.assert_called_once()
+        mock_session_cls.assert_not_called()
+
+    @patch.object(KaggleApi, "_resume_upload")
+    @patch("requests.Session")
+    @patch("kaggle.api.kaggle_api_extended.tqdm")
     def test_upload_complete_resume_incomplete_resumes_and_succeeds(self, mock_tqdm, mock_session_cls, mock_resume):
         mock_resume.return_value = ResumableUploadResult.Incomplete(40)
 
@@ -312,9 +345,12 @@ class TestUploadHelpers(unittest.TestCase):
         context = ResumableUploadContext(no_resume=True)
         path = self._create_dummy_file(100)
 
-        result = self.api._upload_file("dummy.bin", path, ApiBlobType.INBOX, context, quiet=True, resources=None)
+        # A failed upload must abort rather than be reported back as a skipped file,
+        # which would leave it out of the dataset/model version.
+        with self.assertRaises(ValueError) as cm:
+            self.api._upload_file("dummy.bin", path, ApiBlobType.INBOX, context, quiet=True, resources=None)
 
-        self.assertIsNone(result)
+        self.assertIn("Upload unsuccessful: dummy.bin", str(cm.exception))
 
     @patch.object(KaggleApi, "_upload_blob", return_value="token-123")
     def test_upload_file_with_resources_succeeds(self, mock_upload_blob):
@@ -391,11 +427,11 @@ class TestUploadHelpers(unittest.TestCase):
         from contextlib import redirect_stdout
 
         f = io.StringIO()
-        with redirect_stdout(f):
-            result = self.api._upload_file("dummy.bin", path, ApiBlobType.INBOX, context, quiet=False, resources=None)
+        with redirect_stdout(f), self.assertRaises(ValueError) as cm:
+            self.api._upload_file("dummy.bin", path, ApiBlobType.INBOX, context, quiet=False, resources=None)
 
-        self.assertIsNone(result)
-        self.assertIn("Upload unsuccessful: dummy.bin", f.getvalue())
+        self.assertIn("Upload unsuccessful: dummy.bin", str(cm.exception))
+        self.assertIn("Starting upload for file dummy.bin", f.getvalue())
 
     # _upload_blob additional tests
     @patch.object(KaggleApi, "build_kaggle_client")
@@ -439,6 +475,149 @@ class TestUploadHelpers(unittest.TestCase):
         self.assertEqual(token, "token-123")
         # Bug fixed: start_blob_upload should only be called once
         self.assertEqual(mock_kaggle.blobs.blob_api_client.start_blob_upload.call_count, 1)
+
+    def _upload_blob_in_context(self, path, quiet=True):
+        from kaggle.api.kaggle_api_extended import ResumableUploadContext
+
+        with patch("kaggle.api.kaggle_api_extended.tempfile.gettempdir", return_value=self.temp_dir):
+            context = ResumableUploadContext(no_resume=False)
+            with context:
+                return self.api._upload_blob(path, quiet, ApiBlobType.INBOX, context)
+
+    @patch.object(KaggleApi, "upload_complete", return_value=ResumableUploadResult.FAILED)
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_upload_blob_failed_does_not_restart_returns_none(self, mock_client, mock_upload_complete):
+        start_blob_upload = self._mock_blob_client(mock_client)
+        path = self._create_dummy_file(100)
+
+        token = self._upload_blob_in_context(path)
+
+        # FAILED means the server rejected the file, so retrying would only hit the
+        # same error: give up after a single attempt and report no token.
+        self.assertIsNone(token)
+        self.assertEqual(mock_upload_complete.call_count, 1)
+        self.assertEqual(start_blob_upload.call_count, 1)
+
+    @patch.object(KaggleApi, "upload_complete")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_upload_blob_expired_restarts_upload_succeeds(self, mock_client, mock_upload_complete):
+        start_blob_upload = self._mock_blob_client(mock_client)
+        mock_upload_complete.side_effect = [ResumableUploadResult.EXPIRED, ResumableUploadResult.COMPLETE]
+        path = self._create_dummy_file(100)
+
+        token = self._upload_blob_in_context(path)
+
+        # The expired session is dropped and a brand new one is initiated, so the
+        # token must come from the second start_blob_upload call.
+        self.assertEqual(token, "token-2")
+        self.assertEqual(start_blob_upload.call_count, 2)
+        # The restarted attempt uploads from scratch instead of resuming.
+        self.assertEqual(mock_upload_complete.call_args_list[1][1]["resume"], False)
+        self.assertEqual(mock_upload_complete.call_args_list[1][0][1], "http://upload-url/2")
+
+    @patch.object(KaggleApi, "upload_complete", return_value=ResumableUploadResult.EXPIRED)
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_upload_blob_expired_restart_respects_max_attempts_returns_none(self, mock_client, mock_upload_complete):
+        start_blob_upload = self._mock_blob_client(mock_client)
+        path = self._create_dummy_file(100)
+
+        token = self._upload_blob_in_context(path)
+
+        # Restarting is bounded by MAX_UPLOAD_RESUME_ATTEMPTS, i.e., it cannot loop forever.
+        self.assertIsNone(token)
+        self.assertEqual(mock_upload_complete.call_count, KaggleApi.MAX_UPLOAD_RESUME_ATTEMPTS)
+        self.assertEqual(start_blob_upload.call_count, KaggleApi.MAX_UPLOAD_RESUME_ATTEMPTS)
+
+    @patch.object(KaggleApi, "upload_complete", return_value=ResumableUploadResult.INCOMPLETE)
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_upload_blob_incomplete_exhausts_attempts_returns_none(self, mock_client, mock_upload_complete):
+        start_blob_upload = self._mock_blob_client(mock_client)
+        path = self._create_dummy_file(100)
+
+        token = self._upload_blob_in_context(path)
+
+        # Resuming keeps the same session, and running out of attempts yields no token.
+        self.assertIsNone(token)
+        self.assertEqual(mock_upload_complete.call_count, KaggleApi.MAX_UPLOAD_RESUME_ATTEMPTS)
+        self.assertEqual(start_blob_upload.call_count, 1)
+
+    # upload_files tests
+    def _create_upload_folder(self, *file_names):
+        folder = os.path.join(self.temp_dir, "folder")
+        os.makedirs(folder, exist_ok=True)
+        for file_name in file_names:
+            with open(os.path.join(folder, file_name), "w") as f:
+                f.write("data")
+        return folder
+
+    @patch.object(KaggleApi, "upload_complete")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_upload_files_failure_aborts_and_keeps_no_partial_files(self, mock_client, mock_upload_complete):
+        from kaggle.api.kaggle_api_extended import ResumableUploadContext
+
+        self._mock_blob_client(mock_client)
+
+        def upload_complete(path, url, quiet, resume=False):
+            if os.path.basename(path) == "two.csv":
+                return ResumableUploadResult.FAILED
+            return ResumableUploadResult.COMPLETE
+
+        mock_upload_complete.side_effect = upload_complete
+
+        folder = self._create_upload_folder("one.csv", "two.csv", "three.csv")
+        request = ApiCreateDatasetVersionRequestBody()
+        request.files = []
+
+        with patch("kaggle.api.kaggle_api_extended.tempfile.gettempdir", return_value=self.temp_dir):
+            context = ResumableUploadContext(no_resume=False)
+            with self.assertRaises(ValueError) as cm:
+                with context:
+                    self.api.upload_files(request, None, folder, ApiBlobType.DATASET, context, quiet=True)
+
+        # The failed file must not be silently skipped: the whole operation aborts so
+        # that no version is created without it.
+        self.assertIn("Upload unsuccessful: two.csv", str(cm.exception))
+        self.assertLess(len(request.files), 3)
+
+    @patch.object(KaggleApi, "upload_complete", return_value=ResumableUploadResult.COMPLETE)
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_upload_files_all_succeed_registers_every_file(self, mock_client, mock_upload_complete):
+        from kaggle.api.kaggle_api_extended import ResumableUploadContext
+
+        self._mock_blob_client(mock_client)
+
+        folder = self._create_upload_folder("one.csv", "two.csv", "three.csv")
+        request = ApiCreateDatasetVersionRequestBody()
+        request.files = []
+
+        with patch("kaggle.api.kaggle_api_extended.tempfile.gettempdir", return_value=self.temp_dir):
+            context = ResumableUploadContext(no_resume=False)
+            with context:
+                self.api.upload_files(request, None, folder, ApiBlobType.DATASET, context, quiet=True)
+
+        self.assertEqual(len(request.files), 3)
+        self.assertEqual(sorted(f.token for f in request.files), ["token-1", "token-2", "token-3"])
+
+    @patch.object(KaggleApi, "upload_complete", return_value=ResumableUploadResult.COMPLETE)
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_upload_files_skips_folder_without_dir_mode_succeeds(self, mock_client, mock_upload_complete):
+        from kaggle.api.kaggle_api_extended import ResumableUploadContext
+
+        self._mock_blob_client(mock_client)
+
+        folder = self._create_upload_folder("one.csv")
+        os.makedirs(os.path.join(folder, "subfolder"), exist_ok=True)
+        request = ApiCreateDatasetVersionRequestBody()
+        request.files = []
+
+        with patch("kaggle.api.kaggle_api_extended.tempfile.gettempdir", return_value=self.temp_dir):
+            context = ResumableUploadContext(no_resume=False)
+            with context:
+                self.api.upload_files(request, None, folder, ApiBlobType.DATASET, context, quiet=True)
+
+        # An intentionally skipped folder is not an upload failure and must not abort.
+        self.assertEqual(len(request.files), 1)
+        self.assertEqual(request.files[0].token, "token-1")
 
     # Verbose/print tests
     @patch("requests.Session")


### PR DESCRIPTION
## Summary

When creating a dataset or model version, a failed file upload could be silently ignored. If `_upload_blob()` returned `None`—either because the upload failed or because all resume attempts were exhausted—the file was skipped, the create request still went through, and the CLI reported success. This could result in a dataset or model version being created with one or more missing files.

This change makes upload failures abort the operation instead of creating a partial upload.

## Fix

* Raise a `ValueError` when a file upload fails instead of returning `None`.
* Prevent dataset/model version creation if any file upload fails.
* Added a separate `EXPIRED` upload state for resumable uploads whose session can no longer be resumed.
* Restart the upload only when the session can no longer be resumed (for example, an expired upload session). A `FAILED` result still gives up, since the server rejected the upload and restarting would only hit the same error.
* Updated the upload status documentation to match the implemented behavior.

## Behavior change

Since `_upload_file()` is shared, this also affects two other commands:

* `kaggle competitions data update` now aborts if any file upload fails instead of creating a partial data version.
* `kaggle files upload` now aborts if a file upload fails instead of skipping the failed file and continuing.

The CLI now exits with a non-zero status when an upload fails, making these failures visible to automation.

## Tests

Added regression tests to verify that:

* Dataset creation aborts when any file upload fails.
* Model version creation aborts when any file upload fails.
* Failed uploads are no longer silently skipped.
* Expired upload sessions start a new upload instead of reusing the old session.
* Existing successful upload behavior continues to work.

Ran:

* `pytest tests/unit/test_upload_helpers.py`
* `pytest tests/unit/test_dataset_create.py`
* `pytest tests/unit/test_model_create.py`

Also ran the full unit test suite to verify there were no regressions.
