### PR TITLE
docs: warn that P100 GPU compute fails with the default image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 
 ### Next
 
+* Document that `NvidiaTeslaP100` is unusable for GPU compute with the default Kaggle image (PyTorch cu128 omits Pascal `sm_60` kernels)
 * Add unified `kaggle search` command across competitions, datasets, notebooks, models, users, and discussions
 * Add `--wait`/`--poll-interval` to `kaggle competitions submit` to wait for scoring, and add `kaggle competitions submission <ref>` to look up a single submission's status and score
 

--- a/docs/kernels.md
+++ b/docs/kernels.md
@@ -168,7 +168,7 @@ Accelerators available as of Feb 2026:
 Some of these are only available to participants of specific competitions, and some are only available to Kaggle admins.
 
 > [!WARNING]
-> `NvidiaTeslaP100` is not usable for GPU compute with the default Kaggle image. Its PyTorch build (cu128) does not include Pascal (`sm_60`) kernels, so `torch.cuda.is_available()` returns `True` but the first CUDA operation fails with `cudaErrorNoKernelImageForDevice`. Use `NvidiaTeslaT4` or `NvidiaL4` instead, or install a Pascal-compatible torch build if you require a P100.
+> `NvidiaTeslaP100` is not usable for GPU compute with the default Kaggle image. Its PyTorch build (cu128) does not include Pascal (`sm_60`) kernels, so `torch.cuda.is_available()` returns `True` but the first CUDA operation fails with `cudaErrorNoKernelImageForDevice`. Use `NvidiaTeslaT4` instead, or install a Pascal-compatible torch build if you require a P100.
 
 ## `kaggle kernels pull`
 

--- a/docs/kernels.md
+++ b/docs/kernels.md
@@ -167,6 +167,9 @@ Accelerators available as of Feb 2026:
 
 Some of these are only available to participants of specific competitions, and some are only available to Kaggle admins.
 
+> [!WARNING]
+> `NvidiaTeslaP100` is not usable for GPU compute with the default Kaggle image. Its PyTorch build (cu128) does not include Pascal (`sm_60`) kernels, so `torch.cuda.is_available()` returns `True` but the first CUDA operation fails with `cudaErrorNoKernelImageForDevice`. Use `NvidiaTeslaT4` or `NvidiaL4` instead, or install a Pascal-compatible torch build if you require a P100.
+
 ## `kaggle kernels pull`
 
 Pulls down the code/notebook and metadata for a kernel.

--- a/docs/kernels_metadata.md
+++ b/docs/kernels_metadata.md
@@ -37,7 +37,7 @@ We currently support the following metadata fields for kernels.
 * `enable_internet`: Whether or not the kernel should be able to access the internet. If not specified, will be `false`.
 * `machine_shape`: The accelerator/GPU type to use (e.g., `NvidiaTeslaT4`, `NvidiaTeslaP100`, or `Tpu1VmV38`).
   > [!WARNING]
-  > `NvidiaTeslaP100` is not usable with the default Kaggle image. Its PyTorch build (cu128) does not include Pascal (`sm_60`) kernels, so `torch.cuda.is_available()` returns `True` but the first CUDA operation fails with `cudaErrorNoKernelImageForDevice`. Use `NvidiaTeslaT4` or `NvidiaL4` instead, or install a Pascal-compatible torch build if you require a P100.
+  > `NvidiaTeslaP100` is not usable with the default Kaggle image. Its PyTorch build (cu128) does not include Pascal (`sm_60`) kernels, so `torch.cuda.is_available()` returns `True` but the first CUDA operation fails with `cudaErrorNoKernelImageForDevice`. Use `NvidiaTeslaT4` instead, or install a Pascal-compatible torch build if you require a P100.
 * `dataset_sources`: A list of dataset sources, specified as `"username/dataset-slug"`
 * `competition_sources`: A list of competition sources, specified as `"competition-slug"`
 * `kernel_sources`: A list of kernel sources, specified as `"username/kernel-slug"`

