### PR TITLE
Fix UnicodeEncodeError writing kernel log on Windows

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -7237,7 +7237,7 @@ class KaggleApi:
         if log and page_token is None:
             outfile = os.path.join(target_dir, kernel_slug + ".log")
             outfiles.append(outfile)
-            with open(outfile, "w") as out:
+            with open(outfile, "w", encoding="utf-8") as out:
                 out.write(log)
             if not quiet:
                 print("Kernel log downloaded to %s " % outfile)

--- a/tests/unit/test_kernels_logs.py
+++ b/tests/unit/test_kernels_logs.py
@@ -5,6 +5,7 @@ import io
 import json
 import tempfile
 import sys
+import builtins
 
 sys.path.insert(0, "../..")
 
@@ -498,6 +499,38 @@ class TestKernelsLogs(unittest.TestCase):
 
         self.assertIn("giving up", captured_err.getvalue())
         self.assertEqual(mock_stream.call_count, 5)
+
+    @patch("kaggle.api.kaggle_api_extended.requests.get")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_kernels_output_writes_non_ascii_log(self, mock_client, mock_get):
+        """Test the kernel log is written as UTF-8 regardless of locale encoding."""
+        log_text = "Installing packages\n\u2588\u2588\u2588\u2588 100%\n\u25b6 done\n"
+
+        response = MagicMock()
+        response.files = []
+        response.next_page_token = ""
+        response.log = log_text
+
+        mock_kaggle = MagicMock()
+        mock_kaggle.kernels.kernels_api_client.list_kernel_session_output.return_value = response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        real_open = builtins.open
+
+        def _windows_open(file, mode="r", *args, **kwargs):
+            if "b" not in mode and kwargs.get("encoding") is None:
+                kwargs["encoding"] = "cp1252"
+            return real_open(file, mode, *args, **kwargs)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch("builtins.open", _windows_open):
+                outfiles, _ = self.api.kernels_output("owner/kernel-slug", temp_dir, quiet=True)
+
+            self.assertEqual(len(outfiles), 1)
+            self.assertTrue(outfiles[0].endswith("kernel-slug.log"))
+            with real_open(outfiles[0], encoding="utf-8") as f:
+                self.assertEqual(f.read(), log_text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`kernels_output` writes the kernel log with `open(outfile, "w")` and no `encoding`
argument, so Python uses the locale default. On Windows that's cp1252, which can't
encode the block characters pip emits in its progress bars:

`UnicodeEncodeError: 'charmap' codec can't encode character '\u2588' in position 0: character maps to <undefined>`

The data files just above it open in binary mode and are unaffected, so the download
completes and then the command dies on the last write.

I hit this pulling notebook outputs while working on an NLP dataset project.

**Fix:** pass `encoding="utf-8"`. No `errors=` needed — UTF-8 encodes any valid `str`.

**Reproduction** on Linux, forcing the encoding Windows uses by default:
`python3 -c "open('t.log','w',encoding='cp1252').write('\u2588')"`


