### PR TITLE
feat(competitions): add deadline to competition settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 
 ### Next
 
+* Add `deadline` (Competition Deadline) to the competition settings command and bump `kagglesdk` to `>= 0.1.36`
 * Document that `NvidiaTeslaP100` is unusable for GPU compute with the default Kaggle image (PyTorch cu128 omits Pascal `sm_60` kernels)
 * Add unified `kaggle search` command across competitions, datasets, notebooks, models, users, and discussions
 * Add `--wait`/`--poll-interval` to `kaggle competitions submit` to wait for scoring, and add `kaggle competitions submission <ref>` to look up a single submission's status and score

--- a/docs/competition_creation.md
+++ b/docs/competition_creation.md
@@ -437,13 +437,25 @@ Toggle a single boolean:
 kaggle competitions settings update my-comp -f ./disable-leaderboard.json
 ```
 
-Bump the code-competition runtime caps and set the team-merger deadline
-(YAML, mixing types):
+Set the competition deadline:
+
+```json
+// deadline.json
+{ "deadline": "2027-02-01T23:59:00Z" }
+```
+
+```bash
+kaggle competitions settings update my-comp -f ./deadline.json
+```
+
+Bump the code-competition runtime caps and set the competition and team-merger
+deadlines (YAML, mixing types):
 
 ```yaml
 # tune.yaml
 max_cpu_runtime_minutes: 540
 max_gpu_runtime_minutes: 720
+deadline: 2027-02-01T23:59:00Z
 team_merger_explicit_deadline: 2027-01-15T00:00:00Z
 rules_required: true
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ keywords = ["Kaggle", "API"]
 requires-python = ">= 3.11"
 dependencies = [
     "bleach",
-    "kagglesdk >= 0.1.35, < 1.0", # sync with kagglehub
+    "kagglesdk >= 0.1.36, < 1.0", # sync with kagglehub
     "python-slugify",
     "requests",
     "python-dateutil",

--- a/requirements.lock
+++ b/requirements.lock
@@ -26,7 +26,7 @@ jupyter-core==5.9.1
     # via nbformat
 jupytext==1.19.1
     # via kaggle (pyproject.toml)
-kagglesdk==0.1.35
+kagglesdk==0.1.36
     # via kaggle (pyproject.toml)
 markdown-it-py==4.0.0
     # via

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -3126,6 +3126,7 @@ class KaggleApi:
         (
             "Key Dates",
             [
+                "deadline",
                 "team_merger_explicit_deadline",
                 "prohibit_new_entrants_explicit_deadline",
                 "kernels_publishing_disabled_deadline",

--- a/tests/unit/test_competition_settings_update.py
+++ b/tests/unit/test_competition_settings_update.py
@@ -92,6 +92,22 @@ class TestCompetitionUpdateSettings(unittest.TestCase):
         )
 
     @patch.object(KaggleApi, "build_kaggle_client")
+    def test_update_sets_competition_deadline(self, mock_client):
+        mock_kaggle = self._patch_client(mock_client)
+
+        self.api.competition_update_settings(
+            "my-comp",
+            {"deadline": "2027-02-01T23:59:00Z"},
+        )
+
+        request = mock_kaggle.competitions.competition_api_client.update_competition_settings.call_args[0][0]
+        self.assertEqual(request.update_mask.paths, ["deadline"])
+        self.assertEqual(
+            request.settings.deadline,
+            datetime(2027, 2, 1, 23, 59, 0, tzinfo=timezone.utc),
+        )
+
+    @patch.object(KaggleApi, "build_kaggle_client")
     def test_update_coerces_enum_from_full_name(self, mock_client):
         mock_kaggle = self._patch_client(mock_client)
 


### PR DESCRIPTION
Bump kagglesdk to >= 0.1.36, which adds the CompetitionDeadline ('Competition Deadline' in the UI) field to CompetitionSettings, and surface it in the competition settings command under the Key Dates group. Document the new field and add a coercion test.