### PR TITLE
fix(cli): honor --untar for cached model version downloads

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -8493,7 +8493,7 @@ class KaggleApi:
         else:
             downloaded = False
 
-        if downloaded:
+        if downloaded or untar:
             if untar:
                 try:
                     with tarfile.open(outfile, mode="r:gz") as t:

--- a/tests/unit/test_model_download.py
+++ b/tests/unit/test_model_download.py
@@ -145,6 +145,33 @@ class TestModelDownload(unittest.TestCase):
             self.assertEqual(f.read(), b"dummy content")
 
     @patch.object(KaggleApi, "download_file")
+    @patch.object(KaggleApi, "download_needed", return_value=False)
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_download_cached_untar_succeeds(self, mock_client, mock_download_needed, mock_download_file):
+        """An already-cached archive is still extracted when untar=True, without re-downloading."""
+        outfile = os.path.join(self.temp_dir, "model.tar.gz")
+        with tarfile.open(outfile, mode="w:gz") as tar:
+            file_data = b"dummy content"
+            tarinfo = tarfile.TarInfo(name="dummy.txt")
+            tarinfo.size = len(file_data)
+            tar.addfile(tarinfo, io.BytesIO(file_data))
+
+        mock_kaggle = MagicMock()
+        mock_kaggle.models.model_api_client.download_model_instance_version.return_value = MagicMock()
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        version_str = "owner/model/keras/instance/2"
+        self.api.model_instance_version_download(version_str, path=self.temp_dir, untar=True)
+
+        mock_download_file.assert_not_called()
+        extracted_file = os.path.join(self.temp_dir, "dummy.txt")
+        self.assertTrue(os.path.exists(extracted_file))
+        with open(extracted_file, "rb") as f:
+            self.assertEqual(f.read(), b"dummy content")
+        self.assertFalse(os.path.exists(outfile))
+
+    @patch.object(KaggleApi, "download_file")
     @patch.object(KaggleApi, "download_needed", return_value=True)
     @patch.object(KaggleApi, "build_kaggle_client")
     def test_download_untar_failure_fails(self, mock_client, mock_download_needed, mock_download_file):


### PR DESCRIPTION
## Summary

When downloading a model instance version with `--untar`, the archive was not extracted if it was already cached locally.

This happened because the untar logic only ran when the file was downloaded during the current command. If the cached file was already up to date, the download was skipped and the untar step was skipped along with it.

This change makes `--untar` work for both newly downloaded and already cached archives.

## Fix

Updated the extraction condition to also run when `--untar` is requested.

This keeps the existing download and caching behavior unchanged while allowing a cached archive to be extracted without downloading it again.

After this change:

* Cached downloads without `--untar` are still skipped normally.
* Fresh downloads with `--untar` continue to work as before.
* Cached downloads with `--untar` are now extracted correctly.

## Tests

Added a regression test to verify that a cached archive is extracted when `untar=True` without downloading the file again.

Ran:

`pytest tests/unit/test_model_download.py -v`

`pytest tests/unit/test_dataset_download.py tests/unit/test_cli_models.py -q`

`pytest tests/unit -q`

`black --check --diff <modified files>`

`mypy --install-types --non-interactive src/kaggle tests`

All checks pass, including the full unit test suite with 1238 tests passing.