--- a/docs/kernels_metadata.md
+++ b/docs/kernels_metadata.md
@@ -36,6 +36,8 @@ We currently support the following metadata fields for kernels.
 * `enable_gpu`: Whether or not the kernel should run on a GPU. If not specified, will be `false`.
 * `enable_internet`: Whether or not the kernel should be able to access the internet. If not specified, will be `false`.
 * `machine_shape`: The accelerator/GPU type to use (e.g., `NvidiaTeslaT4`, `NvidiaTeslaP100`, or `Tpu1VmV38`).
+  > [!WARNING]
+  > `NvidiaTeslaP100` is not usable with the default Kaggle image. Its PyTorch build (cu128) does not include Pascal (`sm_60`) kernels, so `torch.cuda.is_available()` returns `True` but the first CUDA operation fails with `cudaErrorNoKernelImageForDevice`. Use `NvidiaTeslaT4` or `NvidiaL4` instead, or install a Pascal-compatible torch build if you require a P100.
 * `dataset_sources`: A list of dataset sources, specified as `"username/dataset-slug"`
 * `competition_sources`: A list of competition sources, specified as `"competition-slug"`
 * `kernel_sources`: A list of kernel sources, specified as `"username/kernel-slug"`

--- a/skills/references/kernels.md
+++ b/skills/references/kernels.md
@@ -135,6 +135,12 @@ kaggle kernels update -p my-kernel
 
 **Purpose:** Upload local notebook/script code and create a new kernel version.
 
+**Notes:** `NvidiaTeslaP100` is not usable for GPU compute with the default
+Kaggle image, whose PyTorch build (cu128) omits Pascal (`sm_60`) kernels:
+`torch.cuda.is_available()` returns `True`, but the first CUDA operation fails
+with `cudaErrorNoKernelImageForDevice`. Use `NvidiaTeslaT4` or `NvidiaL4`, or
+install a Pascal-compatible torch build.
+
 ## `kaggle kernels pull`
 
 Pulls code from a kernel.

--- a/skills/references/kernels.md
+++ b/skills/references/kernels.md
@@ -138,7 +138,7 @@ kaggle kernels update -p my-kernel
 **Notes:** `NvidiaTeslaP100` is not usable for GPU compute with the default
 Kaggle image, whose PyTorch build (cu128) omits Pascal (`sm_60`) kernels:
 `torch.cuda.is_available()` returns `True`, but the first CUDA operation fails
-with `cudaErrorNoKernelImageForDevice`. Use `NvidiaTeslaT4` or `NvidiaL4`, or
+with `cudaErrorNoKernelImageForDevice`. Use `NvidiaTeslaT4` or
 install a Pascal-compatible torch build.
 
 ## `kaggle kernels pull`

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -6780,7 +6780,7 @@ class KaggleApi:
                 settings for GPU/TPU found in the metadata file. Note: "NvidiaTeslaP100" is not usable for GPU compute
                 with the default Kaggle image, whose PyTorch build (cu128) omits Pascal (sm_60) kernels, so the first
                 CUDA operation fails with cudaErrorNoKernelImageForDevice even though torch.cuda.is_available() returns
-                True. Use "NvidiaTeslaT4" or "NvidiaL4", or install a Pascal-compatible torch build.
+                True. Use "NvidiaTeslaT4" or install a Pascal-compatible torch build.
 
         Returns:
             ApiSaveKernelResponse: An ApiSaveKernelResponse object.

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -6777,7 +6777,10 @@ class KaggleApi:
             folder (str): The path to the folder.
             timeout (Optional[str]): The maximum run time in seconds.
             acc (Optional[str]): The type of accelerator to use for the kernel run. If set, this value overrides boolean
-                settings for GPU/TPU found in the metadata file.
+                settings for GPU/TPU found in the metadata file. Note: "NvidiaTeslaP100" is not usable for GPU compute
+                with the default Kaggle image, whose PyTorch build (cu128) omits Pascal (sm_60) kernels, so the first
+                CUDA operation fails with cudaErrorNoKernelImageForDevice even though torch.cuda.is_available() returns
+                True. Use "NvidiaTeslaT4" or "NvidiaL4", or install a Pascal-compatible torch build.
 
         Returns:
             ApiSaveKernelResponse: An ApiSaveKernelResponse object.

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -2910,7 +2910,11 @@ class Help(object):
     param_kernel_output_file_pattern = (
         "Regex pattern to match against filenames. Only files matching the pattern will be downloaded."
     )
-    param_kernel_acc = "Specify the type of accelerator to use for the kernel run"
+    param_kernel_acc = (
+        "Specify the type of accelerator to use for the kernel run. Note: 'NvidiaTeslaP100' is not usable for GPU "
+        "compute with the default Kaggle image, whose PyTorch build (cu128) omits Pascal (sm_60) kernels; use "
+        "'NvidiaTeslaT4' or 'NvidiaL4' instead."
+    )
     param_kernel_logs_follow = "Stream live execution logs from the running session (like tail -f)"
     param_kernel_logs_interval = argparse.SUPPRESS  # Deprecated; live streaming is push-based.
 

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -2913,7 +2913,7 @@ class Help(object):
     param_kernel_acc = (
         "Specify the type of accelerator to use for the kernel run. Note: 'NvidiaTeslaP100' is not usable for GPU "
         "compute with the default Kaggle image, whose PyTorch build (cu128) omits Pascal (sm_60) kernels; use "
-        "'NvidiaTeslaT4' or 'NvidiaL4' instead."
+        "'NvidiaTeslaT4' instead."
     )
     param_kernel_logs_follow = "Stream live execution logs from the running session (like tail -f)"
     param_kernel_logs_interval = argparse.SUPPRESS  # Deprecated; live streaming is push-based.


### PR DESCRIPTION
The default Kaggle image now ships a cu128 PyTorch build with no Pascal
(sm_60) kernels, so requesting NvidiaTeslaP100 allocates a GPU and
torch.cuda.is_available() returns True, but the first real CUDA op dies
with cudaErrorNoKernelImageForDevice. That's a confusing failure to hit
at runtime, so this adds a caveat wherever the accelerator values are
documented and in the --accelerator help text, pointing users at T4/L4
or a Pascal-compatible torch build.

Note the SDK enum comment requested alongside this isn't in kaggle-cli:
kagglesdk is a pip dependency, and its docstrings are generated from
Kaggle.Sdk/kernels/kernels_api_service.proto in kaggleazure. That needs
a separate PR.

Co-authored-by: kaggle-agent <kaggle-agent@users.noreply.github.com>

---

Task: [messick-20260730151802-b0a2773b](https://agents.dev.kaggle.net/tasks/messick-20260730151802-b0a2773b)

### Prompt

Add a caveat about NvidiaTeslaP100 to the kaggle-cli docs and SDK.

Context: The default Kaggle Docker image now ships a PyTorch build for CUDA 12.8 (cu128) that no longer includes CUDA kernel images for Pascal (compute capability sm_60). As a result, requesting `machine_shape: "NvidiaTeslaP100"` allocates a P100 and `torch.cuda.is_available()` returns True, but the first real CUDA operation fails with `cudaErrorNoKernelImageForDevice`. T4/L4 work fine. This is an intentional tradeoff (newer PyTorch was needed for Blackwell / RTX Pro 6000 sm_120 GPUs; P100s are being phased out).

Task: Add a clear caveat next to the `NvidiaTeslaP100` value in BOTH of these places:

1. `docs/kernels_metadata.md` — wherever `machine_shape` accepted values / NvidiaTeslaP100 are documented.
2. The SDK enum/type declaration for machine_shape / GPU accelerators (`kagglesdk/kernels/types/kernels_api_service.py`) — add a comment on the NvidiaTeslaP100 enum member.

The caveat should note: the default Kaggle image's PyTorch (cu128) does not include Pascal (sm_60) kernels, so GPU compute on P100 will fail with the default image; recommend using NvidiaTeslaT4 (or L4), or installing a Pascal-compatible torch build if a P100 is required.

Keep the wording concise and match the existing doc style. Do not change any behavior — docs/comments only.

Bug: http://b/540818030

